### PR TITLE
Added GBinderHidlVec and GBinderHidlString types

### DIFF
--- a/include/gbinder_types.h
+++ b/include/gbinder_types.h
@@ -72,6 +72,30 @@ typedef struct gbinder_servicemanager GBinderServiceManager;
 typedef struct gbinder_writer GBinderWriter;
 typedef struct gbinder_parent GBinderParent;
 
+/* Basic HIDL types */
+
+typedef struct gbinder_hidl_vec {
+    union {
+        guint64 value;
+        const void* ptr;
+    } data;
+    guint32 count;
+    guint32 owns_buffer;
+} GBinderHidlVec;
+
+#define GBINDER_HIDL_VEC_BUFFER_OFFSET (0)
+
+typedef struct gbinder_hidl_string {
+    union {
+        guint64 value;
+        const char* str;
+    } data;
+    guint32 len;
+    guint32 owns_buffer;
+} GBinderHidlString;
+
+#define GBINDER_HIDL_STRING_BUFFER_OFFSET (0)
+
 /*
  * Each RPC call is identified by the interface name returned
  * by gbinder_remote_request_interface() the transaction code.

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -333,8 +333,8 @@ gbinder_reader_read_hidl_vec(
     gsize out_count = 0, out_elemsize = 0;
     const void* out = NULL;
 
-    if (buf && buf->size == sizeof(HidlVec)) {
-        const HidlVec* vec = buf->data;
+    if (buf && buf->size == sizeof(GBinderHidlVec)) {
+        const GBinderHidlVec* vec = buf->data;
         const void* next = vec->data.ptr;
 
         if (next) {
@@ -383,8 +383,8 @@ gbinder_reader_read_hidl_string(
     GBinderBuffer* buf = gbinder_reader_read_buffer(reader);
     char* str = NULL;
 
-    if (buf && buf->size == sizeof(HidlString)) {
-        const HidlString* s = buf->data;
+    if (buf && buf->size == sizeof(GBinderHidlString)) {
+        const GBinderHidlString* s = buf->data;
         GBinderBuffer* sbuf = gbinder_reader_read_buffer(reader);
 
         if (sbuf && sbuf->size == s->len + 1 &&
@@ -405,8 +405,8 @@ gbinder_reader_read_hidl_string_vec(
     GBinderBuffer* buf = gbinder_reader_read_buffer(reader);
 
     /* First buffer contains hidl_vector */
