### PR TITLE
Add API to block incoming requests

### DIFF
--- a/include/gbinder_remote_request.h
+++ b/include/gbinder_remote_request.h
@@ -67,6 +67,16 @@ gbinder_remote_request_copy_to_local(
     GBinderRemoteRequest* req) /* since 1.0.6 */
     G_GNUC_WARN_UNUSED_RESULT;
 
+void
+gbinder_remote_request_block(
+    GBinderRemoteRequest* req); /* Since 1.0.20 */
+
+void
+gbinder_remote_request_complete(
+    GBinderRemoteRequest* req,
+    GBinderLocalReply* reply,
+    int status); /* Since 1.0.20 */
+
 /* Convenience function to decode requests with just one data item */
 
 gboolean

--- a/src/gbinder_remote_request_p.h
+++ b/src/gbinder_remote_request_p.h
@@ -37,6 +37,10 @@
 
 #include "gbinder_types_p.h"
 
+struct gbinder_remote_request {
+    GBinderIpcLooperTx* tx;
+};
+
 GBinderRemoteRequest*
 gbinder_remote_request_new(
     GBinderObjectRegistry* reg,

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -45,6 +45,7 @@ typedef struct gbinder_object_registry GBinderObjectRegistry;
 typedef struct gbinder_output_data GBinderOutputData;
 typedef struct gbinder_rpc_protocol GBinderRpcProtocol;
 typedef struct gbinder_servicepoll GBinderServicePoll;
+typedef struct gbinder_ipc_looper_tx GBinderIpcLooperTx;
 
 #define GBINDER_INLINE_FUNC static inline
 

--- a/unit/unit_remote_request/unit_remote_request.c
+++ b/unit/unit_remote_request/unit_remote_request.c
@@ -73,6 +73,8 @@ test_null(
     gbinder_remote_request_unref(NULL);
     gbinder_remote_request_set_data(NULL, 0, NULL);
     gbinder_remote_request_init_reader(NULL, &reader);
+    gbinder_remote_request_block(NULL);
+    gbinder_remote_request_complete(NULL, NULL, 0);
     g_assert(gbinder_reader_at_end(&reader));
     g_assert(!gbinder_remote_request_interface(NULL));
     g_assert(!gbinder_remote_request_copy_to_local(NULL));
@@ -99,6 +101,10 @@ test_basic(
     GBinderReader reader;
     GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
         gbinder_rpc_protocol_for_device(NULL), 0, 0);
+
+    /* These two calls are wrong but won't cause problems: */
+    gbinder_remote_request_block(req);
+    gbinder_remote_request_complete(req, NULL, 0);
 
     gbinder_remote_request_init_reader(req, &reader);
     g_assert(gbinder_reader_at_end(&reader));


### PR DESCRIPTION
`GBinderRemoteRequest` can be marked as blocked by calling `gbinder_remote_request_block()` and later completed with `gbinder_remote_request_complete()`