### PR TITLE
Add gbinder_servicemanager_new_local_object2()

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: libgbinder
 Section: libs
 Priority: optional
 Maintainer: Slava Monich <slava.monich@jolla.com>
-Build-Depends: debhelper (>= 7), libglib2.0-dev (>= 2.0), libglibutil (>= 1.0.34)
+Build-Depends: debhelper (>= 7), libglib2.0-dev (>= 2.0), libglibutil (>= 1.0.35)
 Standards-Version: 3.8.4
 
 Package: libgbinder
 Section: libs
 Architecture: any
-Depends: libglibutil (>= 1.0.34), ${shlibs:Depends}, ${misc:Depends}
+Depends: libglibutil (>= 1.0.35), ${shlibs:Depends}, ${misc:Depends}
 Description: Binder client library
 
 Package: libgbinder-dev

--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -93,6 +93,13 @@ gbinder_servicemanager_new_local_object(
     GBinderLocalTransactFunc handler,
     void* user_data);
 
+GBinderLocalObject*
+gbinder_servicemanager_new_local_object2(
+    GBinderServiceManager* sm,
+    const char* const* ifaces,
+    GBinderLocalTransactFunc handler,
+    void* user_data); /* Since 1.0.29 */
+
 GBinderServiceManager*
 gbinder_servicemanager_ref(
     GBinderServiceManager* sm);

--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -6,9 +6,9 @@ Group: Development/Libraries
 License: BSD
 URL: https://github.com/mer-hybris/libgbinder
 Source: %{name}-%{version}.tar.bz2
-Requires: libglibutil >= 1.0.34
+Requires: libglibutil >= 1.0.35
 BuildRequires: pkgconfig(glib-2.0)
