### PR TITLE
Support for service registration notifications

### DIFF
--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived from
+ *      this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -59,6 +59,13 @@ void
 (*GBinderServiceManagerAddServiceFunc)(
     GBinderServiceManager* sm,
     int status,
+    void* user_data);
+
+typedef
+void
+(*GBinderServiceManagerRegistrationFunc)(
+    GBinderServiceManager* sm,
+    const char* name,
     void* user_data);
 
 GBinderServiceManager*
@@ -129,6 +136,18 @@ void
 gbinder_servicemanager_cancel(
     GBinderServiceManager* sm,
     gulong id);
+
+gulong
+gbinder_servicemanager_add_registration_handler(
+    GBinderServiceManager* sm,
+    const char* name,
+    GBinderServiceManagerRegistrationFunc func,
+    void* user_data); /* Since 1.0.13 */
+
+void
+gbinder_servicemanager_remove_handler(
+    GBinderServiceManager* sm,
+    gulong id); /* Since 1.0.13 */
 
 G_END_DECLS
 

--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -6,9 +6,9 @@ Group: Development/Libraries
 License: BSD
 URL: https://github.com/mer-hybris/libgbinder
 Source: %{name}-%{version}.tar.bz2
-Requires: libglibutil >= 1.0.29
+Requires: libglibutil >= 1.0.34
 BuildRequires: pkgconfig(glib-2.0)
-BuildRequires: pkgconfig(libglibutil) >= 1.0.29
+BuildRequires: pkgconfig(libglibutil) >= 1.0.34
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 

--- a/src/gbinder_defaultservicemanager.c
+++ b/src/gbinder_defaultservicemanager.c
@@ -152,6 +152,17 @@ gbinder_defaultservicemanager_add_service(
 }
 
 static
+GBINDER_SERVICEMANAGER_NAME_CHECK
+gbinder_defaultservicemanager_check_name(
+    GBinderServiceManager* self,
+    const char* name)
+{
+    /* Old servicemanager doesn't support notifications, those would
+     * have to be emulated with polling. Is it necessary though? */
+    return GBINDER_SERVICEMANAGER_NAME_INVALID;
+}
+
+static
 void
 gbinder_defaultservicemanager_init(
     GBinderDefaultServiceManager* self)
@@ -171,6 +182,8 @@ gbinder_defaultservicemanager_class_init(
     klass->list = gbinder_defaultservicemanager_list;
     klass->get_service = gbinder_defaultservicemanager_get_service;
     klass->add_service = gbinder_defaultservicemanager_add_service;
+    klass->check_name = gbinder_defaultservicemanager_check_name;
+    /* No need for other watch callbacks */
 }
 
 /*

--- a/src/gbinder_hwservicemanager.c
+++ b/src/gbinder_hwservicemanager.c
@@ -35,19 +35,35 @@
 #include "gbinder_log.h"
 
 #include <gbinder_client.h>
+#include <gbinder_local_object.h>
 #include <gbinder_local_request.h>
 #include <gbinder_remote_reply.h>
+#include <gbinder_remote_request.h>
 #include <gbinder_reader.h>
 
 #include <errno.h>
 #include <pthread.h>
 
-typedef GBinderServiceManager GBinderHwServiceManager;
+typedef struct gbinder_hwservicemanager_watch {
+    char* name;
+    GBinderLocalObject* callback;
+} GBinderHwServiceManagerWatch;
+
 typedef GBinderServiceManagerClass GBinderHwServiceManagerClass;
+typedef struct gbinder_hwservicemanager {
+    GBinderServiceManager manager;
+    GHashTable* watch_table;
+} GBinderHwServiceManager;
 
 G_DEFINE_TYPE(GBinderHwServiceManager,
     gbinder_hwservicemanager,
     GBINDER_TYPE_SERVICEMANAGER)
+
+#define PARENT_CLASS gbinder_hwservicemanager_parent_class
+#define GBINDER_TYPE_HWSERVICEMANAGER (gbinder_hwservicemanager_get_type())
+#define GBINDER_HWSERVICEMANAGER(obj) \
+    G_TYPE_CHECK_INSTANCE_CAST((obj), GBINDER_TYPE_HWSERVICEMANAGER, \
+    GBinderHwServiceManager)
 
 enum gbinder_hwservicemanager_calls {
     GET_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION,
@@ -60,9 +76,76 @@ enum gbinder_hwservicemanager_calls {
     REGISTER_PASSTHROUGH_CLIENT_TRANSACTION
 };
 
+enum gbinder_hwservicemanager_notifications {
+    ON_REGISTRATION_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION
+};
+
 /* As a special case, ServiceManager's handle is zero */
 #define HWSERVICEMANAGER_HANDLE (0)
 #define HWSERVICEMANAGER_IFACE  "android.hidl.manager@1.0::IServiceManager"
