### PR TITLE
Package binder-list and binder-ping utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 *~
 debian/files
-debian/libgbinder-dev
 debian/libgbinder
+debian/libgbinder-dev
+debian/libgbinder-tools
 debian/*.debhelper.log
 debian/*.debhelper
 debian/*.substvars
-debian/*.install
+debian/libgbinder.install
+debian/libgbinder-dev.install
 debian/tmp
 documentation.list
 installroot

--- a/Makefile
+++ b/Makefile
@@ -231,7 +231,7 @@ clean:
 	rm -fr debian/tmp debian/libgbinder debian/libgbinder-dev
 	rm -f documentation.list debian/files debian/*.substvars
 	rm -f debian/*.debhelper.log debian/*.debhelper debian/*~
-	rm -f debian/*.install
+	rm -f debian/libgbinder.install debian/libgbinder-dev.install
 
 test:
 	make -C unit test

--- a/debian/control
+++ b/debian/control
@@ -16,3 +16,9 @@ Section: libdevel
 Architecture: any
 Depends: libgbinder (= ${binary:Version}), ${misc:Depends}
 Description: Development files for libgbinder
+
+Package: libgbinder-tools
+Section: utils
+Architecture: any
+Depends: libgbinder, ${misc:Depends}
+Description: Binder command line utilities

--- a/debian/libgbinder-tools.install
+++ b/debian/libgbinder-tools.install
@@ -1,0 +1,1 @@
+debian/tmp/usr/bin/* usr/bin

--- a/debian/rules
+++ b/debian/rules
@@ -8,9 +8,13 @@ LIBDIR=usr/lib/$(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 override_dh_auto_build:
 	dh_auto_build -- LIBDIR=$(LIBDIR) release pkgconfig debian/libgbinder.install debian/libgbinder-dev.install
+	dh_auto_build -- -C test/binder-list release
+	dh_auto_build -- -C test/binder-ping release
 
 override_dh_auto_install:
 	dh_auto_install -- LIBDIR=$(LIBDIR) install-dev
+	dh_auto_install -- -C test/binder-list
+	dh_auto_install -- -C test/binder-ping
 
 %:
 	dh $@

--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -30,10 +30,14 @@ This package contains the development library for %{name}.
 
 %build
 make LIBDIR=%{_libdir} KEEP_SYMBOLS=1 release pkgconfig
+make -C test/binder-list release
+make -C test/binder-ping release
 
 %install
 rm -rf %{buildroot}
 make LIBDIR=%{_libdir} DESTDIR=%{buildroot} install-dev
+make -C test/binder-list DESTDIR=%{buildroot} install
+make -C test/binder-ping DESTDIR=%{buildroot} install
 
 %check
 make -C unit test
@@ -51,3 +55,16 @@ make -C unit test
 %{_libdir}/pkgconfig/*.pc
 %{_libdir}/%{name}.so
 %{_includedir}/gbinder/*.h
+
+# Tools
+
+%package tools
+Summary: Binder tools
+
+%description tools
+Binder command line utilities
+
+%files tools
+%defattr(-,root,root,-)
+%{_bindir}/binder-list
+%{_bindir}/binder-ping

--- a/test/binder-list/Makefile
+++ b/test/binder-list/Makefile
@@ -138,3 +138,17 @@ libgbinder-debug:
 
 libgbinder-release:
 	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(RELEASE_SO_FILE) $(RELEASE_LINK_FILE)
+
+#
+# Install
+#
+
+INSTALL = install
+
+INSTALL_BIN_DIR = $(DESTDIR)/usr/bin
+
+install: release $(INSTALL_BIN_DIR)
+	$(INSTALL) -m 755 $(RELEASE_EXE) $(INSTALL_BIN_DIR)
+
+$(INSTALL_BIN_DIR):
+	$(INSTALL) -d $@

--- a/test/binder-list/binder-list.c
+++ b/test/binder-list/binder-list.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -39,7 +39,7 @@
 #define RET_INVARG      (2)
 #define RET_ERR         (3)
 
-#define DEV_DEFAULT     "/dev/binder"
+#define DEV_DEFAULT     GBINDER_DEFAULT_HWBINDER
 
 typedef struct app_options {
     char* dev;

--- a/test/binder-ping/Makefile
+++ b/test/binder-ping/Makefile
@@ -138,3 +138,17 @@ libgbinder-debug:
 
 libgbinder-release:
 	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(RELEASE_SO_FILE) $(RELEASE_LINK_FILE)
+
+#
+# Install
+#
+
+INSTALL = install
+
+INSTALL_BIN_DIR = $(DESTDIR)/usr/bin
+
+install: release $(INSTALL_BIN_DIR)
+	$(INSTALL) -m 755 $(RELEASE_EXE) $(INSTALL_BIN_DIR)
+
+$(INSTALL_BIN_DIR):
+	$(INSTALL) -d $@


### PR DESCRIPTION
Those proved to be quite useful development tools. They are placed into a separate `libgbinder-tools` package which doesn't get installed by default but can be easily pulled in, if needed.