-BuildRequires: pkgconfig(libglibutil) >= 1.0.34
+BuildRequires: pkgconfig(libglibutil) >= 1.0.35
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -932,13 +932,13 @@ gbinder_ipc_remote_object_disposed(
 GBinderLocalObject*
 gbinder_ipc_new_local_object(
     GBinderIpc* self,
-    const char* iface,
+    const char* const* ifaces,
     GBinderLocalTransactFunc txproc,
     void* data)
 {
     GBinderIpcPriv* priv = self->priv;
     GBinderLocalObject* obj = gbinder_local_object_new
-        (self, iface, txproc, data);
+        (self, ifaces, txproc, data);
 
     /* Lock */
     g_mutex_lock(&priv->local_objects_mutex);

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -92,7 +92,7 @@ gbinder_ipc_object_registry(
 GBinderLocalObject*
 gbinder_ipc_new_local_object(
     GBinderIpc* ipc,
-    const char* iface,
+    const char* const* ifaces,
     GBinderLocalTransactFunc txproc,
     void* data);
 

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -55,7 +55,7 @@ struct gbinder_local_object {
     GObject object;
     GBinderLocalObjectPriv* priv;
     GBinderIpc* ipc;
-    const char* iface;
+    const char* const* ifaces;
     gint weak_refs;
     gint strong_refs;
 };
@@ -91,7 +91,7 @@ GType gbinder_local_object_get_type(void);
 GBinderLocalObject*
 gbinder_local_object_new(
     GBinderIpc* ipc,
-    const char* iface,
+    const char* const* ifaces,
     GBinderLocalTransactFunc handler,
     void* user_data);
 

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -510,9 +510,24 @@ gbinder_servicemanager_new_local_object(
     GBinderLocalTransactFunc txproc,
     void* user_data)
 {
+    const char* ifaces[2];
+
+    ifaces[0] = iface;
+    ifaces[1] = NULL;
+    return gbinder_servicemanager_new_local_object2
+        (self, ifaces, txproc, user_data);
+}
+
+GBinderLocalObject*
+gbinder_servicemanager_new_local_object2(
+    GBinderServiceManager* self,
+    const char* const* ifaces,
+    GBinderLocalTransactFunc txproc,
+    void* user_data)
+{
     if (G_LIKELY(self)) {
         return gbinder_ipc_new_local_object(gbinder_client_ipc(self->client),
-            iface, txproc, user_data);
+            ifaces, txproc, user_data);
     }
     return NULL;
 }

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -166,6 +166,7 @@ test_async_oneway(
 
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
+    g_main_loop_unref(loop);
 }
 
 /*==========================================================================*
@@ -673,9 +674,10 @@ test_transact_incoming(
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
+    const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, "test", test_transact_incoming_proc, loop);
+        (ipc, ifaces, test_transact_incoming_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
     GBinderWriter writer;
@@ -735,9 +737,10 @@ test_transact_status_reply(
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
+    const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, "test", test_transact_status_reply_proc, loop);
+        (ipc, ifaces, test_transact_status_reply_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
     GBinderWriter writer;
@@ -840,9 +843,10 @@ test_transact_async(
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
+    const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, "test", test_transact_async_proc, loop);
+        (ipc, ifaces, test_transact_async_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
     GBinderWriter writer;
@@ -911,9 +915,10 @@ test_transact_async_sync(
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
+    const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, "test", test_transact_async_sync_proc, loop);
+        (ipc, ifaces, test_transact_async_sync_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
     GBinderWriter writer;

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -400,8 +400,9 @@ test_local_object(
     GBinderOutputData* data;
     GUtilIntArray* offsets;
     GBinderIpc* ipc = gbinder_ipc_new(NULL, NULL);
-    GBinderLocalObject* obj =
-        gbinder_ipc_new_local_object(ipc, "foo", NULL, NULL);
+    const char* const ifaces[] = { "android.hidl.base@1.0::IBase", NULL };
+    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+        (ipc, ifaces, NULL, NULL);
 
     /* Append a real object (64-bit I/O is used by test_binder.c) */
     reply = gbinder_local_object_new_reply(obj);

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -264,6 +264,7 @@ test_basic(
 {
     const char* obj_name = "test";
     const char* dev = GBINDER_DEFAULT_BINDER;
+    const char* const ifaces[] = { "interface", NULL };
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj;
@@ -272,7 +273,7 @@ test_basic(
 
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
-    obj = gbinder_ipc_new_local_object(ipc, "interface", NULL, NULL);
+    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
     g_assert(!gbinder_servicename_new(sm, obj, NULL));
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
@@ -305,6 +306,7 @@ test_present(
     int add_result)
 {
     const char* obj_name = "test";
+    const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     const int fd = gbinder_driver_fd(ipc->driver);
@@ -317,7 +319,7 @@ test_present(
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     TEST_SERVICEMANAGER(sm)->add_result = add_result;
-    obj = gbinder_ipc_new_local_object(ipc, "interface", NULL, NULL);
+    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
     g_assert(sn);
@@ -369,6 +371,7 @@ test_not_present(
     void)
 {
     const char* obj_name = "test";
+    const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     const int fd = gbinder_driver_fd(ipc->driver);
@@ -383,8 +386,7 @@ test_not_present(
     sm = gbinder_servicemanager_new(dev);
     g_assert(!gbinder_servicemanager_is_present(sm));
     id = gbinder_servicemanager_add_presence_handler(sm, test_quit, loop);
-
-    obj = gbinder_ipc_new_local_object(ipc, "interface", NULL, NULL);
+    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
     g_assert(sn);
@@ -419,6 +421,7 @@ test_cancel(
     void)
 {
     const char* obj_name = "test";
+    const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     const int fd = gbinder_driver_fd(ipc->driver);
@@ -431,7 +434,7 @@ test_cancel(
 
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
-    obj = gbinder_ipc_new_local_object(ipc, "interface", NULL, NULL);
+    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
 
     /* Block name add calls */
     test = TEST_SERVICEMANAGER(sm);


### PR DESCRIPTION
It allows to pass a list of interfaces (top-most interface first) for HIDL_DESCRIPTOR_CHAIN_TRANSACTION to GBinderLocalObject.