### PR TITLE
Drop remote refs and shutdown loopers on unload

### DIFF
--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -68,43 +68,52 @@ void
     int status,
     void* user_data);
 
+G_GNUC_INTERNAL
 GBinderIpc*
 gbinder_ipc_new(
    const char* dev,
    const GBinderRpcProtocol* protocol);
 
+G_GNUC_INTERNAL
 GBinderIpc*
 gbinder_ipc_ref(
     GBinderIpc* ipc);
 
+G_GNUC_INTERNAL
 void
 gbinder_ipc_unref(
     GBinderIpc* ipc);
 
+G_GNUC_INTERNAL
 void
 gbinder_ipc_looper_check(
    GBinderIpc* ipc);
 
+G_GNUC_INTERNAL
 GBinderObjectRegistry*
 gbinder_ipc_object_registry(
     GBinderIpc* ipc);
 
+G_GNUC_INTERNAL
 void
 gbinder_ipc_register_local_object(
     GBinderIpc* ipc,
     GBinderLocalObject* obj);
 
+G_GNUC_INTERNAL
 GBinderRemoteObject*
 gbinder_ipc_get_remote_object(
     GBinderIpc* ipc,
     guint32 handle,
     gboolean maybe_dead);
 
+G_GNUC_INTERNAL
 void
 gbinder_ipc_invalidate_remote_handle(
     GBinderIpc* ipc,
     guint32 handle);
 
+G_GNUC_INTERNAL
 GBinderRemoteReply*
 gbinder_ipc_transact_sync_reply(
     GBinderIpc* ipc,
@@ -113,6 +122,7 @@ gbinder_ipc_transact_sync_reply(
     GBinderLocalRequest* req,
     int* status);
 
+G_GNUC_INTERNAL
 int
 gbinder_ipc_transact_sync_oneway(
     GBinderIpc* ipc,
@@ -120,6 +130,7 @@ gbinder_ipc_transact_sync_oneway(
     guint32 code,
     GBinderLocalRequest* req);
 
+G_GNUC_INTERNAL
 gulong
 gbinder_ipc_transact(
     GBinderIpc* ipc,
@@ -131,6 +142,7 @@ gbinder_ipc_transact(
     GDestroyNotify destroy,
     void* user_data);
 
+G_GNUC_INTERNAL
 gulong
 gbinder_ipc_transact_custom(
     GBinderIpc* ipc,
@@ -139,22 +151,32 @@ gbinder_ipc_transact_custom(
     GDestroyNotify destroy,
     void* user_data);
 
+G_GNUC_INTERNAL
 void
 gbinder_ipc_cancel(
     GBinderIpc* ipc,
     gulong id);
 
 /* Internal for GBinderLocalObject */
+G_GNUC_INTERNAL
 void
 gbinder_ipc_local_object_disposed(
     GBinderIpc* self,
     GBinderLocalObject* obj);
 
 /* Internal for GBinderRemoteObject */
+G_GNUC_INTERNAL
 void
 gbinder_ipc_remote_object_disposed(
     GBinderIpc* self,
     GBinderRemoteObject* obj);
+
+/* Declared for unit tests */
+G_GNUC_INTERNAL
+__attribute__((destructor))
+void
+gbinder_ipc_exit(
+    void);
 
 #endif /* GBINDER_IPC_H */
 

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -165,6 +165,7 @@ gbinder_servicemanager_list_tx_done(
     if (!data->func(data->sm, data->result, data->user_data)) {
         g_strfreev(data->result);
     }
+    data->result = NULL;
 }
 
 static
@@ -174,6 +175,7 @@ gbinder_servicemanager_list_tx_free(
 {
     GBinderServiceManagerListTxData* data = user_data;
 
+    g_strfreev(data->result);
     gbinder_servicemanager_unref(data->sm);
     g_slice_free(GBinderServiceManagerListTxData, data);
 }


### PR DESCRIPTION
That prevents crashes when libgbinder.so is being unloaded. Which went unnoticed because it typically happens when process exits anyway.

Remote references were preventing libgbinder's internal objects from being deallocated on unload, which was leaving looper threads running and trying to execute code already unmapped from the address space.