### PR TITLE
Invalidate handle when remote object dies

### DIFF
--- a/src/gbinder_defaultservicemanager.c
+++ b/src/gbinder_defaultservicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -76,8 +76,6 @@ enum gbinder_defaultservicemanager_calls {
     LIST_SERVICES_TRANSACTION
 };
 
-/* As a special case, ServiceManager's handle is zero */
-#define DEFAULTSERVICEMANAGER_HANDLE (0)
 #define DEFAULTSERVICEMANAGER_IFACE  "android.os.IServiceManager"
 
 GBinderServiceManager*
@@ -301,7 +299,6 @@ void
 gbinder_defaultservicemanager_class_init(
     GBinderDefaultServiceManagerClass* klass)
 {
-    klass->handle = DEFAULTSERVICEMANAGER_HANDLE;
     klass->iface = DEFAULTSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_BINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_binder;

--- a/src/gbinder_hwservicemanager.c
+++ b/src/gbinder_hwservicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -80,8 +80,6 @@ enum gbinder_hwservicemanager_notifications {
     ON_REGISTRATION_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION
 };
 
-/* As a special case, ServiceManager's handle is zero */
-#define HWSERVICEMANAGER_HANDLE (0)
 #define HWSERVICEMANAGER_IFACE  "android.hidl.manager@1.0::IServiceManager"
 #define HWSERVICEMANAGER_NOTIFICATION_IFACE \
     "android.hidl.manager@1.0::IServiceNotification"
@@ -378,7 +376,6 @@ void
 gbinder_hwservicemanager_class_init(
     GBinderHwServiceManagerClass* klass)
 {
-    klass->handle = HWSERVICEMANAGER_HANDLE;
     klass->iface = HWSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_hwbinder;

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -100,6 +100,11 @@ gbinder_ipc_get_remote_object(
     guint32 handle,
     gboolean maybe_dead);
 
+void
+gbinder_ipc_invalidate_remote_handle(
+    GBinderIpc* ipc,
+    guint32 handle);
+
 GBinderRemoteReply*
 gbinder_ipc_transact_sync_reply(
     GBinderIpc* ipc,

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -71,6 +71,10 @@ gbinder_remote_object_died_on_main_thread(
     GASSERT(!self->dead);
     if (!self->dead) {
         self->dead = TRUE;
+        /* Zero handle is servicemanager, it can be reanimated. */
+        if (self->handle) {
+            gbinder_ipc_invalidate_remote_handle(self->ipc, self->handle);
+        }
         gbinder_driver_clear_death_notification(driver, self);
         gbinder_driver_release(driver, self->handle);
         g_signal_emit(self, gbinder_remote_object_signals[SIGNAL_DEATH], 0);

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -33,6 +33,7 @@
 #include "gbinder_driver.h"
 #include "gbinder_ipc.h"
 #include "gbinder_remote_object_p.h"
+#include "gbinder_servicemanager_p.h"
 #include "gbinder_log.h"
 
 struct gbinder_remote_object_priv {
@@ -71,8 +72,8 @@ gbinder_remote_object_died_on_main_thread(
     GASSERT(!self->dead);
     if (!self->dead) {
         self->dead = TRUE;
-        /* Zero handle is servicemanager, it can be reanimated. */
-        if (self->handle) {
+        /* ServiceManager always has the same handle, and can be reanimated. */
+        if (self->handle != GBINDER_SERVICEMANAGER_HANDLE) {
             gbinder_ipc_invalidate_remote_handle(self->ipc, self->handle);
         }
         gbinder_driver_clear_death_notification(driver, self);
@@ -108,6 +109,7 @@ gbinder_remote_object_reanimate(
         GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
 
         /* Kick the horse */
+        GASSERT(self->handle == GBINDER_SERVICEMANAGER_HANDLE);
         if (gbinder_driver_ping(ipc->driver, reg, self->handle) == 0) {
             /* Wow, it's alive! */
             self->dead = FALSE;

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -407,7 +407,7 @@ gbinder_servicemanager_new_with_type(
         if (ipc) {
             /* Create a possible dead remote object */
             GBinderRemoteObject* object = gbinder_ipc_get_remote_object
-                (ipc, klass->handle, TRUE);
+                (ipc, GBINDER_SERVICEMANAGER_HANDLE, TRUE);
 
             if (object) {
                 gboolean first_ref;

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2019 Jolla Ltd.
+ * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -39,6 +39,9 @@
 
 #include <glib-object.h>
 
+/* As a special case, ServiceManager's handle is zero */
+#define GBINDER_SERVICEMANAGER_HANDLE (0)
+
 typedef struct gbinder_servicemanager_priv GBinderServiceManagerPriv;
 
 typedef struct gbinder_servicemanager {
@@ -60,7 +63,6 @@ typedef struct gbinder_servicemanager_class {
     GMutex mutex;
     GHashTable* table;
 
-    guint32 handle;
     const char* iface;
     const char* default_device;
     const GBinderRpcProtocol* rpc_protocol;

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -209,7 +209,6 @@ typedef TestServiceManager TestHwServiceManager;
 G_DEFINE_TYPE(TestHwServiceManager, test_hwservicemanager,
     GBINDER_TYPE_SERVICEMANAGER)
 
-#define TEST_HWSERVICEMANAGER_HANDLE (0)
 #define TEST_HWSERVICEMANAGER_IFACE "android.hidl.manager@1.0::IServiceManager"
 #define TEST_TYPE_HWSERVICEMANAGER (test_hwservicemanager_get_type())
 #define TEST_IS_HWSERVICEMANAGER(obj) \
@@ -280,7 +279,6 @@ void
 test_hwservicemanager_class_init(
     TestHwServiceManagerClass* klass)
 {
-    klass->handle = TEST_HWSERVICEMANAGER_HANDLE;
     klass->iface = TEST_HWSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_hwbinder;
@@ -312,7 +310,6 @@ typedef TestServiceManager TestDefServiceManager;
 G_DEFINE_TYPE(TestDefServiceManager, test_defservicemanager,
     GBINDER_TYPE_SERVICEMANAGER)
 
-#define TEST_DEFSERVICEMANAGER_HANDLE (0)
 #define TEST_DEFSERVICEMANAGER_IFACE "android.os.IServiceManager"
 #define TEST_TYPE_DEFSERVICEMANAGER (test_defservicemanager_get_type())
 #define TEST_IS_DEFSERVICEMANAGER(obj) \
@@ -366,7 +363,6 @@ void
 test_defservicemanager_class_init(
     TestDefServiceManagerClass* klass)
 {
-    klass->handle = TEST_DEFSERVICEMANAGER_HANDLE;
     klass->iface = TEST_DEFSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_BINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_binder;

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -93,7 +93,6 @@ typedef struct test_servicemanager {
 G_DEFINE_TYPE(TestServiceManager, test_servicemanager,
     GBINDER_TYPE_SERVICEMANAGER)
 
-#define TEST_SERVICEMANAGER_HANDLE (0)
 #define TEST_SERVICEMANAGER_IFACE "android.os.IServiceManager"
 #define TEST_TYPE_SERVICEMANAGER (test_servicemanager_get_type())
 #define TEST_SERVICEMANAGER(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), \
@@ -201,7 +200,6 @@ void
 test_servicemanager_class_init(
     TestServiceManagerClass* klass)
 {
-    klass->handle = TEST_SERVICEMANAGER_HANDLE;
     klass->iface = TEST_SERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_binder;

--- a/unit/unit_servicepoll/unit_servicepoll.c
+++ b/unit/unit_servicepoll/unit_servicepoll.c
@@ -71,7 +71,6 @@ typedef struct test_servicemanager {
 G_DEFINE_TYPE(TestServiceManager, test_servicemanager,
     GBINDER_TYPE_SERVICEMANAGER)
 
-#define TEST_SERVICEMANAGER_HANDLE (0)
 #define TEST_SERVICEMANAGER_IFACE "android.os.IServiceManager"
 #define TEST_TYPE_SERVICEMANAGER (test_servicemanager_get_type())
 #define TEST_SERVICEMANAGER(obj) G_TYPE_CHECK_INSTANCE_CAST((obj), \
@@ -173,7 +172,6 @@ void
 test_servicemanager_class_init(
     TestServiceManagerClass* klass)
 {
-    klass->handle = TEST_SERVICEMANAGER_HANDLE;
     klass->iface = TEST_SERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
     klass->rpc_protocol = &gbinder_rpc_protocol_binder;


### PR DESCRIPTION
Otherwise the handle may get reused by the remote side but on our side it would remain mapped to the old `GBinderRemoteObject` (as long as there are any references to it), possibly pointing to an entirely different remote object.