### PR TITLE
Add gbinder_reader_read_hidl_string_c()

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -125,7 +125,7 @@ gbinder_reader_read_buffer(
 const void*
 gbinder_reader_read_hidl_struct1(
     GBinderReader* reader,
-    gsize size); /* since 1.0.9 */
+    gsize size); /* Since 1.0.9 */
 
 #define gbinder_reader_read_hidl_struct(reader,type) \
     ((const type*)gbinder_reader_read_hidl_struct1(reader, sizeof(type)))
@@ -140,7 +140,7 @@ const void*
 gbinder_reader_read_hidl_vec1(
     GBinderReader* reader,
     gsize* count,
-    guint expected_elemsize); /* since 1.0.9 */
+    guint expected_elemsize); /* Since 1.0.9 */
 
 #define gbinder_reader_read_hidl_type_vec(reader,type,count) \
     ((const type*)gbinder_reader_read_hidl_vec1(reader, count, sizeof(type)))
@@ -151,6 +151,13 @@ char*
 gbinder_reader_read_hidl_string(
     GBinderReader* reader)
     G_GNUC_WARN_UNUSED_RESULT;
+
+const char*
+gbinder_reader_read_hidl_string_c(
+    GBinderReader* reader); /* Since 1.0.23 */
+
+#define gbinder_reader_skip_hidl_string(reader) \
+    (gbinder_reader_read_hidl_string_c(reader) != NULL)
 
 char**
 gbinder_reader_read_hidl_string_vec(
@@ -178,7 +185,7 @@ gboolean
 gbinder_reader_read_nullable_string16_utf16(
     GBinderReader* reader,
     gunichar2** out,
-    gsize* len); /* since 1.0.17 */
+    gsize* len); /* Since 1.0.17 */
 
 gboolean
 gbinder_reader_skip_string16(
@@ -187,7 +194,7 @@ gbinder_reader_skip_string16(
 const void*
 gbinder_reader_read_byte_array(
     GBinderReader* reader,
-    gsize* len); /* since 1.0.12 */
+    gsize* len); /* Since 1.0.12 */
 
 gsize
 gbinder_reader_bytes_read(

--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -409,7 +409,7 @@ guint
 GBINDER_IO_FN(decode_buffer_object)(
     GBinderBuffer* buf,
     gsize offset,
-    GBinderBuffer** out)
+    GBinderIoBufferObject* out)
 {
     const void* data = (guint8*)buf->data + offset;
     const gsize size = (offset < buf->size) ? (buf->size - offset) : 0;
@@ -417,12 +417,14 @@ GBINDER_IO_FN(decode_buffer_object)(
 
     if (size >= sizeof(*flat) && flat->hdr.type == BINDER_TYPE_PTR) {
         if (out) {
-            *out = gbinder_buffer_new_with_parent(buf,
-                (void*)(uintptr_t)flat->buffer, flat->length);
+            out->data = (void*)(uintptr_t)flat->buffer;
+            out->size = (gsize)flat->length;
+            out->parent_offset = (gsize)flat->parent_offset;
+            out->has_parent = (flat->flags & BINDER_BUFFER_FLAG_HAS_PARENT) ?
+                TRUE : FALSE;
         }
         return sizeof(*flat);
     }
-    if (out) *out = NULL;
     return 0;
 }
 

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -42,6 +42,13 @@ typedef struct gbinder_io_buf {
     gsize size;
     gsize consumed;
 } GBinderIoBuf;
+
+typedef struct gbinder_io_buffer_object {
+    void* data;
+    gsize size;
+    gsize parent_offset;
+    gboolean has_parent;
+} GBinderIoBufferObject;
 
 typedef struct gbinder_io_tx_data {
     int status;
@@ -165,9 +172,9 @@ struct gbinder_io {
     void* (*decode_binder_ptr_cookie)(const void* data);
     guint (*decode_cookie)(const void* data, guint64* cookie);
     guint (*decode_binder_object)(const void* data, gsize size,
-       GBinderObjectRegistry* reg, GBinderRemoteObject** obj);
+        GBinderObjectRegistry* reg, GBinderRemoteObject** obj);
     guint (*decode_buffer_object)(GBinderBuffer* buf, gsize offset,
-        GBinderBuffer** out);
+        GBinderIoBufferObject* out);
     guint (*decode_fd_object)(const void* data, gsize size, int* fd);
 
     /* ioctl wrappers */


### PR DESCRIPTION
It allows to fetch a pointer to the hidl string contents (which must be NULL terminated) without duplicating the string and allocating any memory in the process.

Added `gbinder_reader_skip_hidl_string()` macro.

Reduced number of memory allocations performed by functions parsing buffer objects. Many of them don't allocate any memory at all now.