### PR TITLE
ServiceManager presence API

### DIFF
--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -36,6 +36,12 @@
 #include <gbinder_types.h>
 
 G_BEGIN_DECLS
+
+typedef
+void
+(*GBinderServiceManagerFunc)(
+    GBinderServiceManager* sm,
+    void* user_data);
 
 /* GBinderServiceManagerListFunc callback returns TRUE to keep the services
  * list, otherwise the caller will deallocate it. */
@@ -95,6 +101,15 @@ void
 gbinder_servicemanager_unref(
     GBinderServiceManager* sm);
 
+gboolean
+gbinder_servicemanager_is_present(
+    GBinderServiceManager* sm); /* Since 1.0.25 */
+
+gboolean
+gbinder_servicemanager_wait(
+    GBinderServiceManager* sm,
+    long max_wait_ms); /* Since 1.0.25 */
+
 gulong
 gbinder_servicemanager_list(
     GBinderServiceManager* sm,
@@ -138,6 +153,12 @@ gbinder_servicemanager_cancel(
     gulong id);
 
 gulong
+gbinder_servicemanager_add_presence_handler(
+    GBinderServiceManager* sm,
+    GBinderServiceManagerFunc func,
+    void* user_data); /* Since 1.0.25 */
+
+gulong
 gbinder_servicemanager_add_registration_handler(
     GBinderServiceManager* sm,
     const char* name,
@@ -148,6 +169,15 @@ void
 gbinder_servicemanager_remove_handler(
     GBinderServiceManager* sm,
     gulong id); /* Since 1.0.13 */
+
+void
+gbinder_servicemanager_remove_handlers(
+    GBinderServiceManager* sm,
+    gulong* ids,
+    guint count); /* Since 1.0.25 */
+
+#define gbinder_servicemanager_remove_all_handlers(r,ids) \
+    gbinder_servicemanager_remove_handlers(sm, ids, G_N_ELEMENTS(ids))
 
 G_END_DECLS
 

--- a/src/gbinder_driver.h
+++ b/src/gbinder_driver.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -130,6 +130,12 @@ gbinder_driver_transact(
     guint32 code,
     GBinderLocalRequest* request,
     GBinderRemoteReply* reply);
+
+int
+gbinder_driver_ping(
+    GBinderDriver* driver,
+    GBinderObjectRegistry* reg,
+    guint32 handle);
 
 GBinderLocalRequest*
 gbinder_driver_local_request_new(

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -99,7 +99,8 @@ gbinder_ipc_new_local_object(
 GBinderRemoteObject*
 gbinder_ipc_get_remote_object(
     GBinderIpc* ipc,
-    guint32 handle);
+    guint32 handle,
+    gboolean maybe_dead);
 
 GBinderRemoteReply*
 gbinder_ipc_transact_sync_reply(

--- a/src/gbinder_remote_object_p.h
+++ b/src/gbinder_remote_object_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -54,7 +54,12 @@ struct gbinder_remote_object {
 GBinderRemoteObject*
 gbinder_remote_object_new(
     GBinderIpc* ipc,
-    guint32 handle);
+    guint32 handle,
+    gboolean maybe_dead);
+
+gboolean
+gbinder_remote_object_reanimate(
+    GBinderRemoteObject* obj);
 
 void
 gbinder_remote_object_handle_death_notification(

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -52,6 +52,14 @@
 
 static
 void
+gbinder_rpc_protocol_binder_write_ping(
+    GBinderWriter* writer)
+{
+    /* No payload */
+}
+
+static
+void
 gbinder_rpc_protocol_binder_write_rpc_header(
     GBinderWriter* writer,
     const char* iface)
@@ -100,6 +108,15 @@ gbinder_rpc_protocol_hwbinder_write_rpc_header(
 }
 
 static
+void
+gbinder_rpc_protocol_hwbinder_write_ping(
+    GBinderWriter* writer)
+{
+    gbinder_rpc_protocol_hwbinder_write_rpc_header(writer,
+        "android.hidl.base@1.0::IBase");
+}
+
+static
 const char*
 gbinder_rpc_protocol_hwbinder_read_rpc_header(
     GBinderReader* reader,
@@ -115,13 +132,17 @@ gbinder_rpc_protocol_hwbinder_read_rpc_header(
  *==========================================================================*/
 
 const GBinderRpcProtocol gbinder_rpc_protocol_binder = {
-    .read_rpc_header = gbinder_rpc_protocol_binder_read_rpc_header,
-    .write_rpc_header = gbinder_rpc_protocol_binder_write_rpc_header
+    .ping_tx = GBINDER_PING_TRANSACTION,
+    .write_ping = gbinder_rpc_protocol_binder_write_ping,
+    .write_rpc_header = gbinder_rpc_protocol_binder_write_rpc_header,
+    .read_rpc_header = gbinder_rpc_protocol_binder_read_rpc_header
 };
 
 const GBinderRpcProtocol gbinder_rpc_protocol_hwbinder = {
-    .read_rpc_header = gbinder_rpc_protocol_hwbinder_read_rpc_header,
-    .write_rpc_header = gbinder_rpc_protocol_hwbinder_write_rpc_header
+    .ping_tx = HIDL_PING_TRANSACTION,
+    .write_ping = gbinder_rpc_protocol_hwbinder_write_ping,
+    .write_rpc_header = gbinder_rpc_protocol_hwbinder_write_rpc_header,
+    .read_rpc_header = gbinder_rpc_protocol_hwbinder_read_rpc_header
 };
 
 const GBinderRpcProtocol*

--- a/src/gbinder_rpc_protocol.h
+++ b/src/gbinder_rpc_protocol.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -42,9 +42,11 @@
  */
 
 struct gbinder_rpc_protocol {
+    guint32 ping_tx;
+    void (*write_ping)(GBinderWriter* writer);
+    void (*write_rpc_header)(GBinderWriter* writer, const char* iface);
     const char* (*read_rpc_header)(GBinderReader* reader, guint32 txcode,
         char** iface);
-    void (*write_rpc_header)(GBinderWriter* writer, const char* iface);
 };
 
 extern const GBinderRpcProtocol gbinder_rpc_protocol_binder;

--- a/test/binder-list/binder-list.c
+++ b/test/binder-list/binder-list.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -245,7 +245,7 @@ int main(int argc, char* argv[])
     app.opt = &opt;
     if (app_init(&opt, argc, argv)) {
         app.sm = gbinder_servicemanager_new(opt.dev);
-        if (app.sm) {
+        if (gbinder_servicemanager_wait(app.sm, -1)) {
             if (opt.async) {
                 app_async(&app);
             } else {

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -35,65 +35,86 @@
 
 #include "test_common.h"
 
-gboolean
+void
 test_binder_br_noop(
     int fd);
 
-gboolean
+void
 test_binder_br_increfs(
     int fd,
     void* ptr);
 
-gboolean
+void
 test_binder_br_acquire(
     int fd,
     void* ptr);
 
-gboolean
+void
 test_binder_br_release(
     int fd,
     void* ptr);
 
-gboolean
+void
 test_binder_br_decrefs(
     int fd,
     void* ptr);
 
-gboolean
+void
 test_binder_br_transaction_complete(
     int fd);
 
-gboolean
+void
+test_binder_br_transaction_complete_later(
+    int fd);
+
+void
 test_binder_br_dead_binder(
     int fd,
     guint handle);
 
-gboolean
+void
 test_binder_br_dead_reply(
     int fd);
 
-gboolean
+void
 test_binder_br_failed_reply(
     int fd);
 
-gboolean
+void
 test_binder_br_transaction(
     int fd,
     void* target,
     guint32 code,
     const GByteArray* bytes);
 
-gboolean
+void
 test_binder_br_reply(
     int fd,
     guint32 handle,
     guint32 code,
     const GByteArray* bytes);
 
-gboolean
+void
 test_binder_br_reply_status(
     int fd,
     gint32 status);
+
+void
+test_binder_br_reply_later(
+    int fd,
+    guint32 handle,
+    guint32 code,
+    const GByteArray* bytes);
+
+void
+test_binder_br_reply_status_later(
+    int fd,
+    gint32 status);
+
+void
+test_binder_set_looper_enabled(
+    int fd,
+    gboolean enabled);
 
 void
 test_binder_set_destroy(

--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -183,10 +183,10 @@ test_sync_reply_tx(
     data = gbinder_local_reply_data(reply);
     g_assert(data);
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_transaction_complete(fd));
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply(fd, handle, code, data->bytes));
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_noop(fd);
+    test_binder_br_reply(fd, handle, code, data->bytes);
 
     tx_reply = gbinder_client_transact_sync_reply(client, 0, req, &status);
     g_assert(tx_reply);
@@ -284,10 +284,10 @@ test_reply_tx(
     data = gbinder_local_reply_data(reply);
     g_assert(data);
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_transaction_complete(fd));
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply(fd, handle, code, data->bytes));
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_noop(fd);
+    test_binder_br_reply(fd, handle, code, data->bytes);
 
     id = gbinder_client_transact(client, 0, 0, req, done, destroy, loop);
     g_assert(id);

--- a/unit/unit_driver/unit_driver.c
+++ b/unit/unit_driver/unit_driver.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -91,7 +91,7 @@ test_noop(
 
     g_assert(driver);
     g_assert(fd >= 0);
-    g_assert(test_binder_br_noop(fd));
+    test_binder_br_noop(fd);
     g_assert(gbinder_driver_poll(driver, NULL) == POLLIN);
     g_assert(gbinder_driver_read(driver, NULL, NULL) == 0);
 

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -143,7 +143,7 @@ test_sync_oneway(
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
 
-    g_assert(test_binder_br_transaction_complete(fd));
+    test_binder_br_transaction_complete(fd);
     g_assert(gbinder_ipc_transact_sync_oneway(ipc, 0, 1, req) ==
         GBINDER_STATUS_OK);
     gbinder_local_request_unref(req);
@@ -175,10 +175,10 @@ test_sync_reply_ok_status(
     data = gbinder_local_reply_data(reply);
     g_assert(data);
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_transaction_complete(fd));
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply(fd, handle, code, data->bytes));
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_noop(fd);
+    test_binder_br_reply(fd, handle, code, data->bytes);
 
     tx_reply = gbinder_ipc_transact_sync_reply(ipc, handle, code, req, status);
     g_assert(tx_reply);
@@ -223,10 +223,10 @@ test_sync_reply_error(
     const gint expected_status = GBINDER_STATUS_FAILED;
     int status = INT_MAX;
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_transaction_complete(fd));
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply_status(fd, expected_status));
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_noop(fd);
+    test_binder_br_reply_status(fd, expected_status);
 
     g_assert(!gbinder_ipc_transact_sync_reply(ipc, handle, code, req, &status));
     g_assert(status == expected_status);
@@ -286,10 +286,10 @@ test_transact_ok(
     data = gbinder_local_reply_data(reply);
     g_assert(data);
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_transaction_complete(fd));
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply(fd, handle, code, data->bytes));
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_noop(fd);
+    test_binder_br_reply(fd, handle, code, data->bytes);
 
     id = gbinder_ipc_transact(ipc, handle, code, 0, req,
         test_transact_ok_done, test_transact_ok_destroy, loop);
@@ -335,8 +335,8 @@ test_transact_dead(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_dead_reply(fd));
+    test_binder_br_noop(fd);
+    test_binder_br_dead_reply(fd);
 
     id = gbinder_ipc_transact(ipc, 1, 2, 0, req, test_transact_dead_done,
         NULL, loop);
@@ -381,8 +381,8 @@ test_transact_failed(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_failed_reply(fd));
+    test_binder_br_noop(fd);
+    test_binder_br_failed_reply(fd);
 
     id = gbinder_ipc_transact(ipc, 1, 2, 0, req, test_transact_failed_done,
         NULL, loop);
@@ -429,8 +429,8 @@ test_transact_status(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
-    g_assert(test_binder_br_noop(fd));
-    g_assert(test_binder_br_reply_status(fd, EXPECTED_STATUS));
+    test_binder_br_noop(fd);
+    test_binder_br_reply_status(fd, EXPECTED_STATUS);
 
     id = gbinder_ipc_transact(ipc, 1, 2, 0, req, test_transact_status_done,
         NULL, loop);
@@ -647,6 +647,7 @@ test_transact_incoming(
     data = gbinder_local_request_data(req);
 
     test_binder_br_transaction(fd, obj, 1, data->bytes);
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     /* Now we need to wait until GBinderIpc is destroyed */
@@ -708,6 +709,7 @@ test_transact_status_reply(
     data = gbinder_local_request_data(req);
 
     test_binder_br_transaction(fd, obj, 1, data->bytes);
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     /* Now we need to wait until GBinderIpc is destroyed */
@@ -812,6 +814,7 @@ test_transact_async(
     data = gbinder_local_request_data(req);
 
     test_binder_br_transaction(fd, obj, 1, data->bytes);
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     /* Now we need to wait until GBinderIpc is destroyed */
@@ -882,6 +885,7 @@ test_transact_async_sync(
     data = gbinder_local_request_data(req);
 
     test_binder_br_transaction(fd, obj, 1, data->bytes);
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     /* Now we need to wait until GBinderIpc is destroyed */

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -525,7 +525,7 @@ test_increfs(
     /* ipc is not an object, will be ignored */
     test_binder_br_increfs(fd, ipc);
     test_binder_br_increfs(fd, obj);
-
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     g_assert(obj->weak_refs == 1);
@@ -568,7 +568,7 @@ test_decrefs(
     test_binder_br_decrefs(fd, ipc);
     test_binder_br_increfs(fd, obj);
     test_binder_br_decrefs(fd, obj);
-
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     g_assert(obj->weak_refs == 0);
@@ -609,7 +609,7 @@ test_acquire(
     /* ipc is not an object, will be ignored */
     test_binder_br_acquire(fd, ipc);
     test_binder_br_acquire(fd, obj);
-
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     g_assert(obj->strong_refs == 1);
@@ -652,7 +652,7 @@ test_release(
     test_binder_br_release(fd, ipc);
     test_binder_br_acquire(fd, obj);
     test_binder_br_release(fd, obj);
-
+    test_binder_set_looper_enabled(fd, TRUE);
     test_run(&test_opt, loop);
 
     g_assert(obj->strong_refs == 0);

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,8 +30,9 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_common.h"
+#include "test_binder.h"
 
+#include "gbinder_driver.h"
 #include "gbinder_client_p.h"
 #include "gbinder_remote_object_p.h"
 #include "gbinder_ipc.h"
@@ -92,6 +93,36 @@ test_transact_func(
     return NULL;
 }
 
+static
+void
+test_inc(
+    GBinderServiceManager* sm,
+    void* user_data)
+{
+    (*((int*)user_data))++;
+}
+
+static
+void
+test_quit(
+    GBinderServiceManager* sm,
+    void* user_data)
+{
+    test_quit_later((GMainLoop*)user_data);
+}
+
+static
+void
+test_setup_ping(
+    GBinderIpc* ipc)
+{
+    const int fd = gbinder_driver_fd(ipc->driver);
+
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_reply(fd, 0, 0, NULL);
+}
+
 /*==========================================================================*
  * TestServiceManager
  *==========================================================================*/
@@ -131,7 +162,7 @@ test_servicemanager_get_service(
     if (gutil_strv_contains(self->services, name)) {
         if (!self->remote) {
             self->remote = gbinder_ipc_get_remote_object
-                (gbinder_client_ipc(sm->client), 1);
+                (gbinder_client_ipc(sm->client), 1, TRUE);
         }
         *status = GBINDER_STATUS_OK;
         return gbinder_remote_object_ref(self->remote);
@@ -355,6 +386,8 @@ test_null(
     g_assert(!gbinder_servicemanager_new_with_type(0, NULL));
     g_assert(!gbinder_servicemanager_new_local_object(NULL, NULL, NULL, NULL));
     g_assert(!gbinder_servicemanager_ref(NULL));
+    g_assert(!gbinder_servicemanager_is_present(NULL));
+    g_assert(!gbinder_servicemanager_wait(NULL, 0));
     g_assert(!gbinder_servicemanager_list(NULL, NULL, NULL));
     g_assert(!gbinder_servicemanager_list_sync(NULL));
     g_assert(!gbinder_servicemanager_get_service(NULL, NULL, NULL, NULL));
@@ -362,9 +395,11 @@ test_null(
     g_assert(!gbinder_servicemanager_add_service(NULL, NULL, NULL, NULL, NULL));
     g_assert(gbinder_servicemanager_add_service_sync(NULL, NULL, NULL) ==
         (-EINVAL));
+    g_assert(!gbinder_servicemanager_add_presence_handler(NULL, NULL, NULL));
     g_assert(!gbinder_servicemanager_add_registration_handler(NULL, NULL,
         NULL, NULL));
     gbinder_servicemanager_remove_handler(NULL, 0);
+    gbinder_servicemanager_remove_handlers(NULL, NULL, 0);
     gbinder_servicemanager_cancel(NULL, 0);
     gbinder_servicemanager_unref(NULL);
 }
@@ -379,9 +414,13 @@ test_invalid(
     void)
 {
     int status = 0;
-    GBinderServiceManager* sm =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_HWBINDER);
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderServiceManager* sm;
+    gulong id = 0;
 
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
     g_assert(!gbinder_servicemanager_new_with_type(GBINDER_TYPE_LOCAL_OBJECT,
         NULL));
     g_assert(TEST_IS_HWSERVICEMANAGER(sm));
@@ -399,12 +438,16 @@ test_invalid(
         (-EINVAL));
     g_assert(gbinder_servicemanager_add_service_sync(sm, "foo", NULL) ==
         (-EINVAL));
+    g_assert(!gbinder_servicemanager_add_presence_handler(sm, NULL, NULL));
     g_assert(!gbinder_servicemanager_add_registration_handler(sm, NULL, NULL,
         NULL));
 
     gbinder_servicemanager_cancel(sm, 0);
     gbinder_servicemanager_remove_handler(sm, 0);
+    gbinder_servicemanager_remove_handlers(sm, NULL, 0);
+    gbinder_servicemanager_remove_handlers(sm, &id, 0);
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
 }
 
 /*==========================================================================*
@@ -416,10 +459,13 @@ void
 test_basic(
     void)
 { 
-    GBinderServiceManager* sm =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_HWBINDER);
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderServiceManager* sm;
     GBinderLocalObject* obj;
 
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
     g_assert(sm);
     obj = gbinder_servicemanager_new_local_object(sm, "foo.bar",
         test_transact_func, NULL);
@@ -429,6 +475,213 @@ test_basic(
     g_assert(gbinder_servicemanager_ref(sm) == sm);
     gbinder_servicemanager_unref(sm);
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+}
+
+/*==========================================================================*
+ * not_present
+ *==========================================================================*/
+
+static
+void
+test_not_present(
+    void)
+{ 
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    GBinderServiceManager* sm;
+
+    /* This makes presence detection PING fail */
+    test_binder_br_reply_status(fd, -1);
+
+    sm = gbinder_servicemanager_new(dev);
+    g_assert(sm);
+    g_assert(!gbinder_servicemanager_is_present(sm));
+
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+}
+
+/*==========================================================================*
+ * wait
+ *==========================================================================*/
+
+static
+void
+test_wait(
+    void)
+{ 
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    const glong forever = (test_opt.flags & TEST_FLAG_DEBUG) ?
+        (TEST_TIMEOUT_SEC * 1000) : -1;
+    GBinderServiceManager* sm;
+    gulong id;
+    int count = 0;
+
+    /* This makes presence detection PING fail */
+    test_binder_br_reply_status(fd, -1);
+
+    sm = gbinder_servicemanager_new(dev);
+    g_assert(sm);
+    g_assert(!gbinder_servicemanager_is_present(sm));
+
+    /* Register the listener */
+    id = gbinder_servicemanager_add_presence_handler(sm, test_inc, &count);
+    g_assert(id);
+
+    /* Make this wait fail */
+    test_binder_br_reply_status(fd, -1);
+    g_assert(!gbinder_servicemanager_wait(sm, 0));
+
+    /* This makes presence detection PING succeed */
+    test_binder_br_noop(fd);
+    test_binder_br_transaction_complete(fd);
+    test_binder_br_reply(fd, 0, 0, NULL);
+    g_assert(gbinder_servicemanager_wait(sm, forever));
+
+    /* The next check succeeds too (without any I/O ) */
+    g_assert(gbinder_servicemanager_is_present(sm));
+    g_assert(gbinder_servicemanager_wait(sm, 0));
+
+    /* The listener must have been invoked exactly once */
+    g_assert(count == 1);
+    gbinder_servicemanager_remove_handler(sm, id);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+}
+
+/*==========================================================================*
+ * wait_long
+ *==========================================================================*/
+
+static
+void
+test_wait_long(
+    void)
+{ 
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    GBinderServiceManager* sm;
+    gulong id;
+    int count = 0;
+
+    /* This makes presence detection PING fail */
+    test_binder_br_reply_status(fd, -1);
+
+    sm = gbinder_servicemanager_new(dev);
+    g_assert(sm);
+    g_assert(!gbinder_servicemanager_is_present(sm));
+
+    /* Register the listener */
+    id = gbinder_servicemanager_add_presence_handler(sm, test_inc, &count);
+    g_assert(id);
+
+    /* Make the first presence detection PING fail and second succeed */
+    test_binder_br_reply_status(fd, -1);
+    test_binder_br_reply_status_later(fd, -1);
+    test_binder_br_transaction_complete_later(fd);
+    test_binder_br_reply_later(fd, 0, 0, NULL);
+    g_assert(gbinder_servicemanager_wait(sm, TEST_TIMEOUT_SEC * 1000));
+
+    /* The next check succeeds too (without any I/O ) */
+    g_assert(gbinder_servicemanager_is_present(sm));
+    g_assert(gbinder_servicemanager_wait(sm, 0));
+
+    /* The listener must have been invoked exactly once */
+    g_assert(count == 1);
+    gbinder_servicemanager_remove_handler(sm, id);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+}
+
+/*==========================================================================*
+ * wait_async
+ *==========================================================================*/
+
+static
+void
+test_wait_async(
+    void)
+{ 
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderServiceManager* sm;
+    gulong id[2];
+    int count = 0;
+
+    /* This makes presence detection PING fail */
+    test_binder_br_reply_status(fd, -1);
+
+    sm = gbinder_servicemanager_new(dev);
+    g_assert(sm);
+    g_assert(!gbinder_servicemanager_is_present(sm));
+
+    /* Register the listeners */
+    id[0] = gbinder_servicemanager_add_presence_handler(sm, test_inc, &count);
+    id[1] = gbinder_servicemanager_add_presence_handler(sm, test_quit, loop);
+    g_assert(id[0]);
+    g_assert(id[1]);
+
+    /* Make the first presence detection PING fail and second succeed */
+    test_binder_br_reply_status(fd, -1);
+    test_binder_br_transaction_complete_later(fd);
+    test_binder_br_reply_later(fd, 0, 0, NULL);
+    test_run(&test_opt, loop);
+
+    /* The listener must have been invoked exactly once */
+    g_assert(count == 1);
+    gbinder_servicemanager_remove_all_handlers(sm, id);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+    g_main_loop_unref(loop);
+}
+
+/*==========================================================================*
+ * death
+ *==========================================================================*/
+
+static
+void
+test_death(
+    void)
+{ 
+    const char* dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderServiceManager* sm;
+    gulong id[2];
+    int count = 0;
+
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
+    g_assert(sm);
+    g_assert(gbinder_servicemanager_is_present(sm));
+
+    /* Register the listeners */
+    id[0] = gbinder_servicemanager_add_presence_handler(sm, test_inc, &count);
+    id[1] = gbinder_servicemanager_add_presence_handler(sm, test_quit, loop);
+    g_assert(id[0]);
+    g_assert(id[1]);
+
+    /* Generate death notification (need looper for that) */
+    test_binder_br_dead_binder(fd, 0);
+    test_binder_set_looper_enabled(fd, TRUE);
+    test_run(&test_opt, loop);
+
+    /* The listener must have been invoked exactly once */
+    g_assert(count == 1);
+    g_assert(!gbinder_servicemanager_is_present(sm));
+    gbinder_servicemanager_remove_all_handlers(sm, id);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+    g_main_loop_unref(loop);
 }
 
 /*==========================================================================*
@@ -440,18 +693,29 @@ void
 test_reuse(
     void)
 { 
-    GBinderServiceManager* m1 =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_BINDER);
-    GBinderServiceManager* m2 =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_BINDER);
-    GBinderServiceManager* vnd1 =
-        gbinder_servicemanager_new("/dev/vpnbinder");
-    GBinderServiceManager* vnd2 =
-        gbinder_servicemanager_new("/dev/vpnbinder");
-    GBinderServiceManager* hw1 =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_HWBINDER);
-    GBinderServiceManager* hw2 =
-        gbinder_servicemanager_new(GBINDER_DEFAULT_HWBINDER);
+    const char* binder_dev = GBINDER_DEFAULT_BINDER;
+    const char* vndbinder_dev = "/dev/vpnbinder";
+    const char* hwbinder_dev = GBINDER_DEFAULT_HWBINDER;
+    GBinderIpc* binder_ipc = gbinder_ipc_new(binder_dev, NULL);
+    GBinderIpc* vndbinder_ipc = gbinder_ipc_new(vndbinder_dev, NULL);
+    GBinderIpc* hwbinder_ipc = gbinder_ipc_new(hwbinder_dev, NULL);
+    GBinderServiceManager* m1;
+    GBinderServiceManager* m2;
+    GBinderServiceManager* vnd1;
+    GBinderServiceManager* vnd2;
+    GBinderServiceManager* hw1;
+    GBinderServiceManager* hw2;
+
+    test_setup_ping(binder_ipc);
+    test_setup_ping(vndbinder_ipc);
+    test_setup_ping(hwbinder_ipc);
+
+    m1 = gbinder_servicemanager_new(binder_dev);
+    m2 = gbinder_servicemanager_new(binder_dev);
+    vnd1 = gbinder_servicemanager_new(vndbinder_dev);
+    vnd2 = gbinder_servicemanager_new(vndbinder_dev);
+    hw1 = gbinder_servicemanager_new(hwbinder_dev);
+    hw2 = gbinder_servicemanager_new(hwbinder_dev);
 
     g_assert(m1);
     g_assert(m1 == m2);
@@ -471,6 +735,9 @@ test_reuse(
     gbinder_servicemanager_unref(vnd2);
     gbinder_servicemanager_unref(hw1);
     gbinder_servicemanager_unref(hw2);
+    gbinder_ipc_unref(binder_ipc);
+    gbinder_ipc_unref(vndbinder_ipc);
+    gbinder_ipc_unref(hwbinder_ipc);
 }
 
 /*==========================================================================*
@@ -480,15 +747,22 @@ test_reuse(
 static
 void
 test_notify_type(
-    GType t)
+    GType t,
+    const char* dev)
 {
-    GBinderServiceManager* sm = gbinder_servicemanager_new_with_type(t, NULL);
-    TestHwServiceManager* test = TEST_SERVICEMANAGER2(sm, t);
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderServiceManager* sm;
+    TestHwServiceManager* test;
     const char* name = "foo";
     int count = 0;
-    gulong id1 = gbinder_servicemanager_add_registration_handler(sm, name,
+    gulong id1, id2;
+
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new_with_type(t, NULL);
+    test = TEST_SERVICEMANAGER2(sm, t);
+    id1 = gbinder_servicemanager_add_registration_handler(sm, name,
         test_registration_func_inc, &count);
-    gulong id2 = gbinder_servicemanager_add_registration_handler(sm, name,
+    id2 = gbinder_servicemanager_add_registration_handler(sm, name,
         test_registration_func_inc, &count);
 
     g_assert(id1 && id2);
@@ -507,6 +781,7 @@ test_notify_type(
     gbinder_servicemanager_remove_handler(sm, id1);
     gbinder_servicemanager_remove_handler(sm, id2);
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
 }
 
 static
@@ -514,8 +789,8 @@ void
 test_notify(
     void)
 {
-    test_notify_type(TEST_TYPE_HWSERVICEMANAGER);
-    test_notify_type(TEST_TYPE_DEFSERVICEMANAGER);
+    test_notify_type(TEST_TYPE_HWSERVICEMANAGER, GBINDER_DEFAULT_HWBINDER);
+    test_notify_type(TEST_TYPE_DEFSERVICEMANAGER, GBINDER_DEFAULT_BINDER);
 }
 
 /*==========================================================================*
@@ -541,12 +816,17 @@ void
 test_list(
     void)
 {
-    GBinderServiceManager* sm = gbinder_servicemanager_new(NULL);
-    TestHwServiceManager* test = TEST_SERVICEMANAGER(sm);
+    const char* dev = GBINDER_DEFAULT_BINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderServiceManager* sm;
+    TestHwServiceManager* test;
     char** list;
     gulong id;
 
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
+    test = TEST_SERVICEMANAGER(sm);
     test->services = gutil_strv_add(test->services, "foo");
     list = gbinder_servicemanager_list_sync(sm);
     g_assert(gutil_strv_equal(test->services, list));
@@ -558,6 +838,7 @@ test_list(
     test_run(&test_opt, loop);
 
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
     g_main_loop_unref(loop);
 }
 
@@ -583,14 +864,20 @@ void
 test_get(
     void)
 {
-    GBinderServiceManager* sm = gbinder_servicemanager_new(NULL);
-    TestHwServiceManager* test = TEST_SERVICEMANAGER(sm);
-    int status = -1;
-    GBinderLocalObject* obj =
-        gbinder_servicemanager_new_local_object(sm, "foo.bar",
-            test_transact_func, NULL);
+    const char* dev = GBINDER_DEFAULT_BINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderServiceManager* sm;
+    TestHwServiceManager* test;
+    int status = -1;
+    GBinderLocalObject* obj;
     gulong id;
+
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
+    test = TEST_SERVICEMANAGER(sm);
+    obj = gbinder_servicemanager_new_local_object(sm, "foo.bar",
+       test_transact_func, NULL);
 
     /* Add a service */
     g_assert(obj);
@@ -614,6 +901,7 @@ test_get(
     test_run(&test_opt, loop);
 
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
     g_main_loop_unref(loop);
 }
 
@@ -637,13 +925,21 @@ void
 test_add(
     void)
 {
-    GBinderServiceManager* sm = gbinder_servicemanager_new(NULL);
-    TestHwServiceManager* test = TEST_SERVICEMANAGER(sm);
-    GBinderLocalObject* obj =
-        gbinder_servicemanager_new_local_object(sm, "foo.bar",
-            test_transact_func, NULL);
+    const char* dev = GBINDER_DEFAULT_BINDER;
+    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    gulong id = gbinder_servicemanager_add_service(sm, "foo", obj,
+    GBinderServiceManager* sm;
+    TestHwServiceManager* test;
+    GBinderLocalObject* obj;
+    gulong id;
+
+    test_setup_ping(ipc);
+    sm = gbinder_servicemanager_new(dev);
+    test = TEST_SERVICEMANAGER(sm);
+
+    obj = gbinder_servicemanager_new_local_object(sm, "foo.bar",
+        test_transact_func, NULL);
+    id = gbinder_servicemanager_add_service(sm, "foo", obj,
         test_add_func, loop);
 
     g_assert(id);
@@ -651,6 +947,7 @@ test_add(
     g_assert(gutil_strv_contains(test->services, "foo"));
 
     gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
     g_main_loop_unref(loop);
 }
 
@@ -666,6 +963,11 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("null"), test_null);
     g_test_add_func(TEST_("invalid"), test_invalid);
     g_test_add_func(TEST_("basic"), test_basic);
+    g_test_add_func(TEST_("not_present"), test_not_present);
+    g_test_add_func(TEST_("wait"), test_wait);
+    g_test_add_func(TEST_("wait_long"), test_wait_long);
+    g_test_add_func(TEST_("wait_async"), test_wait_async);
+    g_test_add_func(TEST_("death"), test_death);
     g_test_add_func(TEST_("reuse"), test_reuse);
     g_test_add_func(TEST_("notify"), test_notify);
     g_test_add_func(TEST_("list"), test_list);


### PR DESCRIPTION
This function allows to wait for servicemanager synchronously, blocking the event loop in the process (not recommended):

  `gbinder_servicemanager_wait()`

These two allow to follow the presence state of servicemanager without blocking the event loop:

  `gbinder_servicemanager_is_present()`
  `gbinder_servicemanager_add_presence_handler()`

Note that services need to re-add their names to servicemanager after it has restarted. This can be done by the presence handler.