### PR TITLE
Make gbinder_local_object_new() public

### DIFF
--- a/include/gbinder_local_object.h
+++ b/include/gbinder_local_object.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -36,6 +36,14 @@
 #include "gbinder_types.h"
 
 G_BEGIN_DECLS
+
+GBinderLocalObject*
+gbinder_local_object_new(
+    GBinderIpc* ipc,
+    const char* const* ifaces,
+    GBinderLocalTransactFunc handler,
+    void* user_data) /* Since 1.0.30 */
+    G_GNUC_WARN_UNUSED_RESULT;
 
 GBinderLocalObject*
 gbinder_local_object_ref(

--- a/include/gbinder_remote_object.h
+++ b/include/gbinder_remote_object.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -50,6 +50,10 @@ gbinder_remote_object_ref(
 void
 gbinder_remote_object_unref(
     GBinderRemoteObject* obj);
+
+GBinderIpc*
+gbinder_remote_object_ipc(
+    GBinderRemoteObject* obj); /* Since 1.0.30 */
 
 gboolean
 gbinder_remote_object_is_dead(

--- a/include/gbinder_types.h
+++ b/include/gbinder_types.h
@@ -61,6 +61,7 @@ G_BEGIN_DECLS
 
 typedef struct gbinder_buffer GBinderBuffer;
 typedef struct gbinder_client GBinderClient;
+typedef struct gbinder_ipc GBinderIpc;
 typedef struct gbinder_local_object GBinderLocalObject;
 typedef struct gbinder_local_reply GBinderLocalReply;
 typedef struct gbinder_local_request GBinderLocalRequest;

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -929,16 +929,12 @@ gbinder_ipc_remote_object_disposed(
     /* Unlock */
 }
 
-GBinderLocalObject*
-gbinder_ipc_new_local_object(
+void
+gbinder_ipc_register_local_object(
     GBinderIpc* self,
-    const char* const* ifaces,
-    GBinderLocalTransactFunc txproc,
-    void* data)
+    GBinderLocalObject* obj)
 {
     GBinderIpcPriv* priv = self->priv;
-    GBinderLocalObject* obj = gbinder_local_object_new
-        (self, ifaces, txproc, data);
 
     /* Lock */
     g_mutex_lock(&priv->local_objects_mutex);
@@ -951,7 +947,6 @@ gbinder_ipc_new_local_object(
 
     GVERBOSE_("%p", obj);
     gbinder_ipc_looper_check(self);
-    return obj;
 }
 
 static

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -89,12 +89,10 @@ GBinderObjectRegistry*
 gbinder_ipc_object_registry(
     GBinderIpc* ipc);
 
-GBinderLocalObject*
-gbinder_ipc_new_local_object(
+void
+gbinder_ipc_register_local_object(
     GBinderIpc* ipc,
-    const char* const* ifaces,
-    GBinderLocalTransactFunc txproc,
-    void* data);
+    GBinderLocalObject* obj);
 
 GBinderRemoteObject*
 gbinder_ipc_get_remote_object(

--- a/src/gbinder_local_object.c
+++ b/src/gbinder_local_object.c
@@ -332,9 +332,8 @@ gbinder_local_object_new(
     GBinderIpc* ipc,
     const char* const* ifaces,
     GBinderLocalTransactFunc txproc,
-    void* user_data)
+    void* user_data) /* Since 1.0.30 */
 {
-    /* Should only be called from gbinder_ipc_new_local_object() */
     if (G_LIKELY(ipc)) {
         GBinderLocalObject* self = g_object_new
             (GBINDER_TYPE_LOCAL_OBJECT, NULL);
@@ -364,6 +363,7 @@ gbinder_local_object_new(
         self->ifaces = (const char**)priv->ifaces;
         priv->txproc = txproc;
         priv->user_data = user_data;
+        gbinder_ipc_register_local_object(ipc, self);
         return self;
     }
     return NULL;

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -87,14 +87,6 @@ GType gbinder_local_object_get_type(void);
 #define gbinder_local_object_dev(obj) (gbinder_driver_dev((obj)->ipc->driver))
 #define gbinder_local_object_io(obj) (gbinder_driver_io((obj)->ipc->driver))
 
-/* Should only be called from gbinder_ipc_new_local_object() */
-GBinderLocalObject*
-gbinder_local_object_new(
-    GBinderIpc* ipc,
-    const char* const* ifaces,
-    GBinderLocalTransactFunc handler,
-    void* user_data);
-
 gulong
 gbinder_local_object_add_weak_refs_changed_handler(
     GBinderLocalObject* obj,

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -172,6 +172,13 @@ gbinder_remote_object_unref(
     }
 }
 
+GBinderIpc*
+gbinder_remote_object_ipc(
+    GBinderRemoteObject* self) /* Since 1.0.30 */
+{
+    return G_LIKELY(self) ? self->ipc : NULL;
+}
+
 gboolean
 gbinder_remote_object_is_dead(
     GBinderRemoteObject* self)

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -526,7 +526,7 @@ gbinder_servicemanager_new_local_object2(
     void* user_data)
 {
     if (G_LIKELY(self)) {
-        return gbinder_ipc_new_local_object(gbinder_client_ipc(self->client),
+        return gbinder_local_object_new(gbinder_client_ipc(self->client),
             ifaces, txproc, user_data);
     }
     return NULL;

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -40,7 +40,6 @@ typedef struct gbinder_cleanup GBinderCleanup;
 typedef struct gbinder_driver GBinderDriver;
 typedef struct gbinder_handler GBinderHandler;
 typedef struct gbinder_io GBinderIo;
-typedef struct gbinder_ipc GBinderIpc;
 typedef struct gbinder_object_registry GBinderObjectRegistry;
 typedef struct gbinder_output_data GBinderOutputData;
 typedef struct gbinder_rpc_protocol GBinderRpcProtocol;

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -676,7 +676,7 @@ test_transact_incoming(
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_incoming_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
@@ -739,7 +739,7 @@ test_transact_status_reply(
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_status_reply_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
@@ -845,7 +845,7 @@ test_transact_async(
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_async_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;
@@ -917,7 +917,7 @@ test_transact_async_sync(
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     const char* const ifaces[] = { "test", NULL };
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_async_sync_proc, loop);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GBinderOutputData* data;

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -161,8 +161,8 @@ test_basic(
     g_assert(!gbinder_object_registry_get_local(reg, ipc));
 
     /* Create a new local objects */
-    foo = gbinder_ipc_new_local_object(ipc, ifaces_foo, NULL, NULL);
-    bar = gbinder_ipc_new_local_object(ipc, ifaces_bar, NULL, NULL);
+    foo = gbinder_local_object_new(ipc, ifaces_foo, NULL, NULL);
+    bar = gbinder_local_object_new(ipc, ifaces_bar, NULL, NULL);
 
     /* But ipc is still not a local object! */
     g_assert(!gbinder_object_registry_get_local(reg, ipc));
@@ -204,8 +204,7 @@ test_ping(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj =
-        gbinder_ipc_new_local_object(ipc, NULL, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     GBinderLocalReply* reply;
     GBinderOutputData* out_data;
     static const guint8 result[] = { 0x00, 0x00, 0x00, 0x00 };
@@ -251,8 +250,7 @@ test_interface(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, ifaces, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
     GBinderLocalReply* reply;
     GBinderOutputData* out_data;
     static const guint8 result[] = {
@@ -301,8 +299,7 @@ test_hidl_ping(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj =
-        gbinder_ipc_new_local_object(ipc, NULL, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     GBinderLocalReply* reply;
     GBinderOutputData* out_data;
     static const guint8 result[] = { 0x00, 0x00, 0x00, 0x00 };
@@ -352,8 +349,7 @@ test_get_descriptor(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj =
-        gbinder_ipc_new_local_object(ipc, NULL, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     GBinderLocalReply* reply;
 
     gbinder_remote_request_set_data(req, HIDL_PING_TRANSACTION,
@@ -409,8 +405,7 @@ test_descriptor_chain(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, ifaces, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
     GBinderLocalReply* reply;
     GBinderOutputData* reply_data;
 
@@ -484,7 +479,7 @@ test_custom_iface(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object(ipc, ifaces,
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces,
         test_custom_iface_handler, &count);
     GBinderLocalReply* reply;
     GBinderReaderData reader_data;
@@ -591,7 +586,7 @@ test_reply_status(
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object(ipc, ifaces,
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces,
         test_reply_status_handler, &count);
 
     gbinder_remote_request_set_data(req, HIDL_PING_TRANSACTION,
@@ -630,7 +625,7 @@ test_increfs(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);
@@ -672,7 +667,7 @@ test_decrefs(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);
@@ -714,7 +709,7 @@ test_acquire(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
+    GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);
@@ -756,8 +751,7 @@ test_release(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, NULL, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);
     gulong id = gbinder_local_object_add_strong_refs_changed_handler(obj,

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -401,8 +401,7 @@ test_local_object(
     GUtilIntArray* offsets;
     GBinderIpc* ipc = gbinder_ipc_new(NULL, NULL);
     const char* const ifaces[] = { "android.hidl.base@1.0::IBase", NULL };
-    GBinderLocalObject* obj = gbinder_ipc_new_local_object
-        (ipc, ifaces, NULL, NULL);
+    GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
 
     /* Append a real object (64-bit I/O is used by test_binder.c) */
     reply = gbinder_local_object_new_reply(obj);

--- a/unit/unit_remote_object/unit_remote_object.c
+++ b/unit/unit_remote_object/unit_remote_object.c
@@ -52,6 +52,7 @@ test_null(
 {
     g_assert(!gbinder_remote_object_new(NULL, 0, FALSE));
     g_assert(!gbinder_remote_object_ref(NULL));
+    g_assert(!gbinder_remote_object_ipc(NULL));
     gbinder_remote_object_unref(NULL);
     g_assert(gbinder_remote_object_is_dead(NULL));
     g_assert(!gbinder_remote_object_add_death_handler(NULL, NULL, NULL));
@@ -76,7 +77,10 @@ test_basic(
     g_assert(obj2);
     g_assert(obj1->handle == 1u);
     g_assert(obj2->handle == 2u);
+    g_assert(gbinder_remote_object_ipc(obj1) == ipc);
+    g_assert(gbinder_remote_object_ipc(obj2) == ipc);
     g_assert(!gbinder_remote_object_is_dead(obj1));
+    g_assert(gbinder_remote_object_reanimate(obj1));
     g_assert(gbinder_remote_object_ref(obj1) == obj1);
     gbinder_remote_object_unref(obj1); /* Compensate the above reference */
     g_assert(!gbinder_remote_object_add_death_handler(obj1, NULL, NULL));

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -273,7 +273,7 @@ test_basic(
 
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
-    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
+    obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
     g_assert(!gbinder_servicename_new(sm, obj, NULL));
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
@@ -319,7 +319,7 @@ test_present(
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     TEST_SERVICEMANAGER(sm)->add_result = add_result;
-    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
+    obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
     g_assert(sn);
@@ -386,7 +386,7 @@ test_not_present(
     sm = gbinder_servicemanager_new(dev);
     g_assert(!gbinder_servicemanager_is_present(sm));
     id = gbinder_servicemanager_add_presence_handler(sm, test_quit, loop);
-    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
+    obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
 
     sn = gbinder_servicename_new(sm, obj, obj_name);
     g_assert(sn);
@@ -434,7 +434,7 @@ test_cancel(
 
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
-    obj = gbinder_ipc_new_local_object(ipc, ifaces, NULL, NULL);
+    obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
 
     /* Block name add calls */
     test = TEST_SERVICEMANAGER(sm);


### PR DESCRIPTION
Until now, `gbinder_servicemanager_new_local_object()` was the only way to create local objects. That was slightly weird because creating local object don't have much to do servicemanager, it's a purely local operation. All we need to know is which binder device (`GBinderIpc`) the object is going to be associated with. That's what `gbinder_remote_object_ipc()` is for.