### PR TITLE
[local_object] Revert "Make sure NULL objects are passed as BINDER_TYPE_WEAK_HANDLE". Fixes JB#44476

### DIFF
--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -128,7 +128,7 @@ GBINDER_IO_FN(encode_local_object)(
     struct flat_binder_object* dest = out;
 
     memset(dest, 0, sizeof(*dest));
-    dest->hdr.type = obj ? BINDER_TYPE_BINDER : BINDER_TYPE_WEAK_HANDLE;
+    dest->hdr.type = BINDER_TYPE_BINDER;
     dest->flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
     dest->binder = (uintptr_t)obj;
     return sizeof(*dest);


### PR DESCRIPTION
This reverts commit 3b299d33454f71882373af0ff3542886f12778c3 which broke handling of NULL objects in certain situations.