### PR TITLE
Support for multiple versions of hwbinder interfaces

### DIFF
--- a/include/gbinder_client.h
+++ b/include/gbinder_client.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -37,6 +37,11 @@
 
 G_BEGIN_DECLS
 
+typedef struct gbinder_client_iface_info {
+    const char* iface;
+    guint32 last_code;
+} GBinderClientIfaceInfo;
+
 typedef
 void
 (*GBinderClientReplyFunc)(
@@ -51,6 +56,12 @@ gbinder_client_new(
     const char* iface);
 
 GBinderClient*
+gbinder_client_new2(
+    GBinderRemoteObject* object,
+    const GBinderClientIfaceInfo* ifaces,
+    gsize count); /* since 1.0.42 */
+
+GBinderClient*
 gbinder_client_ref(
     GBinderClient* client);
 
@@ -62,9 +73,19 @@ const char*
 gbinder_client_interface(
     GBinderClient* client); /* since 1.0.22 */
 
+const char*
+gbinder_client_interface2(
+    GBinderClient* client,
+    guint32 code); /* since 1.0.42 */
+
 GBinderLocalRequest*
 gbinder_client_new_request(
     GBinderClient* client);
+
+GBinderLocalRequest*
+gbinder_client_new_request2(
+    GBinderClient* client,
+    guint32 code); /* since 1.0.42 */
 
 GBinderRemoteReply*
 gbinder_client_transact_sync_reply(

--- a/src/gbinder_client_p.h
+++ b/src/gbinder_client_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -38,7 +38,6 @@
 #include "gbinder_types_p.h"
 
 struct gbinder_client {
-    const char* iface;
     GBinderRemoteObject* remote;
 };
 


### PR DESCRIPTION
It required creating multiple instances of `GBinderClient`, now even a single client can do it. The change is not totally transparent, though - you have to use `gbinder_client_new_request2()` to let the client know which transaction code you're going to be using, so that it knows which request template (and which interface name@version) to use.