-    if (buf && buf->size == sizeof(HidlVec)) {
-        HidlVec* vec = buf->data;
+    if (buf && buf->size == sizeof(GBinderHidlVec)) {
+        GBinderHidlVec* vec = buf->data;
         const guint n = vec->count;
         const void* next = vec->data.ptr;
 
@@ -419,8 +419,9 @@ gbinder_reader_read_hidl_string_vec(
         } else {
             /* The second buffer (if any) contains n hidl_string's */
             buf = gbinder_reader_read_buffer(reader);
-            if (buf && buf->data == next && buf->size == sizeof(HidlString)*n) {
-                const HidlString* strings = buf->data;
+            if (buf && buf->data == next &&
+                buf->size == (sizeof(GBinderHidlString) * n)) {
+                const GBinderHidlString* strings = buf->data;
                 GBinderBuffer* sbuf;
                 GPtrArray* list = g_ptr_array_new();
                 guint i;
@@ -428,7 +429,7 @@ gbinder_reader_read_hidl_string_vec(
                 /* Now we expect n buffers containing the actual data */
                 for (i=0; i<n &&
                     (sbuf = gbinder_reader_read_buffer(reader)); i++) {
-                    const HidlString* s = strings + i;
+                    const GBinderHidlString* s = strings + i;
                     if (sbuf->size == s->len + 1 &&
                         sbuf->data == s->data.str &&
                         s->data.str[s->len] == 0) {

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -46,28 +46,6 @@ typedef struct gbinder_output_data GBinderOutputData;
 typedef struct gbinder_rpc_protocol GBinderRpcProtocol;
 typedef struct gbinder_servicepoll GBinderServicePoll;
 
-typedef struct hidl_vec {
-    union {
-        guint64 value;
-        const void* ptr;
-    } data;
-    guint32 count;
-    guint32 owns_buffer;
-} HidlVec;
-
-#define HIDL_VEC_BUFFER_OFFSET (0)
-
-typedef struct hidl_string {
-    union {
-        guint64 value;
-        const char* str;
-    } data;
-    guint32 len;
-    guint32 owns_buffer;
-} HidlString;
-
-#define HIDL_STRING_BUFFER_OFFSET (0)
-
 #define GBINDER_INLINE_FUNC static inline
 
 #define GBINDER_TRANSACTION(c2,c3,c4)     GBINDER_FOURCC('_',c2,c3,c4)

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -504,13 +504,13 @@ gbinder_writer_data_append_hidl_vec(
     guint elemsize)
 {
     GBinderParent vec_parent;
-    HidlVec* vec = g_new0(HidlVec, 1);
+    GBinderHidlVec* vec = g_new0(GBinderHidlVec, 1);
     const gsize total = count * elemsize;
     void* buf = g_memdup(base, total);
 
     /* Prepare parent descriptor for the string data */
     vec_parent.index = gbinder_writer_data_prepare(data);
-    vec_parent.offset = HIDL_VEC_BUFFER_OFFSET;
+    vec_parent.offset = GBINDER_HIDL_VEC_BUFFER_OFFSET;
 
     /* Fill in the vector descriptor */
     if (buf) {
@@ -550,12 +550,12 @@ gbinder_writer_data_append_hidl_string(
     const char* str)
 {
     GBinderParent str_parent;
-    HidlString* hidl_string = g_new0(HidlString, 1);
+    GBinderHidlString* hidl_string = g_new0(GBinderHidlString, 1);
     const gsize len = str ? strlen(str) : 0;
 
     /* Prepare parent descriptor for the string data */
     str_parent.index = gbinder_writer_data_prepare(data);
-    str_parent.offset = HIDL_STRING_BUFFER_OFFSET;
+    str_parent.offset = GBINDER_HIDL_STRING_BUFFER_OFFSET;
 
     /* Fill in the string descriptor and store it */
     hidl_string->data.str = str;
@@ -597,8 +597,8 @@ gbinder_writer_data_append_hidl_string_vec(
     gssize count)
 {
     GBinderParent vec_parent;
-    HidlVec* vec = g_new0(HidlVec, 1);
-    HidlString* strings = NULL;
+    GBinderHidlVec* vec = g_new0(GBinderHidlVec, 1);
+    GBinderHidlString* strings = NULL;
     int i;
 
     if (count < 0) {
@@ -608,11 +608,11 @@ gbinder_writer_data_append_hidl_string_vec(
 
     /* Prepare parent descriptor for the vector data */
     vec_parent.index = gbinder_writer_data_prepare(data);
-    vec_parent.offset = HIDL_VEC_BUFFER_OFFSET;
+    vec_parent.offset = GBINDER_HIDL_VEC_BUFFER_OFFSET;
 
     /* Fill in the vector descriptor */
     if (count > 0) {
-        strings = g_new0(HidlString, count);
+        strings = g_new0(GBinderHidlString, count);
         vec->data.ptr = strings;
         data->cleanup = gbinder_cleanup_add(data->cleanup, g_free, strings);
     }
@@ -623,7 +623,7 @@ gbinder_writer_data_append_hidl_string_vec(
     /* Fill in string descriptors */
     for (i = 0; i < count; i++) {
         const char* str = strv[i];
-        HidlString* hidl_str = strings + i;
+        GBinderHidlString* hidl_str = strings + i;
 
         if ((hidl_str->data.str = str) != NULL) {
             hidl_str->len = strlen(str);
@@ -638,7 +638,7 @@ gbinder_writer_data_append_hidl_string_vec(
 
         /* Prepare parent descriptor for the string data */
         str_parent.index = data->offsets->count;
-        str_parent.offset = HIDL_STRING_BUFFER_OFFSET;
+        str_parent.offset = GBINDER_HIDL_STRING_BUFFER_OFFSET;
 
         /* Write the vector data (it's parent for the string data) */
         gbinder_writer_data_write_buffer_object(data, strings,
@@ -646,7 +646,7 @@ gbinder_writer_data_append_hidl_string_vec(
 
         /* Write the string data */
         for (i = 0; i < count; i++) {
-            HidlString* hidl_str = strings + i;
+            GBinderHidlString* hidl_str = strings + i;
 
             if (hidl_str->data.str) {
                 gbinder_writer_data_write_buffer_object(data,
@@ -655,7 +655,7 @@ gbinder_writer_data_append_hidl_string_vec(
                     (guint)hidl_str->len, (guint)str_parent.index,
                     (guint)data->buffers_size);
             }
-            str_parent.offset += sizeof(HidlString);
+            str_parent.offset += sizeof(GBinderHidlString);
         }
     }
 }

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -359,7 +359,7 @@ test_hidl_string(
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets->count == 1);
     g_assert(offsets->data[0] == 0);
-    g_assert(gbinder_output_data_buffers_size(data) == sizeof(HidlString));
+    g_assert(gbinder_output_data_buffers_size(data)==sizeof(GBinderHidlString));
     g_assert(data->bytes->len == BUFFER_OBJECT_SIZE_32);
     gbinder_local_reply_unref(reply);
 }
@@ -382,7 +382,7 @@ test_hidl_string_vec(
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets->count == 1);
     g_assert(offsets->data[0] == 0);
-    g_assert(gbinder_output_data_buffers_size(data) == sizeof(HidlVec));
+    g_assert(gbinder_output_data_buffers_size(data) == sizeof(GBinderHidlVec));
     g_assert(data->bytes->len == BUFFER_OBJECT_SIZE_32);
     gbinder_local_reply_unref(reply);
 }

--- a/unit/unit_local_request/unit_local_request.c
+++ b/unit/unit_local_request/unit_local_request.c
@@ -375,7 +375,7 @@ test_hidl_string(
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets->count == 1);
     g_assert(offsets->data[0] == 0);
-    g_assert(gbinder_output_data_buffers_size(data) == sizeof(HidlString));
+    g_assert(gbinder_output_data_buffers_size(data)==sizeof(GBinderHidlString));
     g_assert(data->bytes->len == BUFFER_OBJECT_SIZE_32);
     gbinder_local_request_unref(req);
 }
@@ -398,7 +398,7 @@ test_hidl_string_vec(
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets->count == 1);
     g_assert(offsets->data[0] == 0);
-    g_assert(gbinder_output_data_buffers_size(data) == sizeof(HidlVec));
+    g_assert(gbinder_output_data_buffers_size(data) == sizeof(GBinderHidlVec));
     g_assert(data->bytes->len == BUFFER_OBJECT_SIZE_32);
     gbinder_local_request_unref(req);
 }
@@ -525,8 +525,9 @@ test_remote_request_obj_validate_data(
     g_assert(offsets->data[1] == 4 + BUFFER_OBJECT_SIZE_64);
     g_assert(offsets->data[2] == 4 + 2*BUFFER_OBJECT_SIZE_64);
     g_assert(bytes->len == 4 + 2*BUFFER_OBJECT_SIZE_64 + BINDER_OBJECT_SIZE_64);
-    /* HidlString + the contents (2 bytes) aligned at 8-byte boundary */
-    g_assert(gbinder_output_data_buffers_size(data) == (sizeof(HidlString)+8));
+    /* GBinderHidlString + the contents (2 bytes) aligned at 8-byte boundary */
+    g_assert(gbinder_output_data_buffers_size(data) ==
+        (sizeof(GBinderHidlString) + 8));
 }
 
 static

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -603,7 +603,7 @@ typedef struct test_hidl_vec {
 
 static const guint test_hidl_vec_2offsets [] = { 0, BUFFER_OBJECT_SIZE_64 };
 static const guint8 test_hidl_vec_2bytes_data [] = { 0x01, 0x02 };
-static const HidlVec test_hidl_vec_2bytes = {
+static const GBinderHidlVec test_hidl_vec_2bytes = {
     .data.ptr = test_hidl_vec_2bytes_data,
     sizeof(test_hidl_vec_2bytes_data),
     TRUE
@@ -612,81 +612,81 @@ static const BinderObject64 test_hidl_vec_2bytes_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_2bytes },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_2bytes_data },
         sizeof(test_hidl_vec_2bytes_data), 0,
-        HIDL_VEC_BUFFER_OFFSET
+        GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
-static const HidlVec test_hidl_vec_empty = {
+static const GBinderHidlVec test_hidl_vec_empty = {
     .data.ptr = test_hidl_vec_2bytes_data, 0, TRUE
 };
 static const BinderObject64 test_hidl_vec_empty_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_empty },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_2bytes_data },
-        0, 0, HIDL_VEC_BUFFER_OFFSET
+        0, 0, GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
 static const guint test_hidl_vec_1offset [] = {0};
-static const HidlVec test_hidl_vec_null = {{0}, 0, TRUE};
+static const GBinderHidlVec test_hidl_vec_null = {{0}, 0, TRUE};
 static const BinderObject64 test_hidl_vec_null_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_null },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     }
 };
 
-/* Buffer smaller than HidlVec */
+/* Buffer smaller than GBinderHidlVec */
 static const BinderObject64 test_hidl_vec_short_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_empty },
-        sizeof(HidlVec) - 1, 0, 0
+        sizeof(GBinderHidlVec) - 1, 0, 0
     }
 };
 
 /* NULL buffer with size 1 */
 static const guint test_hidl_vec_badnull_offsets [] = {0};
-static const HidlVec test_hidl_vec_badnull = {{0}, 1, TRUE};
+static const GBinderHidlVec test_hidl_vec_badnull = {{0}, 1, TRUE};
 static const BinderObject64 test_hidl_vec_badnull_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_badnull },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     }
 };
 
 /* Buffer size not divisible by count */
 static const guint8 test_hidl_vec_badsize_data [] = { 0x01, 0x02, 0x03 };
-static const HidlVec test_hidl_vec_badsize = {
+static const GBinderHidlVec test_hidl_vec_badsize = {
     .data.ptr = test_hidl_vec_badsize_data, 2, TRUE
 };
 static const BinderObject64 test_hidl_vec_badsize_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_badsize },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_badsize_data },
         sizeof(test_hidl_vec_badsize_data), 0,
-        HIDL_VEC_BUFFER_OFFSET
+        GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
 /* Bad buffer address */
 static const guint8 test_hidl_vec_badbuf_data [] = { 0x01, 0x02, 0x03 };
-static const HidlVec test_hidl_vec_badbuf = {
+static const GBinderHidlVec test_hidl_vec_badbuf = {
     .data.ptr = test_hidl_vec_badbuf_data,
     sizeof(test_hidl_vec_badbuf_data), TRUE
 };
@@ -694,45 +694,45 @@ static const BinderObject64 test_hidl_vec_badbuf_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_badbuf },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_badsize_data },
         sizeof(test_hidl_vec_badsize_data), 0,
-        HIDL_VEC_BUFFER_OFFSET
+        GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
 /* Non-zero count and zero size */
-static const HidlVec test_hidl_vec_badcount1 = {
+static const GBinderHidlVec test_hidl_vec_badcount1 = {
     .data.ptr = test_hidl_vec_badsize_data, 1, TRUE
 };
 static const BinderObject64 test_hidl_vec_badcount1_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_badcount1 },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_badsize_data }, 0, 0,
-        HIDL_VEC_BUFFER_OFFSET
+        GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
 /* Zero count0 and non-zero size */
-static const HidlVec test_hidl_vec_badcount2 = {
+static const GBinderHidlVec test_hidl_vec_badcount2 = {
     .data.ptr = test_hidl_vec_badsize_data, 0, TRUE
 };
 static const BinderObject64 test_hidl_vec_badcount2_buf [] = {
     {
         BINDER_TYPE_PTR, 0,
         { &test_hidl_vec_badcount2 },
-        sizeof(HidlVec), 0, 0
+        sizeof(GBinderHidlVec), 0, 0
     },{
         BINDER_TYPE_PTR, BINDER_BUFFER_FLAG_HAS_PARENT,
         { test_hidl_vec_badsize_data },
         sizeof(test_hidl_vec_badsize_data), 0,
-        HIDL_VEC_BUFFER_OFFSET
+        GBINDER_HIDL_VEC_BUFFER_OFFSET
     }
 };
 
@@ -1004,7 +1004,7 @@ test_vec(
     GBinderReaderData data;
     GBinderReader reader;
     BinderObject64 obj;
-    HidlVec vec;
+    GBinderHidlVec vec;
     char** out;
 
     g_assert(ipc);

--- a/unit/unit_writer/unit_writer.c
+++ b/unit/unit_writer/unit_writer.c
@@ -366,15 +366,15 @@ static guint test_hidl_vec_offsets_64[] =
 
 static const TestHidlVecData test_hidl_vec_tests[] = {
     { "32/null", &gbinder_io_32, NULL, 0, 0,
-      TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_0), sizeof(HidlVec) },
+      TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_0), sizeof(GBinderHidlVec) },
     { "32/2x1", &gbinder_io_32, "xy", 2, 1,
       TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_32),
-      sizeof(HidlVec) + 8 /* vec data aligned at 8 bytes boundary */ },
+      sizeof(GBinderHidlVec) + 8 /* vec data aligned at 8 bytes boundary */ },
     { "64/null", &gbinder_io_64, NULL, 0, 0,
-      TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_0), sizeof(HidlVec) },
+      TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_0), sizeof(GBinderHidlVec) },
     { "64/2x2", &gbinder_io_64, "xxyy", 2, 2,
       TEST_ARRAY_AND_COUNT(test_hidl_vec_offsets_64),
-      sizeof(HidlVec) + 8 /* vec data aligned at 8 bytes boundary */ }
+      sizeof(GBinderHidlVec) + 8 /* vec data aligned at 8 bytes boundary */ }
 };
 
 static
