### PR TITLE
Add binder-ping test

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -5,5 +5,6 @@ all:
 	@$(MAKE) -C binder-client $*
 	@$(MAKE) -C binder-dump $*
 	@$(MAKE) -C binder-list $*
+	@$(MAKE) -C binder-ping $*
 	@$(MAKE) -C binder-service $*
 	@$(MAKE) -C rild-card-status $*

--- a/test/binder-ping/Makefile
+++ b/test/binder-ping/Makefile
@@ -1,0 +1,140 @@
+# -*- Mode: makefile-gmake -*-
+
+.PHONY: all debug release clean cleaner
+.PHONY: libgbinder-release libgbinder-debug
+
+#
+# Required packages
+#
+
+PKGS = glib-2.0 gio-2.0 gio-unix-2.0 libglibutil
+
+#
+# Default target
+#
+
+all: debug release
+
+#
+# Executable
+#
+
+EXE = binder-ping
+
+#
+# Sources
+#
+
+SRC = $(EXE).c
+
+#
+# Directories
+#
+
+SRC_DIR = .
+BUILD_DIR = build
+LIB_DIR = ../..
+DEBUG_BUILD_DIR = $(BUILD_DIR)/debug
+RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+
+#
+# Tools and flags
+#
+
+CC = $(CROSS_COMPILE)gcc
+LD = $(CC)
+WARNINGS = -Wall
+INCLUDES = -I$(LIB_DIR)/include
+BASE_FLAGS = -fPIC
+CFLAGS = $(BASE_FLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
+  $(shell pkg-config --cflags $(PKGS))
+LDFLAGS = $(BASE_FLAGS) $(shell pkg-config --libs $(PKGS))
+QUIET_MAKE = make --no-print-directory
+DEBUG_FLAGS = -g
+RELEASE_FLAGS =
+
+ifndef KEEP_SYMBOLS
+KEEP_SYMBOLS = 0
+endif
+
+ifneq ($(KEEP_SYMBOLS),0)
+RELEASE_FLAGS += -g
+SUBMAKE_OPTS += KEEP_SYMBOLS=1
+endif
+
+DEBUG_LDFLAGS = $(LDFLAGS) $(DEBUG_FLAGS)
+RELEASE_LDFLAGS = $(LDFLAGS) $(RELEASE_FLAGS)
+DEBUG_CFLAGS = $(CFLAGS) $(DEBUG_FLAGS) -DDEBUG
+RELEASE_CFLAGS = $(CFLAGS) $(RELEASE_FLAGS) -O2
+
+#
+# Files
+#
+
+DEBUG_OBJS = $(SRC:%.c=$(DEBUG_BUILD_DIR)/%.o)
+RELEASE_OBJS = $(SRC:%.c=$(RELEASE_BUILD_DIR)/%.o)
+DEBUG_SO_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_debug_so)
+RELEASE_SO_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_release_so)
+DEBUG_LINK_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_debug_link)
+RELEASE_LINK_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_release_link)
+DEBUG_SO = $(LIB_DIR)/$(DEBUG_SO_FILE)
+RELEASE_SO = $(LIB_DIR)/$(RELEASE_SO_FILE)
+
+#
+# Dependencies
+#
+
+DEPS = $(DEBUG_OBJS:%.o=%.d) $(RELEASE_OBJS:%.o=%.d)
+ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(DEPS)),)
+-include $(DEPS)
+endif
+endif
+
+$(DEBUG_OBJS): | $(DEBUG_BUILD_DIR)
+$(RELEASE_OBJS): | $(RELEASE_BUILD_DIR)
+
+#
+# Rules
+#
+
+DEBUG_EXE = $(DEBUG_BUILD_DIR)/$(EXE)
+RELEASE_EXE = $(RELEASE_BUILD_DIR)/$(EXE)
+
+debug: libgbinder-debug $(DEBUG_EXE)
+
+release: libgbinder-release $(RELEASE_EXE)
+
+clean:
+	rm -f *~
+	rm -fr $(BUILD_DIR)
+
+cleaner: clean
+	@make -C $(LIB_DIR) clean
+
+$(DEBUG_BUILD_DIR):
+	mkdir -p $@
+
+$(RELEASE_BUILD_DIR):
+	mkdir -p $@
+
+$(DEBUG_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(DEBUG_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(RELEASE_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(RELEASE_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(DEBUG_EXE): $(DEBUG_SO) $(DEBUG_BUILD_DIR) $(DEBUG_OBJS)
+	$(LD) $(DEBUG_OBJS) $(DEBUG_LDFLAGS) $< -o $@
+
+$(RELEASE_EXE): $(RELEASE_SO) $(RELEASE_BUILD_DIR) $(RELEASE_OBJS)
+	$(LD) $(RELEASE_OBJS) $(RELEASE_LDFLAGS) $< -o $@
+ifeq ($(KEEP_SYMBOLS),0)
+	strip $@
+endif
+
+libgbinder-debug:
+	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(DEBUG_SO_FILE) $(DEBUG_LINK_FILE)
+
+libgbinder-release:
+	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(RELEASE_SO_FILE) $(RELEASE_LINK_FILE)

--- a/test/binder-ping/binder-ping.c
+++ b/test/binder-ping/binder-ping.c
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gbinder.h>
+
+#include <gutil_log.h>
+
+#define RET_OK          (0)
+#define RET_NOTFOUND    (1)
+#define RET_INVARG      (2)
+#define RET_ERR         (3)
+
+#define DEFAULT_BINDER          GBINDER_DEFAULT_HWBINDER
+#define AIDL_PING_TRANSACTION   GBINDER_FOURCC('_','P','N','G')
+#define HIDL_PING_TRANSACTION   GBINDER_FOURCC(0x0f,'P','N','G')
+
+typedef struct app_options {
+    const char* fqname;
+    char* dev;
+    guint32 ping_code;
+    const char* iface;
+} AppOptions;
+
+static
+int
+app_run(
+    const AppOptions* opt)
+{
+    int ret = RET_NOTFOUND;
+    GBinderServiceManager* sm = gbinder_servicemanager_new(opt->dev);
+
+    if (sm) {
+        int status = 0;
+        GBinderRemoteObject* remote = gbinder_servicemanager_get_service_sync
+            (sm, opt->fqname, &status);
+
+        if (remote) {
+            int status;
+            GBinderClient* client = gbinder_client_new(remote, opt->iface);
+            GBinderRemoteReply* reply = gbinder_client_transact_sync_reply
+                (client, opt->ping_code, NULL, &status);
+                             
+            if (reply) {
+                GINFO("OK");
+                ret = RET_OK;
+            } else {
+                GERR("Ping failed (%d)", status);
+                ret = RET_ERR;
+            }
+            gbinder_remote_reply_unref(reply);
+            gbinder_client_unref(client);
+        } else {
+            GERR("%s not found", opt->fqname);
+        }
+        gbinder_servicemanager_unref(sm);
+    } else {
+        GERR("No servicemanager at %s", opt->dev);
+    }
+    return ret;
+}
+
+static
+gboolean
+app_log_verbose(
+    const gchar* name,
+    const gchar* value,
+    gpointer data,
+    GError** error)
+{
+    gutil_log_default.level = GLOG_LEVEL_VERBOSE;
+    return TRUE;
+}
+
+static
+gboolean
+app_log_quiet(
+    const gchar* name,
+    const gchar* value,
+    gpointer data,
+    GError** error)
+{
+    gutil_log_default.level = GLOG_LEVEL_NONE;
+    return TRUE;
+}
+
+static
+gboolean
+app_init(
+    AppOptions* opt,
+    int argc,
+    char* argv[])
+{
+    gboolean ok = FALSE;
+    GOptionEntry entries[] = {
+        { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+          app_log_verbose, "Enable verbose output", NULL },
+        { "quiet", 'q', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+          app_log_quiet, "Be quiet", NULL },
+        { "device", 'd', 0, G_OPTION_ARG_STRING, &opt->dev,
+          "Binder device [" DEFAULT_BINDER "]", "DEVICE" },
+        { NULL }
+    };
+
+    GError* error = NULL;
+    GOptionContext* options = g_option_context_new("[FQNAME]");
+
+    gutil_log_timestamp = FALSE;
+    gutil_log_default.level = GLOG_LEVEL_DEFAULT;
+
+    g_option_context_add_main_entries(options, entries, NULL);
+    if (g_option_context_parse(options, &argc, &argv, &error)) {
+        if (!opt->dev || !opt->dev[0]) {
+            opt->dev = g_strdup(DEFAULT_BINDER);
+        }
+        if (argc == 2) {
+            opt->fqname = argv[1];
+            if (g_strcmp0(opt->dev, GBINDER_DEFAULT_BINDER)) {
+                opt->ping_code = HIDL_PING_TRANSACTION;
+                opt->iface = "android.hidl.base@1.0::IBase";
+            } else {
+                opt->ping_code = AIDL_PING_TRANSACTION;
+                opt->iface = "android.os.IBinder";
+            }
+            ok = TRUE;
+        } else {
+            char* help = g_option_context_get_help(options, TRUE, NULL);
+
+            fprintf(stderr, "%s", help);
+            g_free(help);
+        }
+    } else {
+        GERR("%s", error->message);
+        g_error_free(error);
+    }
+    g_option_context_free(options);
+    return ok;
+}
+
+int main(int argc, char* argv[])
+{
+    AppOptions opt;
+    int ret = RET_INVARG;
+
+    memset(&opt, 0, sizeof(opt));
+    if (app_init(&opt, argc, argv)) {
+        ret = app_run(&opt);
+    }
+    g_free(opt.dev);
+    return ret;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */


### PR DESCRIPTION
Checks the presence of a binder service. Can also be used for figuring out which process implements the service (ping it and check `/sys/kernel/debug/binder/transaction_log`).