### PR TITLE
Add gbinder_writer_append_hidl_vec() and gbinder_reader_read_hidl_vec()

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -112,6 +112,12 @@ GBinderBuffer*
 gbinder_reader_read_buffer(
     GBinderReader* reader)
     G_GNUC_WARN_UNUSED_RESULT;
+
+const void*
+gbinder_reader_read_hidl_vec(
+    GBinderReader* reader,
+    gsize* count,
+    gsize* elemsize);
 
 char*
 gbinder_reader_read_hidl_string(

--- a/include/gbinder_writer.h
+++ b/include/gbinder_writer.h
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -120,6 +120,13 @@ gbinder_writer_append_buffer_object(
     GBinderWriter* writer,
     const void* buf,
     gsize len);
+
+void
+gbinder_writer_append_hidl_vec(
+    GBinderWriter* writer,
+    const void* base,
+    guint count,
+    guint elemsize); /* since 1.0.8 */
 
 void
 gbinder_writer_append_hidl_string(

--- a/src/gbinder_writer_p.h
+++ b/src/gbinder_writer_p.h
@@ -111,6 +111,13 @@ gbinder_writer_data_append_buffer_object(
     const GBinderParent* parent);
 
 void
+gbinder_writer_data_append_hidl_vec(
+    GBinderWriterData* data,
+    const void* base,
+    guint count,
+    guint elemsize);
+
+void
 gbinder_writer_data_append_hidl_string(
     GBinderWriterData* data,
     const char* str);


### PR DESCRIPTION
These provide a generic way to read and write arrays of any primitive types or structures.