@@ -425,15 +425,17 @@ static guint test_hidl_string_offsets_64[] =
 
 static const TestHidlStringData test_hidl_string_tests[] = {
     { "32/null", &gbinder_io_32, NULL,
-      TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_0), sizeof(HidlString) },
+      TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_0),
+      sizeof(GBinderHidlString) },
     { "32/xxx", &gbinder_io_32, "xxx",
       TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_32),
-      sizeof(HidlString) + 8 /* string data aligned at 8 bytes boundary */ },
+      sizeof(GBinderHidlString) + 8 /* string data aligned at 8 bytes */ },
     { "64/null", &gbinder_io_64, NULL,
-      TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_0), sizeof(HidlString) },
+      TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_0),
+      sizeof(GBinderHidlString) },
     { "64/xxxxxxx", &gbinder_io_64, "xxxxxxx",
       TEST_ARRAY_AND_COUNT(test_hidl_string_offsets_64),
-      sizeof(HidlString) + 8 /* string data aligned at 8 bytes boundary */ }
+      sizeof(GBinderHidlString) + 8 /* string data aligned at 8 bytes */ }
 };
 
 static
@@ -481,8 +483,9 @@ test_hidl_string2(
     g_assert(offsets->data[0] == 0);
     g_assert(offsets->data[1] == BUFFER_OBJECT_SIZE_32);
     g_assert(offsets->data[2] == 2*BUFFER_OBJECT_SIZE_32);
-    /* 2 HidlStrings + "foo" aligned at 8 bytes boundary */
-    g_assert(gbinder_output_data_buffers_size(data) == 2*sizeof(HidlString)+8);
+    /* 2 GBinderHidlStrings + "foo" aligned at 8 bytes boundary */
+    g_assert(gbinder_output_data_buffers_size(data) ==
+        (2 * sizeof(GBinderHidlString) + 8));
 
     gbinder_local_request_unref(req);
 }
