### PR TITLE
Reading and writing UTF-16 strings without any conversion

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -166,6 +166,12 @@ gbinder_reader_read_nullable_string16(
     char** out);
 
 gboolean
+gbinder_reader_read_nullable_string16_utf16(
+    GBinderReader* reader,
+    gunichar2** out,
+    gsize* len); /* since 1.0.17 */
+
+gboolean
 gbinder_reader_skip_string16(
     GBinderReader* reader);
 

--- a/include/gbinder_writer.h
+++ b/include/gbinder_writer.h
@@ -87,6 +87,12 @@ gbinder_writer_append_string16_len(
     gssize num_bytes);
 
 void
+gbinder_writer_append_string16_utf16(
+    GBinderWriter* writer,
+    const gunichar2* utf16,
+    gssize length); /* Since 1.0.17 */
+
+void
 gbinder_writer_append_string8(
     GBinderWriter* writer,
     const char* str);


### PR DESCRIPTION
This is good for performance and also allows serializing and deserializing strings containing embedded NULL characters (https://github.com/mer-hybris/libgbinder/issues/13).