### PR TITLE
[binder] Set type for local nulls to BINDER_TYPE_WEAK_BINDER. JB#44588

### DIFF
--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -128,9 +128,13 @@ GBINDER_IO_FN(encode_local_object)(
     struct flat_binder_object* dest = out;
 
     memset(dest, 0, sizeof(*dest));
-    dest->hdr.type = BINDER_TYPE_BINDER;
-    dest->flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
-    dest->binder = (uintptr_t)obj;
+    if (obj) {
+        dest->hdr.type = BINDER_TYPE_BINDER;
+        dest->flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
+        dest->binder = (uintptr_t)obj;
+    } else {
+        dest->hdr.type = BINDER_TYPE_WEAK_BINDER;
+    }
     return sizeof(*dest);
 }
 


### PR DESCRIPTION
Else they are not equivalent to null in Java.