@@ -513,18 +516,18 @@ static guint test_hidl_string_vec_offsets_1_64[] =
 static const TestHidlStringVecData test_hidl_string_vec_tests[] = {
     { "32/null", &gbinder_io_32, NULL, -1,
       TEST_ARRAY_AND_COUNT(test_hidl_string_vec_offsets_empty),
-      sizeof(HidlVec) },
+      sizeof(GBinderHidlVec) },
     { "32/1", &gbinder_io_32,
       (const char**)TEST_ARRAY_AND_COUNT(test_hidl_string_vec_data_1),
       TEST_ARRAY_AND_COUNT(test_hidl_string_vec_offsets_1_32),
-      sizeof(HidlVec) + sizeof(HidlString) + 8 },
+      sizeof(GBinderHidlVec) + sizeof(GBinderHidlString) + 8 },
     { "64/null", &gbinder_io_64, NULL, -1,
       TEST_ARRAY_AND_COUNT(test_hidl_string_vec_offsets_empty),
-      sizeof(HidlVec) },
+      sizeof(GBinderHidlVec) },
     { "64/1", &gbinder_io_64,
       (const char**)TEST_ARRAY_AND_COUNT(test_hidl_string_vec_data_1),
       TEST_ARRAY_AND_COUNT(test_hidl_string_vec_offsets_1_64),
-      sizeof(HidlVec) + sizeof(HidlString) + 8 },
+      sizeof(GBinderHidlVec) + sizeof(GBinderHidlString) + 8 },
 };
 
 static


### PR DESCRIPTION
These basic HIDL types are often used as a part of a larger structure.