+#define HWSERVICEMANAGER_NOTIFICATION_IFACE \
+    "android.hidl.manager@1.0::IServiceNotification"
+
+static
+void
+gbinder_hwservicemanager_handle_registration(
+    GBinderHwServiceManager* self,
+    GBinderReader* reader)
+{
+    char* fqname = gbinder_reader_read_hidl_string(reader);
+    char* name = gbinder_reader_read_hidl_string(reader);
+    gboolean preexisting;
+
+    /* (string fqName, string name, bool preexisting) */
+    if (fqname && name && gbinder_reader_read_bool(reader, &preexisting) &&
+        gbinder_reader_at_end(reader)) {
+        char* full_name = g_strconcat(fqname, "/", name, NULL);
+
+        GDEBUG("%s %s", full_name, preexisting ? "true" : "false");
+        gbinder_servicemanager_service_registered(&self->manager, full_name);
+        g_free(full_name);
+    } else {
+        GWARN("Failed to parse IServiceNotification::onRegistration payload");
+    }
+    g_free(fqname);
+    g_free(name);
+}
+
+static
+GBinderLocalReply*
+gbinder_hwservicemanager_notification(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(user_data);
+    const char* iface = gbinder_remote_request_interface(req);
+
+    if (!g_strcmp0(iface, HWSERVICEMANAGER_NOTIFICATION_IFACE)) {
+        GBinderReader reader;
+
+        gbinder_remote_request_init_reader(req, &reader);
+        switch (code) {
+        case ON_REGISTRATION_TRANSACTION:
+            GDEBUG(HWSERVICEMANAGER_NOTIFICATION_IFACE " %u onRegistration",
+                code);
+            gbinder_hwservicemanager_handle_registration(self, &reader);
+            *status = GBINDER_STATUS_OK;
+            break;
+        default:
+            GDEBUG(HWSERVICEMANAGER_NOTIFICATION_IFACE " %u", code);
+            *status = GBINDER_STATUS_FAILED;
+            break;
+        }
+    } else {
+        GDEBUG("%s %u", iface, code);
+        *status = GBINDER_STATUS_FAILED;
+    }
+    return NULL;
+}
 
 GBinderServiceManager*
 gbinder_hwservicemanager_new(
@@ -75,7 +158,7 @@ gbinder_hwservicemanager_new(
 static
 char**
 gbinder_hwservicemanager_list(
-    GBinderHwServiceManager* self)
+    GBinderServiceManager* self)
 {
     GBinderLocalRequest* req = gbinder_client_new_request(self->client);
     GBinderRemoteReply* reply = gbinder_client_transact_sync_reply
@@ -111,6 +194,7 @@ gbinder_hwservicemanager_get_service(
     /* e.g. "android.hardware.radio@1.1::IRadio/slot1" */
     const char* sep = strchr(fqinstance, '/');
     GBinderRemoteObject* obj = NULL;
+
     if (sep) {
         GBinderRemoteReply* reply;
         GBinderLocalRequest* req = gbinder_client_new_request(self->client);
@@ -172,9 +256,121 @@ gbinder_hwservicemanager_add_service(
 
 static
 void
+gbinder_hwservicemanager_watch_free(
+    gpointer data)
+{
+    GBinderHwServiceManagerWatch* watch = data;
+
+    g_free(watch->name);
+    gbinder_local_object_drop(watch->callback);
+    g_free(watch);
+}
+
+static
+GBINDER_SERVICEMANAGER_NAME_CHECK
+gbinder_hwservicemanager_check_name(
+    GBinderServiceManager* self,
+    const char* name)
+{
+    if (name) {
+        const gsize len = strlen(name);
+        static const char allowed_chars[] = "./0123456789:@"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "abcdefghijklmnopqrstuvwxyz";
+
+        if (len && strspn(name, allowed_chars) == len) {
+            return strchr(name, '/') ?
+                GBINDER_SERVICEMANAGER_NAME_NORMALIZE :
+                GBINDER_SERVICEMANAGER_NAME_OK;
+        }
+    }
+    return GBINDER_SERVICEMANAGER_NAME_INVALID;
+}
+
+static
+char*
+gbinder_hwservicemanager_normalize_name(
+    GBinderServiceManager* self,
+    const char* name)
+{
+    /* Slash must be there, see gbinder_hwservicemanager_check_name() above */
+    return g_strndup(name, strchr(name, '/') - name);
+}
+
+static
+gboolean
+gbinder_hwservicemanager_watch(
+    GBinderServiceManager* manager,
+    const char* name)
+{
+    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(manager);
+    GBinderLocalRequest* req = gbinder_client_new_request(manager->client);
+    GBinderRemoteReply* reply;
+    GBinderHwServiceManagerWatch* watch =
+        g_new0(GBinderHwServiceManagerWatch, 1);
+    gboolean success = FALSE;
+    int status;
+
+    watch->name = g_strdup(name);
+    watch->callback = gbinder_servicemanager_new_local_object(manager,
+        HWSERVICEMANAGER_NOTIFICATION_IFACE,
+        gbinder_hwservicemanager_notification, self);
+    g_hash_table_replace(self->watch_table, watch->name, watch);
+
+    /* registerForNotifications(string fqName, string name,
+     * IServiceNotification callback) generates (bool success); */
+    gbinder_local_request_append_hidl_string(req, name);
+    gbinder_local_request_append_hidl_string(req, "");
+    gbinder_local_request_append_local_object(req, watch->callback);
+    reply = gbinder_client_transact_sync_reply(manager->client,
+        REGISTER_FOR_NOTIFICATIONS_TRANSACTION, req, &status);
+
+    if (status == GBINDER_STATUS_OK && reply) {
+        GBinderReader reader;
+
+        gbinder_remote_reply_init_reader(reply, &reader);
+        if (gbinder_reader_read_int32(&reader, &status) &&
+            status == GBINDER_STATUS_OK) {
+            gbinder_reader_read_bool(&reader, &success);
+        }
+    }
+    gbinder_remote_reply_unref(reply);
+    gbinder_local_request_unref(req);
+
+    if (!success) {
+        /* unwatch() won't be called if we return FALSE */
+        g_hash_table_remove(self->watch_table, watch->name);
+    }
+    return success;
+}
+
+static
+void
+gbinder_hwservicemanager_unwatch(
+    GBinderServiceManager* manager,
+    const char* name)
+{
+    g_hash_table_remove(GBINDER_HWSERVICEMANAGER(manager)->watch_table, name);
+}
+
+static
+void
 gbinder_hwservicemanager_init(
     GBinderHwServiceManager* self)
 {
+    self->watch_table = g_hash_table_new_full(g_str_hash, g_str_equal,
+        NULL, gbinder_hwservicemanager_watch_free);
+}
+
+static
+void
+gbinder_hwservicemanager_finalize(
+    GObject* object)
+{
+    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(object);
+
+    g_hash_table_destroy(self->watch_table);
+    G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
 }
 
 static
@@ -190,6 +386,11 @@ gbinder_hwservicemanager_class_init(
     klass->list = gbinder_hwservicemanager_list;
     klass->get_service = gbinder_hwservicemanager_get_service;
     klass->add_service = gbinder_hwservicemanager_add_service;
+    klass->check_name = gbinder_hwservicemanager_check_name;
+    klass->normalize_name = gbinder_hwservicemanager_normalize_name;
+    klass->watch = gbinder_hwservicemanager_watch;
+    klass->unwatch = gbinder_hwservicemanager_unwatch;
+    G_OBJECT_CLASS(klass)->finalize = gbinder_hwservicemanager_finalize;
 }
 
 /*

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -39,12 +39,21 @@
 
 #include <glib-object.h>
 
+typedef struct gbinder_servicemanager_priv GBinderServiceManagerPriv;
+
 typedef struct gbinder_servicemanager {
     GObject parent;
+    GBinderServiceManagerPriv* priv;
     const char* dev;
     GBinderClient* client;
     GUtilIdlePool* pool;
 } GBinderServiceManager;
+
+typedef enum gbinder_servicemanager_name_check {
+    GBINDER_SERVICEMANAGER_NAME_OK,
+    GBINDER_SERVICEMANAGER_NAME_NORMALIZE,
+    GBINDER_SERVICEMANAGER_NAME_INVALID,
+} GBINDER_SERVICEMANAGER_NAME_CHECK;
 
 typedef struct gbinder_servicemanager_class {
     GObjectClass parent;
@@ -63,6 +72,15 @@ typedef struct gbinder_servicemanager_class {
     int (*add_service)
         (GBinderServiceManager* self, const char* name,
             GBinderLocalObject* obj);
+
+    /* Checking/normalizing watch names */
+    GBINDER_SERVICEMANAGER_NAME_CHECK (*check_name)
+        (GBinderServiceManager* self, const char* name);
+    char* (*normalize_name)(GBinderServiceManager* self, const char* name);
+
+    /* If watch() returns FALSE, unwatch() is not called */
+    gboolean (*watch)(GBinderServiceManager* self, const char* name);
+    void (*unwatch)(GBinderServiceManager* self, const char* name);
 } GBinderServiceManagerClass;
 
 GType gbinder_servicemanager_get_type(void);
@@ -72,6 +90,11 @@ GBinderServiceManager*
 gbinder_servicemanager_new_with_type(
     GType type,
     const char* dev);
+
+void
+gbinder_servicemanager_service_registered(
+    GBinderServiceManager* self,
+    const char* name);
 
 #endif /* GBINDER_SERVICEMANAGER_PRIVATE_H */
 


### PR DESCRIPTION
[android.hidl.manager@1.0::IServiceManager](https://android.googlesource.com/platform/system/libhidl/+/master/transport/manager/1.0/IServiceManager.hal) provides registration notifications via [android.hidl.manager@1.0::IServiceNotification](https://android.googlesource.com/platform/system/libhidl/+/master/transport/manager/1.0/IServiceNotification.hal) callback.

Sailfish OS services that talk to Android services via binder should use this mechanism to wait for their Android counterpart at startup.