### PR TITLE
Getters for pid/euid of GBinderRemoteRequest

### DIFF
--- a/include/gbinder_remote_request.h
+++ b/include/gbinder_remote_request.h
@@ -54,6 +54,14 @@ gbinder_remote_request_init_reader(
     GBinderRemoteRequest* req,
     GBinderReader* reader);
 
+pid_t
+gbinder_remote_request_sender_pid(
+    GBinderRemoteRequest* req);
+
+uid_t
+gbinder_remote_request_sender_euid(
+    GBinderRemoteRequest* req);
+
 /* Convenience function to decode requests with just one data item */
 
 gboolean

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -425,7 +425,7 @@ gbinder_driver_handle_transaction(
     const void* data)
 {
     GBinderLocalReply* reply = NULL;
-    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, self->protocol);
+    GBinderRemoteRequest* req;
     GBinderIoTxData tx;
     GBinderLocalObject* obj;
     const char* iface;
@@ -433,6 +433,7 @@ gbinder_driver_handle_transaction(
 
     self->io->decode_transaction_data(data, &tx);
     gbinder_driver_verbose_transaction_data("BR_TRANSACTION", &tx);
+    req = gbinder_remote_request_new(reg, self->protocol, tx.pid, tx.euid);
     obj = gbinder_object_registry_get_local(reg, tx.target);
 
     /* Transfer data ownership to the request */

--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -278,6 +278,8 @@ GBINDER_IO_FN(decode_transaction_data)(
     tx->objects = NULL;
     tx->code = tr->code;
     tx->flags = 0;
+    tx->pid = tr->sender_pid;
+    tx->euid = tr->sender_euid;
     tx->target = (void*)(uintptr_t)tr->target.ptr;
     tx->data = (void*)(uintptr_t)tr->data.ptr.buffer;
     if (tr->flags & TF_STATUS_CODE) {

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -47,6 +47,8 @@ typedef struct gbinder_io_tx_data {
     int status;
     guint32 code;
     guint32 flags;   /* GBINDER_TX_FLAG_xxx */
+    pid_t pid;
+    uid_t euid;
     void* target;
     void* data;
     gsize size;
@@ -57,11 +59,11 @@ typedef struct gbinder_io_tx_data {
 #define GBINDER_IO_READ_BUFFER_SIZE (128)
 
 /*
- * There are (at least) 2 versions of the binder ioctl API, implemented
+ * There are (at least) 2 versions of the binder ioctl API, implemented by
  * 32-bit and 64-bit kernels. The ioctl codes, transaction commands - many
  * of those are derived from the sizes of the structures being passed
  * between the driver and the user space client. All these differences
- * are abstracted away by the GBinderIo interfaces.
+ * are abstracted away by GBinderIo interfaces.
  *
  * The API version is returned by BINDER_VERSION ioctl which itself doesn't
  * depend on the API version (it would be very strange if it did).

--- a/src/gbinder_remote_request.c
+++ b/src/gbinder_remote_request.c
@@ -41,6 +41,8 @@
 
 struct gbinder_remote_request {
     gint refcount;
+    pid_t pid;
+    uid_t euid;
     const GBinderRpcProtocol* protocol;
     const char* iface;
     char* iface2;
@@ -51,12 +53,16 @@ struct gbinder_remote_request {
 GBinderRemoteRequest*
 gbinder_remote_request_new(
     GBinderObjectRegistry* reg,
-    const GBinderRpcProtocol* protocol)
+    const GBinderRpcProtocol* protocol,
+    pid_t pid,
+    uid_t euid)
 {
     GBinderRemoteRequest* self = g_slice_new0(GBinderRemoteRequest);
     GBinderReaderData* data = &self->data;
 
     g_atomic_int_set(&self->refcount, 1);
+    self->pid = pid;
+    self->euid = euid;
     self->protocol = protocol;
     data->reg = gbinder_object_registry_ref(reg);
     return self;
@@ -162,6 +168,20 @@ gbinder_remote_request_init_reader(
     } else {
         gbinder_reader_init(reader, NULL, 0, 0);
     }
+}
+
+pid_t
+gbinder_remote_request_sender_pid(
+    GBinderRemoteRequest* self)
+{
+    return G_LIKELY(self) ? self->pid : (uid_t)(-1);
+}
+
+uid_t
+gbinder_remote_request_sender_euid(
+    GBinderRemoteRequest* self)
+{
+    return G_LIKELY(self) ? self->euid : (uid_t)(-1);
 }
 
 gboolean

--- a/src/gbinder_remote_request_p.h
+++ b/src/gbinder_remote_request_p.h
@@ -40,7 +40,9 @@
 GBinderRemoteRequest*
 gbinder_remote_request_new(
     GBinderObjectRegistry* reg,
-    const GBinderRpcProtocol* protocol);
+    const GBinderRpcProtocol* protocol,
+    pid_t pid,
+    uid_t euid);
 
 void
 gbinder_remote_request_set_data(

--- a/unit/common/test_binder.c
+++ b/unit/common/test_binder.c
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/types.h>
 
 static GHashTable* test_fd_map = NULL;
 static GHashTable* test_node_map = NULL;
@@ -263,6 +264,8 @@ test_binder_fill_transaction_data(
     tr->handle = handle;
     tr->code = code;
     tr->data_size = bytes->len;
+    tr->sender_pid = getpid();
+    tr->sender_euid = geteuid();
     /* This memory should eventually get deallocated with BC_FREE_BUFFER_64 */
     tr->data_buffer = (gsize)g_memdup(bytes->data, bytes->len);
 }

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -46,7 +46,9 @@
 
 #include <gutil_log.h>
 
+#include <unistd.h>
 #include <errno.h>
+#include <sys/types.h>
 
 static TestOpt test_opt;
 
@@ -593,6 +595,8 @@ test_transact_incoming_proc(
 {
     GVERBOSE_("\"%s\" %u", gbinder_remote_request_interface(req), code);
     g_assert(!flags);
+    g_assert(gbinder_remote_request_sender_pid(req) == getpid());
+    g_assert(gbinder_remote_request_sender_euid(req) == geteuid());
     g_assert(!g_strcmp0(gbinder_remote_request_interface(req), "test"));
     g_assert(!g_strcmp0(gbinder_remote_request_read_string8(req), "message"));
     g_assert(code == 1);

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -202,8 +202,8 @@ test_get_descriptor(
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     GBinderIpc* ipc = gbinder_ipc_new(dev);
-    GBinderRemoteRequest* req = gbinder_remote_request_new
-        (gbinder_ipc_object_registry(ipc), prot);
+    GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
+    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj =
         gbinder_ipc_new_local_object(ipc, NULL, NULL, NULL);
     GBinderLocalReply* reply;
@@ -257,8 +257,8 @@ test_descriptor_chain(
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     GBinderIpc* ipc = gbinder_ipc_new(dev);
-    GBinderRemoteRequest* req = gbinder_remote_request_new
-        (gbinder_ipc_object_registry(ipc), prot);
+    GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
+    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj =
         gbinder_ipc_new_local_object(ipc, NULL, NULL, NULL);
     GBinderLocalReply* reply;
@@ -324,8 +324,8 @@ test_custom_iface(
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     GBinderIpc* ipc = gbinder_ipc_new(dev);
-    GBinderRemoteRequest* req = gbinder_remote_request_new
-        (gbinder_ipc_object_registry(ipc), prot);
+    GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
+    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object(ipc, custom_iface,
         test_custom_iface_handler, &count);
     GBinderLocalReply* reply;
@@ -430,7 +430,7 @@ test_reply_status(
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
-    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot);
+    GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object(ipc, custom_iface,
         test_reply_status_handler, &count);
 

--- a/unit/unit_protocol/unit_protocol.c
+++ b/unit/unit_protocol/unit_protocol.c
@@ -100,7 +100,7 @@ test_no_header(
     void)
 {
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(GBINDER_DEFAULT_BINDER));
+        gbinder_rpc_protocol_for_device(GBINDER_DEFAULT_BINDER), 0, 0);
 
     gbinder_remote_request_set_data(req, NULL, NULL);
     g_assert(!gbinder_remote_request_interface(req));
@@ -142,7 +142,7 @@ test_read_header(
     const TestHeaderData* test = test_data;
     GBinderDriver* driver = gbinder_driver_new(test->dev);
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(test->dev));
+        gbinder_rpc_protocol_for_device(test->dev), 0, 0);
 
     gbinder_remote_request_set_data(req, gbinder_buffer_new(driver,
         g_memdup(test->header, test->header_size), test->header_size), NULL);

--- a/unit/unit_remote_request/unit_remote_request.c
+++ b/unit/unit_remote_request/unit_remote_request.c
@@ -67,6 +67,8 @@ test_null(
     gbinder_remote_request_init_reader(NULL, &reader);
     g_assert(gbinder_reader_at_end(&reader));
     g_assert(!gbinder_remote_request_interface(NULL));
+    g_assert(gbinder_remote_request_sender_pid(NULL) == (pid_t)(-1));
+    g_assert(gbinder_remote_request_sender_euid(NULL) == (uid_t)(-1));
     g_assert(!gbinder_remote_request_read_int32(NULL, NULL));
     g_assert(!gbinder_remote_request_read_uint32(NULL, NULL));
     g_assert(!gbinder_remote_request_read_int64(NULL, NULL));
@@ -87,7 +89,7 @@ test_basic(
 {
     GBinderReader reader;
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(NULL));
+        gbinder_rpc_protocol_for_device(NULL), 0, 0);
 
     gbinder_remote_request_init_reader(req, &reader);
     g_assert(gbinder_reader_at_end(&reader));
@@ -116,7 +118,7 @@ test_int32(
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderDriver* driver = gbinder_driver_new(dev);
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(dev));
+        gbinder_rpc_protocol_for_device(dev), 0, 0);
 
     gbinder_remote_request_set_data(req, gbinder_buffer_new(driver,
         g_memdup(request_data, sizeof(request_data)), sizeof(request_data)),
@@ -150,7 +152,7 @@ test_int64(
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderDriver* driver = gbinder_driver_new(dev);
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(dev));
+        gbinder_rpc_protocol_for_device(dev), 0, 0);
 
     gbinder_remote_request_set_data(req, gbinder_buffer_new(driver,
         g_memdup(request_data, sizeof(request_data)), sizeof(request_data)),
@@ -182,7 +184,7 @@ test_string8(
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderDriver* driver = gbinder_driver_new(dev);
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(dev));
+        gbinder_rpc_protocol_for_device(dev), 0, 0);
 
     gbinder_remote_request_set_data(req, gbinder_buffer_new(driver,
         g_memdup(request_data, sizeof(request_data)), sizeof(request_data)),
@@ -213,7 +215,7 @@ test_string16(
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderDriver* driver = gbinder_driver_new(dev);
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(dev));
+        gbinder_rpc_protocol_for_device(dev), 0, 0);
     char* str;
 
     gbinder_remote_request_set_data(req, gbinder_buffer_new(driver,


### PR DESCRIPTION
Can be used for access control.