### PR TITLE
Make protocol and service managers configurable per binder device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,7 @@ SRC = \
 SRC += \
   gbinder_servicemanager.c \
   gbinder_servicemanager_aidl.c \
+  gbinder_servicemanager_aidl2.c \
   gbinder_servicemanager_hidl.c
 
 SRC += \

--- a/Makefile
+++ b/Makefile
@@ -98,9 +98,9 @@ SRC = \
   gbinder_writer.c
 
 SRC += \
-  gbinder_defaultservicemanager.c \
-  gbinder_hwservicemanager.c \
-  gbinder_servicemanager.c
+  gbinder_servicemanager.c \
+  gbinder_servicemanager_aidl.c \
+  gbinder_servicemanager_hidl.c
 
 SRC += \
   gbinder_system.c

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,7 @@ SRC = \
   gbinder_buffer.c \
   gbinder_cleanup.c \
   gbinder_client.c \
+  gbinder_config.c \
   gbinder_driver.c \
   gbinder_eventloop.c \
   gbinder_io_32.c \

--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -80,11 +80,13 @@ gbinder_servicemanager_new(
 
 GBinderServiceManager*
 gbinder_defaultservicemanager_new(
-    const char* dev);
+    const char* dev)
+    G_DEPRECATED_FOR(gbinder_servicemanager_new);
 
 GBinderServiceManager*
 gbinder_hwservicemanager_new(
-    const char* dev);
+    const char* dev)
+    G_DEPRECATED_FOR(gbinder_servicemanager_new);
 
 GBinderLocalObject*
 gbinder_servicemanager_new_local_object(

--- a/src/gbinder_config.c
+++ b/src/gbinder_config.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gbinder_config.h"
+#include "gbinder_eventloop_p.h"
+#include "gbinder_log.h"
+
+/*
+ * The contents of the config file is queried from (at least) two places,
+ * and pretty much always this happens the same stack. Which means that
+ * we can avoid reading the same file twice if we delay dereferencing of
+ * GKeyFile until the next idle loop.
+ */
+static GKeyFile* gbinder_config_keyfile = NULL;
+static GBinderEventLoopCallback* gbinder_config_autorelease = NULL;
+
+static const char gbinder_config_default_file[] = "/etc/gbinder.conf";
+const char* gbinder_config_file = gbinder_config_default_file;
+
+static
+void
+gbinder_config_autorelease_cb(
+    gpointer data)
+{
+    GASSERT(gbinder_config_keyfile == data);
+    gbinder_config_keyfile = NULL;
+    g_key_file_unref(data);
+}
+
+GKeyFile* /* autoreleased */
+gbinder_config_get()
+{
+    if (!gbinder_config_keyfile && gbinder_config_file &&
+        g_file_test(gbinder_config_file, G_FILE_TEST_EXISTS)) {
+        GError* error = NULL;
+
+        gbinder_config_keyfile = g_key_file_new();
+        if (g_key_file_load_from_file(gbinder_config_keyfile,
+            gbinder_config_file, G_KEY_FILE_NONE, &error)) {
+            gbinder_config_autorelease = gbinder_idle_callback_schedule_new
+               (gbinder_config_autorelease_cb, gbinder_config_keyfile, NULL);
+        } else {
+            GERR("Error loading %s: %s", gbinder_config_file, error->message);
+            g_error_free(error);
+            g_key_file_unref(gbinder_config_keyfile);
+            gbinder_config_keyfile = NULL;
+            gbinder_config_file = NULL; /* Don't retry */
+        }
+    }
+    return gbinder_config_keyfile;
+}
+
+void
+gbinder_config_exit()
+{
+    if (gbinder_config_autorelease) {
+        gbinder_idle_callback_destroy(gbinder_config_autorelease);
+        gbinder_config_autorelease = NULL;
+    }
+    if (gbinder_config_keyfile) {
+        g_key_file_unref(gbinder_config_keyfile);
+        gbinder_config_keyfile = NULL;
+    }
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/gbinder_config.c
+++ b/src/gbinder_config.c
@@ -34,17 +34,166 @@
 #include "gbinder_eventloop_p.h"
 #include "gbinder_log.h"
 
+#include <gutil_strv.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
 /*
  * The contents of the config file is queried from (at least) two places,
  * and pretty much always this happens the same stack. Which means that
  * we can avoid reading the same file twice if we delay dereferencing of
  * GKeyFile until the next idle loop.
  */
+
 static GKeyFile* gbinder_config_keyfile = NULL;
 static GBinderEventLoopCallback* gbinder_config_autorelease = NULL;
 
+static const char gbinder_config_suffix[] = ".conf";
 static const char gbinder_config_default_file[] = "/etc/gbinder.conf";
+static const char gbinder_config_default_dir[] = "/etc/gbinder.d";
+
 const char* gbinder_config_file = gbinder_config_default_file;
+const char* gbinder_config_dir = gbinder_config_default_dir;
+
+static
+char**
+gbinder_config_collect_files(
+    const char* path,
+    const char* suffix)
+{
+    /*
+     * Returns sorted list of regular files in the directory,
+     * optionally having the specified suffix (e.g. ".conf").
+     * Returns NULL if nothing appropriate has been found.
+     */
+    char** files = NULL;
+
+    if (path) {
+        GDir* dir = g_dir_open(path, 0, NULL);
+
+        if (dir) {
+            GPtrArray* list = g_ptr_array_new();
+            const gchar* name;
+
+            while ((name = g_dir_read_name(dir)) != NULL) {
+                if (g_str_has_suffix(name, suffix)) {
+                    char* fullname = g_build_filename(path, name, NULL);
+                    struct stat st;
+
+                    if (!stat(fullname, &st) && S_ISREG(st.st_mode)) {
+                        g_ptr_array_add(list, fullname);
+                    } else {
+                        g_free(fullname);
+                    }
+                }
+            }
+
+            if (list->len > 0) {
+                g_ptr_array_add(list, NULL);
+                files = (char**) g_ptr_array_free(list, FALSE);
+                gutil_strv_sort(files, TRUE);
+            } else {
+                g_ptr_array_free(list, TRUE);
+            }
+
+            g_dir_close(dir);
+        }
+    }
+
+    return files;
+}
+
+static
+GKeyFile*
+gbinder_config_merge_keyfiles(
+    GKeyFile* dest,
+    GKeyFile* src)
+{
+    gsize i, ngroups;
+    gchar** groups = g_key_file_get_groups(src, &ngroups);
+
+    for (i = 0; i < ngroups; i++) {
+        gsize k, nkeys;
+        const char* group = groups[i];
+        char** keys = g_key_file_get_keys(src, group, &nkeys, NULL);
+
+        for (k = 0; k < nkeys; k++) {
+            const char* key = keys[k];
+            char* value = g_key_file_get_value(src, group, key, NULL);
+
+            g_key_file_set_value(dest, group, key, value);
+            g_free(value);
+        }
+
+        g_strfreev(keys);
+    }
+
+    g_strfreev(groups);
+    return dest;
+}
+
+static
+GKeyFile*
+gbinder_config_load_files()
+{
+    GError* error = NULL;
+    GKeyFile* out = NULL;
+    char** files = gbinder_config_collect_files(gbinder_config_dir,
+        gbinder_config_suffix);
+
+    if (gbinder_config_file &&
+        g_file_test(gbinder_config_file, G_FILE_TEST_EXISTS)) {
+        out = g_key_file_new();
+        if (g_key_file_load_from_file(out, gbinder_config_file,
+            G_KEY_FILE_NONE, &error)) {
+            GDEBUG("Loaded %s", gbinder_config_file);
+        } else {
+            GERR("Error loading %s: %s", gbinder_config_file, error->message);
+            g_error_free(error);
+            error = NULL;
+            gbinder_config_file = NULL; /* Don't retry */
+            g_key_file_unref(out);
+            out = NULL;
+        }
+    }
+
+    /* Files in the config directory overwrite /etc/gbinder.conf */
+    if (files) {
+        char** ptr;
+        GKeyFile* override = NULL;
+
+        for (ptr = files; *ptr; ptr++) {
+            const char* file = *ptr;
+
+            if (!override) {
+                override = g_key_file_new();
+            }
+            if (g_key_file_load_from_file(override, file,
+                G_KEY_FILE_NONE, &error)) {
+                GDEBUG("Loaded %s", file);
+                if (!out) {
+                    out = override;
+                    override = NULL;
+                } else {
+                    out = gbinder_config_merge_keyfiles(out, override);
+                }
+            } else {
+                GERR("Error loading %s: %s", file, error->message);
+                g_error_free(error);
+                error = NULL;
+            }
+        }
+
+        g_strfreev(files);
+        if (override) {
+            g_key_file_unref(override);
+        }
+    }
+
+    return out;
+}
 
 static
 void
@@ -59,21 +208,13 @@ gbinder_config_autorelease_cb(
 GKeyFile* /* autoreleased */
 gbinder_config_get()
 {
-    if (!gbinder_config_keyfile && gbinder_config_file &&
-        g_file_test(gbinder_config_file, G_FILE_TEST_EXISTS)) {
-        GError* error = NULL;
-
-        gbinder_config_keyfile = g_key_file_new();
-        if (g_key_file_load_from_file(gbinder_config_keyfile,
-            gbinder_config_file, G_KEY_FILE_NONE, &error)) {
+    if (!gbinder_config_keyfile &&
+        (gbinder_config_file || gbinder_config_dir)) {
+        gbinder_config_keyfile = gbinder_config_load_files();
+        if (gbinder_config_keyfile) {
+            /* See the comment at the top of the file why this is needed */
             gbinder_config_autorelease = gbinder_idle_callback_schedule_new
                (gbinder_config_autorelease_cb, gbinder_config_keyfile, NULL);
-        } else {
-            GERR("Error loading %s: %s", gbinder_config_file, error->message);
-            g_error_free(error);
-            g_key_file_unref(gbinder_config_keyfile);
-            gbinder_config_keyfile = NULL;
-            gbinder_config_file = NULL; /* Don't retry */
         }
     }
     return gbinder_config_keyfile;

--- a/src/gbinder_config.h
+++ b/src/gbinder_config.h
@@ -58,8 +58,9 @@ gbinder_config_exit(
     GBINDER_INTERNAL
     GBINDER_DESTRUCTOR;
 
-/* And this one too */
+/* And these too */
 extern const char* gbinder_config_file GBINDER_INTERNAL;
+extern const char* gbinder_config_dir GBINDER_INTERNAL;
 
 #endif /* GBINDER_CONFIG_H */
 

--- a/src/gbinder_config.h
+++ b/src/gbinder_config.h
@@ -62,6 +62,11 @@ gbinder_config_exit(
 extern const char* gbinder_config_file GBINDER_INTERNAL;
 extern const char* gbinder_config_dir GBINDER_INTERNAL;
 
+/* Configuration groups and special value */
+#define GBINDER_CONFIG_GROUP_PROTOCOL "Protocol"
+#define GBINDER_CONFIG_GROUP_SERVICEMANAGER "ServiceManager"
+#define GBINDER_CONFIG_VALUE_DEFAULT "Default"
+
 #endif /* GBINDER_CONFIG_H */
 
 /*

--- a/src/gbinder_config.h
+++ b/src/gbinder_config.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,39 +30,27 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GBINDER_RPC_PROTOCOL_H
-#define GBINDER_RPC_PROTOCOL_H
+#ifndef GBINDER_CONFIG_H
+#define GBINDER_CONFIG_H
 
 #include "gbinder_types_p.h"
 
-/*
- * There are several versions of binder RPC protocol with diffferent
- * transaction headers and transaction codes.
- */
-
-struct gbinder_rpc_protocol {
-    const char* name;
-    guint32 ping_tx;
-    void (*write_ping)(GBinderWriter* writer);
-    void (*write_rpc_header)(GBinderWriter* writer, const char* iface);
-    const char* (*read_rpc_header)(GBinderReader* reader, guint32 txcode,
-        char** iface);
-};
-
-/* Returns one of the above based on the device name */
-const GBinderRpcProtocol*
-gbinder_rpc_protocol_for_device(
-    const char* dev)
-    GBINDER_INTERNAL;
-
-/* Runs at exit, declared here strictly for unit tests */
-void
-gbinder_rpc_protocol_exit(
+GKeyFile* /* autoreleased */
+gbinder_config_get(
     void)
-    GBINDER_DESTRUCTOR
     GBINDER_INTERNAL;
 
-#endif /* GBINDER_RPC_PROTOCOL_H */
+/* This one declared strictly for unit tests */
+void
+gbinder_config_exit(
+    void)
+    GBINDER_INTERNAL
+    GBINDER_DESTRUCTOR;
+
+/* And this one too */
+extern const char* gbinder_config_file GBINDER_INTERNAL;
+
+#endif /* GBINDER_CONFIG_H */
 
 /*
  * Local Variables:

--- a/src/gbinder_config.h
+++ b/src/gbinder_config.h
@@ -35,6 +35,17 @@
 
 #include "gbinder_types_p.h"
 
+typedef
+gconstpointer
+(*GBinderConfigValueMapFunc)(
+    const char* value);
+
+GHashTable*
+gbinder_config_load(
+    const char* group,
+    GBinderConfigValueMapFunc map)
+    GBINDER_INTERNAL;
+
 GKeyFile* /* autoreleased */
 gbinder_config_get(
     void)

--- a/src/gbinder_defaultservicemanager.c
+++ b/src/gbinder_defaultservicemanager.c
@@ -300,7 +300,6 @@ gbinder_defaultservicemanager_class_init(
 {
     klass->iface = DEFAULTSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_BINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_binder;
 
     klass->list = gbinder_defaultservicemanager_list;
     klass->get_service = gbinder_defaultservicemanager_get_service;

--- a/src/gbinder_hwservicemanager.c
+++ b/src/gbinder_hwservicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -378,7 +378,6 @@ gbinder_hwservicemanager_class_init(
 {
     klass->iface = HWSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_hwbinder;
 
     klass->list = gbinder_hwservicemanager_list;
     klass->get_service = gbinder_hwservicemanager_get_service;

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -36,6 +36,7 @@
 #include "gbinder_driver.h"
 #include "gbinder_handler.h"
 #include "gbinder_io.h"
+#include "gbinder_rpc_protocol.h"
 #include "gbinder_object_registry.h"
 #include "gbinder_local_object_p.h"
 #include "gbinder_local_reply.h"
@@ -1570,12 +1571,14 @@ gbinder_ipc_tx_proc(
 
 GBinderIpc*
 gbinder_ipc_new(
-    const char* dev,
-    const GBinderRpcProtocol* protocol)
+    const char* dev)
 {
     GBinderIpc* self = NULL;
+    const GBinderRpcProtocol* protocol;
 
     if (!dev || !dev[0]) dev = GBINDER_DEFAULT_BINDER;
+    protocol = gbinder_rpc_protocol_for_device(dev); /* Never returns NULL */
+
     /* Lock */
     pthread_mutex_lock(&gbinder_ipc_mutex);
     if (gbinder_ipc_table) {

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -69,8 +69,7 @@ void
 
 GBinderIpc*
 gbinder_ipc_new(
-    const char* dev,
-    const GBinderRpcProtocol* protocol)
+    const char* dev)
     GBINDER_INTERNAL;
 
 GBinderIpc*
@@ -171,11 +170,11 @@ gbinder_ipc_remote_object_disposed(
     GBINDER_INTERNAL;
 
 /* Declared for unit tests */
-__attribute__((destructor))
 void
 gbinder_ipc_exit(
     void)
-    GBINDER_INTERNAL;
+    GBINDER_INTERNAL
+    GBINDER_DESTRUCTOR;
 
 #endif /* GBINDER_IPC_H */
 

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -33,6 +33,8 @@
 #include "gbinder_rpc_protocol.h"
 #include "gbinder_reader.h"
 #include "gbinder_writer.h"
+#include "gbinder_config.h"
+#include "gbinder_log.h"
 
 /*==========================================================================*
  * GBinderIpcProtocol callbacks (see Parcel::writeInterfaceToken in Android)
@@ -40,10 +42,35 @@
  *
  *   platform/system/libhwbinder/Parcel.cpp
  *   platform/frameworks/native/libs/binder/Parcel.cpp
+ *
+ * which mutate from version to version. Specific device => protocol
+ * mapping can be optionally configured in /etc/gbinder.conf file.
+ * The default protocol configuration looks like this:
+ *
+ *   [Protocol]
+ *   Default = aidl
+ *   /dev/binder = aidl
+ *   /dev/hwbinder = hidl
+ *
  *==========================================================================*/
 
+#define CONF_GROUP "Protocol"
+#define CONF_DEFAULT "Default"
+
+static GHashTable* gbinder_rpc_protocol_map = NULL;
+
+/*
+ * Default protocol for those binder devices which which haven't been
+ * explicitely mapped.
+ */
+#define DEFAULT_PROTOCOL gbinder_rpc_protocol_aidl
+static const GBinderRpcProtocol DEFAULT_PROTOCOL;
+static const GBinderRpcProtocol* gbinder_rpc_protocol_default =
+    &DEFAULT_PROTOCOL;
+
 /*==========================================================================*
- * /dev/binder
+ * The original AIDL protocol.
+ * Still used for talking to Java services.
  *==========================================================================*/
 
 /* No idea what that is... */
@@ -52,7 +79,7 @@
 
 static
 void
-gbinder_rpc_protocol_binder_write_ping(
+gbinder_rpc_protocol_aidl_write_ping(
     GBinderWriter* writer)
 {
     /* No payload */
@@ -60,7 +87,7 @@ gbinder_rpc_protocol_binder_write_ping(
 
 static
 void
-gbinder_rpc_protocol_binder_write_rpc_header(
+gbinder_rpc_protocol_aidl_write_rpc_header(
     GBinderWriter* writer,
     const char* iface)
 {
@@ -75,7 +102,7 @@ gbinder_rpc_protocol_binder_write_rpc_header(
 
 static
 const char*
-gbinder_rpc_protocol_binder_read_rpc_header(
+gbinder_rpc_protocol_aidl_read_rpc_header(
     GBinderReader* reader,
     guint32 txcode,
     char** iface)
@@ -91,13 +118,21 @@ gbinder_rpc_protocol_binder_read_rpc_header(
     return *iface;
 }
 
+static const GBinderRpcProtocol gbinder_rpc_protocol_aidl = {
+    .name = "aidl",
+    .ping_tx = GBINDER_PING_TRANSACTION,
+    .write_ping = gbinder_rpc_protocol_aidl_write_ping,
+    .write_rpc_header = gbinder_rpc_protocol_aidl_write_rpc_header,
+    .read_rpc_header = gbinder_rpc_protocol_aidl_read_rpc_header
+};
+
 /*==========================================================================*
- * /dev/hwbinder
+ * The original /dev/hwbinder protocol.
  *==========================================================================*/
 
 static
 void
-gbinder_rpc_protocol_hwbinder_write_rpc_header(
+gbinder_rpc_protocol_hidl_write_rpc_header(
     GBinderWriter* writer,
     const char* iface)
 {
@@ -109,16 +144,16 @@ gbinder_rpc_protocol_hwbinder_write_rpc_header(
 
 static
 void
-gbinder_rpc_protocol_hwbinder_write_ping(
+gbinder_rpc_protocol_hidl_write_ping(
     GBinderWriter* writer)
 {
-    gbinder_rpc_protocol_hwbinder_write_rpc_header(writer,
+    gbinder_rpc_protocol_hidl_write_rpc_header(writer,
         "android.hidl.base@1.0::IBase");
 }
 
 static
 const char*
-gbinder_rpc_protocol_hwbinder_read_rpc_header(
+gbinder_rpc_protocol_hidl_read_rpc_header(
     GBinderReader* reader,
     guint32 txcode,
     char** iface)
@@ -127,30 +162,137 @@ gbinder_rpc_protocol_hwbinder_read_rpc_header(
     return gbinder_reader_read_string8(reader);
 }
 
+static const GBinderRpcProtocol gbinder_rpc_protocol_hidl = {
+    .name = "hidl",
+    .ping_tx = HIDL_PING_TRANSACTION,
+    .write_ping = gbinder_rpc_protocol_hidl_write_ping,
+    .write_rpc_header = gbinder_rpc_protocol_hidl_write_rpc_header,
+    .read_rpc_header = gbinder_rpc_protocol_hidl_read_rpc_header
+};
+
+/*==========================================================================*
+ * Implementation
+ *==========================================================================*/
+
+/* All known protocols */
+static const GBinderRpcProtocol* gbinder_rpc_protocol_list[] = {
+    &gbinder_rpc_protocol_aidl,
+    &gbinder_rpc_protocol_hidl
+};
+
+static
+const GBinderRpcProtocol*
+gbinder_rpc_protocol_find(
+    const char* name)
+{
+    guint i;
+
+    for (i = 0; i < G_N_ELEMENTS(gbinder_rpc_protocol_list); i++) {
+        if (!g_ascii_strcasecmp(gbinder_rpc_protocol_list[i]->name, name)) {
+            return gbinder_rpc_protocol_list[i];
+        }
+    }
+    return NULL;
+}
+
+static
+void
+gbinder_rpc_protocol_map_add_default(
+    GHashTable* map,
+    const char* dev,
+    const GBinderRpcProtocol* protocol)
+{
+    if (!g_hash_table_contains(map, dev)) {
+        g_hash_table_insert(map, g_strdup(dev), (gpointer) protocol);
+    }
+}
+
+static
+GHashTable*
+gbinder_rpc_protocol_load_config()
+{
+    GKeyFile* k = gbinder_config_get();
+    GHashTable* map = g_hash_table_new_full(g_str_hash, g_str_equal,
+        g_free, NULL);
+
+    if (k) {
+        gsize n;
+        char** devs = g_key_file_get_keys(k, CONF_GROUP, &n, NULL);
+
+        if (devs) {
+            gsize i;
+
+            for (i = 0; i < n; i++) {
+                char* dev = devs[i];
+                char* name = g_key_file_get_value(k, CONF_GROUP, dev, NULL);
+                const GBinderRpcProtocol* p = gbinder_rpc_protocol_find(name);
+
+                if (p) {
+                    if (!strcmp(dev, CONF_DEFAULT)) {
+                        gbinder_rpc_protocol_default = p;
+                    } else {
+                        g_hash_table_replace(map, dev, (gpointer) p);
+                    }
+                } else {
+                    GWARN("Unknown protocol name '%s' is configured for %s",
+                        name, dev);
+                    g_free(dev);
+                }
+                g_free(name);
+            }
+
+            /* Shallow delete (contents got stolen or freed) */
+            g_free(devs);
+        }
+    }
+
+    /* Add default configuration if it's not overridden */
+    gbinder_rpc_protocol_map_add_default(map,
+        GBINDER_DEFAULT_BINDER, &gbinder_rpc_protocol_aidl);
+    gbinder_rpc_protocol_map_add_default(map,
+        GBINDER_DEFAULT_HWBINDER, &gbinder_rpc_protocol_hidl);
+
+    return map;
+}
+
+/* Runs at exit */
+void
+gbinder_rpc_protocol_exit()
+{
+    if (gbinder_rpc_protocol_map) {
+        g_hash_table_destroy(gbinder_rpc_protocol_map);
+        gbinder_rpc_protocol_map = NULL;
+    }
+    /* Reset the default too, mostly for unit testing */
+    gbinder_rpc_protocol_default = &DEFAULT_PROTOCOL;
+}
+
 /*==========================================================================*
  * Interface
  *==========================================================================*/
-
-const GBinderRpcProtocol gbinder_rpc_protocol_binder = {
-    .ping_tx = GBINDER_PING_TRANSACTION,
-    .write_ping = gbinder_rpc_protocol_binder_write_ping,
-    .write_rpc_header = gbinder_rpc_protocol_binder_write_rpc_header,
-    .read_rpc_header = gbinder_rpc_protocol_binder_read_rpc_header
-};
-
-const GBinderRpcProtocol gbinder_rpc_protocol_hwbinder = {
-    .ping_tx = HIDL_PING_TRANSACTION,
-    .write_ping = gbinder_rpc_protocol_hwbinder_write_ping,
-    .write_rpc_header = gbinder_rpc_protocol_hwbinder_write_rpc_header,
-    .read_rpc_header = gbinder_rpc_protocol_hwbinder_read_rpc_header
-};
 
 const GBinderRpcProtocol*
 gbinder_rpc_protocol_for_device(
     const char* dev)
 {
-    return (dev && !strcmp(dev, GBINDER_DEFAULT_HWBINDER)) ?
-        &gbinder_rpc_protocol_hwbinder : &gbinder_rpc_protocol_binder;
+    if (dev) {
+        const GBinderRpcProtocol* protocol;
+
+        if (!gbinder_rpc_protocol_map) {
+            gbinder_rpc_protocol_map = gbinder_rpc_protocol_load_config();
+        }
+        protocol = g_hash_table_lookup(gbinder_rpc_protocol_map, dev);
+        if (protocol) {
+            GDEBUG("Using %s protocol for %s", protocol->name, dev);
+            return protocol;
+        }
+        GDEBUG("Using default protocol %s for %s",
+            gbinder_rpc_protocol_default->name, dev);
+    } else {
+        GDEBUG("Using default protocol %s",
+            gbinder_rpc_protocol_default->name);
+    }
+    return gbinder_rpc_protocol_default;
 }
 
 /*

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -58,8 +58,8 @@
  *
  *==========================================================================*/
 
-#define CONF_GROUP "Protocol"
-#define CONF_DEFAULT "Default"
+#define CONF_GROUP GBINDER_CONFIG_GROUP_PROTOCOL
+#define CONF_DEFAULT GBINDER_CONFIG_VALUE_DEFAULT
 
 static GHashTable* gbinder_rpc_protocol_map = NULL;
 

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -81,11 +81,12 @@ typedef struct gbinder_servicemanager_type {
 
 static const GBinderServiceManagerType gbinder_servicemanager_types[] = {
     { "aidl", gbinder_servicemanager_aidl_get_type },
+    { "aidl2", gbinder_servicemanager_aidl2_get_type },
     { "hidl", gbinder_servicemanager_hidl_get_type }
 };
 
 #define SERVICEMANAGER_TYPE_AIDL (gbinder_servicemanager_types + 0)
-#define SERVICEMANAGER_TYPE_HIDL (gbinder_servicemanager_types + 1)
+#define SERVICEMANAGER_TYPE_HIDL (gbinder_servicemanager_types + 2)
 #define SERVICEMANAGER_TYPE_DEFAULT SERVICEMANAGER_TYPE_AIDL
 
 static GHashTable* gbinder_servicemanager_map = NULL;
@@ -120,9 +121,6 @@ G_DEFINE_ABSTRACT_TYPE(GBinderServiceManager, gbinder_servicemanager,
 #define GBINDER_SERVICEMANAGER(obj) \
     G_TYPE_CHECK_INSTANCE_CAST((obj), GBINDER_TYPE_SERVICEMANAGER, \
     GBinderServiceManager)
-#define GBINDER_SERVICEMANAGER_CLASS(klass) \
-    G_TYPE_CHECK_CLASS_CAST((klass), GBINDER_TYPE_SERVICEMANAGER, \
-    GBinderServiceManagerClass)
 #define GBINDER_SERVICEMANAGER_GET_CLASS(obj) \
     G_TYPE_INSTANCE_GET_CLASS((obj), GBINDER_TYPE_SERVICEMANAGER, \
     GBinderServiceManagerClass)

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -34,6 +34,7 @@
 
 #include "gbinder_servicemanager_p.h"
 #include "gbinder_client_p.h"
+#include "gbinder_config.h"
 #include "gbinder_local_object_p.h"
 #include "gbinder_remote_object_p.h"
 #include "gbinder_eventloop_p.h"
@@ -46,6 +47,50 @@
 #include <gutil_misc.h>
 
 #include <errno.h>
+
+/*==========================================================================*
+ *
+ * Different versions of Android come with different flavors of service
+ * managers. They are usually based on these two more or less independent
+ * variants:
+ *
+ *   platform/frameworks/native/cmds/servicemanager/ServiceManager.cpp
+ *   platform/system/hwservicemanager/ServiceManager.cpp
+ *
+ * They are talking slightly different protocols which slightly mutate
+ * from version to version. If that's not complex enough, different
+ * kinds of service managers can be running simultaneously, serving
+ * different binder devices. Specific device => servicemanager mapping
+ * can be optionally configured in /etc/gbinder.conf file. The default
+ * service manager configuration looks like this:
+ *
+ *   [ServiceManager]
+ *   Default = aidl
+ *   /dev/binder = aidl
+ *   /dev/hwbinder = hidl
+ *
+ *==========================================================================*/
+
+#define CONF_GROUP "ServiceManager"
+#define CONF_DEFAULT "Default"
+
+typedef struct gbinder_servicemanager_type {
+    const char* name;
+    GType (*get_type)(void);
+} GBinderServiceManagerType;
+
+static const GBinderServiceManagerType gbinder_servicemanager_types[] = {
+    { "aidl", gbinder_servicemanager_aidl_get_type },
+    { "hidl", gbinder_servicemanager_hidl_get_type }
+};
+
+#define SERVICEMANAGER_TYPE_AIDL (gbinder_servicemanager_types + 0)
+#define SERVICEMANAGER_TYPE_HIDL (gbinder_servicemanager_types + 1)
+#define SERVICEMANAGER_TYPE_DEFAULT SERVICEMANAGER_TYPE_AIDL
+
+static GHashTable* gbinder_servicemanager_map = NULL;
+static const GBinderServiceManagerType* gbinder_servicemanager_default =
+    SERVICEMANAGER_TYPE_DEFAULT;
 
 #define PRESENSE_WAIT_MS_MIN  (100)
 #define PRESENSE_WAIT_MS_MAX  (1000)
@@ -408,6 +453,64 @@ gbinder_servicemanager_autorelease_cb(
     g_slist_free_full(list, g_object_unref);
 }
 
+static
+void
+gbinder_servicemanager_map_add_default(
+    GHashTable* map,
+    const char* dev,
+    const GBinderServiceManagerType* type)
+{
+    if (!g_hash_table_contains(map, dev)) {
+        g_hash_table_insert(map, g_strdup(dev), (gpointer) type);
+    }
+}
+
+static
+gconstpointer
+gbinder_servicemanager_value_map(
+    const char* name)
+{
+    guint i;
+
+    for (i = 0; i < G_N_ELEMENTS(gbinder_servicemanager_types); i++) {
+        const GBinderServiceManagerType* t = gbinder_servicemanager_types + i;
+
+        if (!g_strcmp0(name, t->name)) {
+            return t;
+        }
+    }
+    return NULL;
+}
+
+static
+GHashTable*
+gbinder_servicemanager_load_config()
+{
+    GHashTable* map = gbinder_config_load(CONF_GROUP,
+        gbinder_servicemanager_value_map);
+
+    /* Add default configuration if it's not overridden */
+    gbinder_servicemanager_map_add_default(map,
+        GBINDER_DEFAULT_BINDER, SERVICEMANAGER_TYPE_AIDL);
+    gbinder_servicemanager_map_add_default(map,
+        GBINDER_DEFAULT_HWBINDER, SERVICEMANAGER_TYPE_HIDL);
+
+    return map;
+}
+
+/* Runs at exit */
+void
+gbinder_servicemanager_exit(
+    void)
+{
+    if (gbinder_servicemanager_map) {
+        g_hash_table_destroy(gbinder_servicemanager_map);
+        gbinder_servicemanager_map = NULL;
+    }
+    /* Reset the default too, mostly for unit testing */
+    gbinder_servicemanager_default = SERVICEMANAGER_TYPE_DEFAULT;
+}
+
 /*==========================================================================*
  * Internal interface
  *==========================================================================*/
@@ -426,7 +529,7 @@ gbinder_servicemanager_new_with_type(
         if (!dev) dev = klass->default_device;
         ipc = gbinder_ipc_new(dev);
         if (ipc) {
-            /* Create a possible dead remote object */
+            /* Create a possibly dead remote object */
             GBinderRemoteObject* object = gbinder_ipc_get_remote_object
                 (ipc, GBINDER_SERVICEMANAGER_HANDLE, TRUE);
 
@@ -517,11 +620,35 @@ GBinderServiceManager*
 gbinder_servicemanager_new(
     const char* dev)
 {
-    if (!g_strcmp0(dev, GBINDER_DEFAULT_HWBINDER)) {
-        return gbinder_hwservicemanager_new(dev);
-    } else {
-        return gbinder_defaultservicemanager_new(dev);
+    if (dev) {
+        const GBinderServiceManagerType* type = NULL;
+
+        if (!gbinder_servicemanager_map) {
+            const GBinderServiceManagerType* t;
+
+            /* One-time initialization */
+            gbinder_servicemanager_map = gbinder_servicemanager_load_config();
+
+            /* "Default" is a special value stored in a special variable */
+            t = g_hash_table_lookup(gbinder_servicemanager_map, CONF_DEFAULT);
+            if (t) {
+                g_hash_table_remove(gbinder_servicemanager_map, CONF_DEFAULT);
+                gbinder_servicemanager_default = t;
+            } else {
+                gbinder_servicemanager_default = SERVICEMANAGER_TYPE_DEFAULT;
+            }
+        }
+
+        type = g_hash_table_lookup(gbinder_servicemanager_map, dev);
+        if (type) {
+            GDEBUG("Using %s service manager for %s", type->name, dev);
+        } else {
+            type = gbinder_servicemanager_default;
+            GDEBUG("Using default service manager %s for %s", type->name, dev);
+        }
+        return gbinder_servicemanager_new_with_type(type->get_type(), dev);
     }
+    return NULL;
 }
 
 GBinderLocalObject*

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -71,8 +71,8 @@
  *
  *==========================================================================*/
 
-#define CONF_GROUP "ServiceManager"
-#define CONF_DEFAULT "Default"
+#define CONF_GROUP GBINDER_CONFIG_GROUP_SERVICEMANAGER
+#define CONF_DEFAULT GBINDER_CONFIG_VALUE_DEFAULT
 
 typedef struct gbinder_servicemanager_type {
     const char* name;

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -424,7 +424,7 @@ gbinder_servicemanager_new_with_type(
         GBinderIpc* ipc;
 
         if (!dev) dev = klass->default_device;
-        ipc = gbinder_ipc_new(dev, klass->rpc_protocol);
+        ipc = gbinder_ipc_new(dev);
         if (ipc) {
             /* Create a possible dead remote object */
             GBinderRemoteObject* object = gbinder_ipc_get_remote_object

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -870,6 +870,28 @@ gbinder_servicemanager_remove_handlers(
     }
 }
 
+/*
+ * These two exist mostly for backward compatibility. Normally,
+ * gbinder_servicemanager_new() should be used, to allow the type of
+ * service manager to be configurable per device via /etc/gbinder.conf
+ */
+
+GBinderServiceManager*
+gbinder_defaultservicemanager_new(
+    const char* dev)
+{
+    return gbinder_servicemanager_new_with_type
+        (gbinder_servicemanager_aidl_get_type(), dev);
+}
+
+GBinderServiceManager*
+gbinder_hwservicemanager_new(
+    const char* dev)
+{
+    return gbinder_servicemanager_new_with_type
+        (gbinder_servicemanager_hidl_get_type(), dev);
+}
+
 /*==========================================================================*
  * Internals
  *==========================================================================*/

--- a/src/gbinder_servicemanager_aidl.h
+++ b/src/gbinder_servicemanager_aidl.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef GBINDER_SERVICEMANAGER_AIDL_H
+#define GBINDER_SERVICEMANAGER_AIDL_H
+
+#include "gbinder_servicemanager_p.h"
+
+typedef struct gbinder_servicemanager_aidl_priv GBinderServiceManagerAidlPriv;
+typedef struct gbinder_servicemanager_aidl {
+    GBinderServiceManager manager;
+    GBinderServiceManagerAidlPriv* priv;
+} GBinderServiceManagerAidl;
+
+typedef struct gbinder_servicemanager_aidl_class {
+    GBinderServiceManagerClass parent;
+    GBinderLocalRequest* (*list_services_req)
+        (GBinderClient* client, gint32 index);
+    GBinderLocalRequest* (*add_service_req)
+        (GBinderClient* client, const char* name, GBinderLocalObject* obj);
+} GBinderServiceManagerAidlClass;
+
+#define GBINDER_TYPE_SERVICEMANAGER_AIDL \
+    gbinder_servicemanager_aidl_get_type()
+#define GBINDER_SERVICEMANAGER_AIDL_CLASS(klass) \
+    G_TYPE_CHECK_CLASS_CAST((klass), GBINDER_TYPE_SERVICEMANAGER_AIDL, \
+    GBinderServiceManagerAidlClass)
+
+#endif /* GBINDER_SERVICEMANAGER_AIDL_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/gbinder_servicemanager_aidl2.c
+++ b/src/gbinder_servicemanager_aidl2.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gbinder_servicemanager_aidl.h"
+
+#include <gbinder_client.h>
+#include <gbinder_local_request.h>
+
+/* Variant of AIDL servicemanager appeared in Android 9 (API level 28) */
+
+typedef GBinderServiceManagerAidl GBinderServiceManagerAidl2;
+typedef GBinderServiceManagerAidlClass GBinderServiceManagerAidl2Class;
+
+G_DEFINE_TYPE(GBinderServiceManagerAidl2,
+    gbinder_servicemanager_aidl2,
+    GBINDER_TYPE_SERVICEMANAGER_AIDL)
+
+#define PARENT_CLASS gbinder_servicemanager_aidl2_parent_class
+#define DUMP_FLAG_PRIORITY_DEFAULT (8)
+
+static
+GBinderLocalRequest*
+gbinder_servicemanager_aidl2_list_services_req(
+    GBinderClient* client,
+    gint32 index)
+{
+    GBinderLocalRequest* req = gbinder_client_new_request(client);
+
+    gbinder_local_request_append_int32(req, index);
+    gbinder_local_request_append_int32(req, DUMP_FLAG_PRIORITY_DEFAULT);
+    return req;
+}
+
+static
+GBinderLocalRequest*
+gbinder_servicemanager_aidl2_add_service_req(
+    GBinderClient* client,
+    const char* name,
+    GBinderLocalObject* obj)
+{
+    GBinderLocalRequest* req = gbinder_client_new_request(client);
+
+    gbinder_local_request_append_string16(req, name);
+    gbinder_local_request_append_local_object(req, obj);
+    gbinder_local_request_append_int32(req, 0);
+    gbinder_local_request_append_int32(req, DUMP_FLAG_PRIORITY_DEFAULT);
+    return req;
+}
+
+static
+void
+gbinder_servicemanager_aidl2_init(
+    GBinderServiceManagerAidl* self)
+{
+}
+
+static
+void
+gbinder_servicemanager_aidl2_class_init(
+    GBinderServiceManagerAidl2Class* cls)
+{
+    cls->list_services_req = gbinder_servicemanager_aidl2_list_services_req;
+    cls->add_service_req = gbinder_servicemanager_aidl2_add_service_req;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/gbinder_servicemanager_hidl.c
+++ b/src/gbinder_servicemanager_hidl.c
@@ -31,7 +31,6 @@
  */
 
 #include "gbinder_servicemanager_p.h"
-#include "gbinder_rpc_protocol.h"
 #include "gbinder_log.h"
 
 #include <gbinder_client.h>
@@ -42,30 +41,30 @@
 #include <gbinder_reader.h>
 
 #include <errno.h>
-#include <pthread.h>
 
-typedef struct gbinder_hwservicemanager_watch {
+typedef struct gbinder_servicemanager_hidl_watch {
     char* name;
     GBinderLocalObject* callback;
-} GBinderHwServiceManagerWatch;
+} GBinderServiceManagerHidlWatch;
 
-typedef GBinderServiceManagerClass GBinderHwServiceManagerClass;
-typedef struct gbinder_hwservicemanager {
+typedef GBinderServiceManagerClass GBinderServiceManagerHidlClass;
+typedef struct gbinder_servicemanager_hidl {
     GBinderServiceManager manager;
     GHashTable* watch_table;
-} GBinderHwServiceManager;
+} GBinderServiceManagerHidl;
 
-G_DEFINE_TYPE(GBinderHwServiceManager,
-    gbinder_hwservicemanager,
+G_DEFINE_TYPE(GBinderServiceManagerHidl,
+    gbinder_servicemanager_hidl,
     GBINDER_TYPE_SERVICEMANAGER)
 
-#define PARENT_CLASS gbinder_hwservicemanager_parent_class
-#define GBINDER_TYPE_HWSERVICEMANAGER (gbinder_hwservicemanager_get_type())
-#define GBINDER_HWSERVICEMANAGER(obj) \
-    G_TYPE_CHECK_INSTANCE_CAST((obj), GBINDER_TYPE_HWSERVICEMANAGER, \
-    GBinderHwServiceManager)
+#define PARENT_CLASS gbinder_servicemanager_hidl_parent_class
+#define GBINDER_TYPE_SERVICEMANAGER_HIDL \
+    gbinder_servicemanager_hidl_get_type()
+#define GBINDER_SERVICEMANAGER_HIDL(obj) \
+    G_TYPE_CHECK_INSTANCE_CAST((obj), GBINDER_TYPE_SERVICEMANAGER_HIDL, \
+    GBinderServiceManagerHidl)
 
-enum gbinder_hwservicemanager_calls {
+enum gbinder_servicemanager_hidl_calls {
     GET_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION,
     ADD_TRANSACTION,
     GET_TRANSPORT_TRANSACTION,
@@ -76,18 +75,18 @@ enum gbinder_hwservicemanager_calls {
     REGISTER_PASSTHROUGH_CLIENT_TRANSACTION
 };
 
-enum gbinder_hwservicemanager_notifications {
+enum gbinder_servicemanager_hidl_notifications {
     ON_REGISTRATION_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION
 };
 
-#define HWSERVICEMANAGER_IFACE  "android.hidl.manager@1.0::IServiceManager"
-#define HWSERVICEMANAGER_NOTIFICATION_IFACE \
+#define SERVICEMANAGER_HIDL_IFACE  "android.hidl.manager@1.0::IServiceManager"
+#define SERVICEMANAGER_HIDL_NOTIFICATION_IFACE \
     "android.hidl.manager@1.0::IServiceNotification"
 
 static
 void
-gbinder_hwservicemanager_handle_registration(
-    GBinderHwServiceManager* self,
+gbinder_servicemanager_hidl_handle_registration(
+    GBinderServiceManagerHidl* self,
     GBinderReader* reader)
 {
     char* fqname = gbinder_reader_read_hidl_string(reader);
@@ -111,7 +110,7 @@ gbinder_hwservicemanager_handle_registration(
 
 static
 GBinderLocalReply*
-gbinder_hwservicemanager_notification(
+gbinder_servicemanager_hidl_notification(
     GBinderLocalObject* obj,
     GBinderRemoteRequest* req,
     guint code,
@@ -119,22 +118,22 @@ gbinder_hwservicemanager_notification(
     int* status,
     void* user_data)
 {
-    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(user_data);
+    GBinderServiceManagerHidl* self = GBINDER_SERVICEMANAGER_HIDL(user_data);
     const char* iface = gbinder_remote_request_interface(req);
 
-    if (!g_strcmp0(iface, HWSERVICEMANAGER_NOTIFICATION_IFACE)) {
+    if (!g_strcmp0(iface, SERVICEMANAGER_HIDL_NOTIFICATION_IFACE)) {
         GBinderReader reader;
 
         gbinder_remote_request_init_reader(req, &reader);
         switch (code) {
         case ON_REGISTRATION_TRANSACTION:
-            GDEBUG(HWSERVICEMANAGER_NOTIFICATION_IFACE " %u onRegistration",
+            GDEBUG(SERVICEMANAGER_HIDL_NOTIFICATION_IFACE " %u onRegistration",
                 code);
-            gbinder_hwservicemanager_handle_registration(self, &reader);
+            gbinder_servicemanager_hidl_handle_registration(self, &reader);
             *status = GBINDER_STATUS_OK;
             break;
         default:
-            GDEBUG(HWSERVICEMANAGER_NOTIFICATION_IFACE " %u", code);
+            GDEBUG(SERVICEMANAGER_HIDL_NOTIFICATION_IFACE " %u", code);
             *status = GBINDER_STATUS_FAILED;
             break;
         }
@@ -145,17 +144,9 @@ gbinder_hwservicemanager_notification(
     return NULL;
 }
 
-GBinderServiceManager*
-gbinder_hwservicemanager_new(
-    const char* dev)
-{
-    return gbinder_servicemanager_new_with_type
-        (gbinder_hwservicemanager_get_type(), dev);
-}
-
 static
 char**
-gbinder_hwservicemanager_list(
+gbinder_servicemanager_hidl_list(
     GBinderServiceManager* self)
 {
     GBinderLocalRequest* req = gbinder_client_new_request(self->client);
@@ -184,7 +175,7 @@ gbinder_hwservicemanager_list(
 
 static
 GBinderRemoteObject*
-gbinder_hwservicemanager_get_service(
+gbinder_servicemanager_hidl_get_service(
     GBinderServiceManager* self,
     const char* fqinstance,
     int* status)
@@ -231,7 +222,7 @@ gbinder_hwservicemanager_get_service(
 
 static
 int
-gbinder_hwservicemanager_add_service(
+gbinder_servicemanager_hidl_add_service(
     GBinderServiceManager* self,
     const char* name,
     GBinderLocalObject* obj)
@@ -254,10 +245,10 @@ gbinder_hwservicemanager_add_service(
 
 static
 void
-gbinder_hwservicemanager_watch_free(
+gbinder_servicemanager_hidl_watch_free(
     gpointer data)
 {
-    GBinderHwServiceManagerWatch* watch = data;
+    GBinderServiceManagerHidlWatch* watch = data;
 
     g_free(watch->name);
     gbinder_local_object_drop(watch->callback);
@@ -266,7 +257,7 @@ gbinder_hwservicemanager_watch_free(
 
 static
 GBINDER_SERVICEMANAGER_NAME_CHECK
-gbinder_hwservicemanager_check_name(
+gbinder_servicemanager_hidl_check_name(
     GBinderServiceManager* self,
     const char* name)
 {
@@ -287,32 +278,32 @@ gbinder_hwservicemanager_check_name(
 
 static
 char*
-gbinder_hwservicemanager_normalize_name(
+gbinder_servicemanager_hidl_normalize_name(
     GBinderServiceManager* self,
     const char* name)
 {
-    /* Slash must be there, see gbinder_hwservicemanager_check_name() above */
+    /* Slash must be there, see gbinder_servicemanager_hidl_check_name() */
     return g_strndup(name, strchr(name, '/') - name);
 }
 
 static
 gboolean
-gbinder_hwservicemanager_watch(
+gbinder_servicemanager_hidl_watch(
     GBinderServiceManager* manager,
     const char* name)
 {
-    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(manager);
+    GBinderServiceManagerHidl* self = GBINDER_SERVICEMANAGER_HIDL(manager);
     GBinderLocalRequest* req = gbinder_client_new_request(manager->client);
     GBinderRemoteReply* reply;
-    GBinderHwServiceManagerWatch* watch =
-        g_new0(GBinderHwServiceManagerWatch, 1);
+    GBinderServiceManagerHidlWatch* watch =
+        g_new0(GBinderServiceManagerHidlWatch, 1);
     gboolean success = FALSE;
     int status;
 
     watch->name = g_strdup(name);
     watch->callback = gbinder_servicemanager_new_local_object(manager,
-        HWSERVICEMANAGER_NOTIFICATION_IFACE,
-        gbinder_hwservicemanager_notification, self);
+        SERVICEMANAGER_HIDL_NOTIFICATION_IFACE,
+        gbinder_servicemanager_hidl_notification, self);
     g_hash_table_replace(self->watch_table, watch->name, watch);
 
     /* registerForNotifications(string fqName, string name,
@@ -344,28 +335,29 @@ gbinder_hwservicemanager_watch(
 
 static
 void
-gbinder_hwservicemanager_unwatch(
+gbinder_servicemanager_hidl_unwatch(
     GBinderServiceManager* manager,
     const char* name)
 {
-    g_hash_table_remove(GBINDER_HWSERVICEMANAGER(manager)->watch_table, name);
+    g_hash_table_remove(GBINDER_SERVICEMANAGER_HIDL(manager)->
+        watch_table, name);
 }
 
 static
 void
-gbinder_hwservicemanager_init(
-    GBinderHwServiceManager* self)
+gbinder_servicemanager_hidl_init(
+    GBinderServiceManagerHidl* self)
 {
     self->watch_table = g_hash_table_new_full(g_str_hash, g_str_equal,
-        NULL, gbinder_hwservicemanager_watch_free);
+        NULL, gbinder_servicemanager_hidl_watch_free);
 }
 
 static
 void
-gbinder_hwservicemanager_finalize(
+gbinder_servicemanager_hidl_finalize(
     GObject* object)
 {
-    GBinderHwServiceManager* self = GBINDER_HWSERVICEMANAGER(object);
+    GBinderServiceManagerHidl* self = GBINDER_SERVICEMANAGER_HIDL(object);
 
     g_hash_table_destroy(self->watch_table);
     G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
@@ -373,20 +365,20 @@ gbinder_hwservicemanager_finalize(
 
 static
 void
-gbinder_hwservicemanager_class_init(
-    GBinderHwServiceManagerClass* klass)
+gbinder_servicemanager_hidl_class_init(
+    GBinderServiceManagerHidlClass* klass)
 {
-    klass->iface = HWSERVICEMANAGER_IFACE;
+    klass->iface = SERVICEMANAGER_HIDL_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
 
-    klass->list = gbinder_hwservicemanager_list;
-    klass->get_service = gbinder_hwservicemanager_get_service;
-    klass->add_service = gbinder_hwservicemanager_add_service;
-    klass->check_name = gbinder_hwservicemanager_check_name;
-    klass->normalize_name = gbinder_hwservicemanager_normalize_name;
-    klass->watch = gbinder_hwservicemanager_watch;
-    klass->unwatch = gbinder_hwservicemanager_unwatch;
-    G_OBJECT_CLASS(klass)->finalize = gbinder_hwservicemanager_finalize;
+    klass->list = gbinder_servicemanager_hidl_list;
+    klass->get_service = gbinder_servicemanager_hidl_get_service;
+    klass->add_service = gbinder_servicemanager_hidl_add_service;
+    klass->check_name = gbinder_servicemanager_hidl_check_name;
+    klass->normalize_name = gbinder_servicemanager_hidl_normalize_name;
+    klass->watch = gbinder_servicemanager_hidl_watch;
+    klass->unwatch = gbinder_servicemanager_hidl_unwatch;
+    G_OBJECT_CLASS(klass)->finalize = gbinder_servicemanager_hidl_finalize;
 }
 
 /*

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -98,6 +98,13 @@ gbinder_servicemanager_service_registered(
     const char* name)
     GBINDER_INTERNAL;
 
+/* Declared for unit tests */
+void
+gbinder_servicemanager_exit(
+    void)
+    GBINDER_INTERNAL
+    GBINDER_DESTRUCTOR;
+
 /* Derived types */
 
 GType gbinder_servicemanager_aidl_get_type(void) GBINDER_INTERNAL;

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -98,6 +98,11 @@ gbinder_servicemanager_service_registered(
     const char* name)
     GBINDER_INTERNAL;
 
+/* Derived types */
+
+GType gbinder_servicemanager_aidl_get_type(void) GBINDER_INTERNAL;
+GType gbinder_servicemanager_hidl_get_type(void) GBINDER_INTERNAL;
+
 #endif /* GBINDER_SERVICEMANAGER_PRIVATE_H */
 
 /*

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -64,7 +64,6 @@ typedef struct gbinder_servicemanager_class {
 
     const char* iface;
     const char* default_device;
-    const GBinderRpcProtocol* rpc_protocol;
 
     /* Methods (synchronous) */
     char** (*list)(GBinderServiceManager* self);

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -85,6 +85,9 @@ typedef struct gbinder_servicemanager_class {
 
 GType gbinder_servicemanager_get_type(void) GBINDER_INTERNAL;
 #define GBINDER_TYPE_SERVICEMANAGER (gbinder_servicemanager_get_type())
+#define GBINDER_SERVICEMANAGER_CLASS(klass) \
+    G_TYPE_CHECK_CLASS_CAST((klass), GBINDER_TYPE_SERVICEMANAGER, \
+    GBinderServiceManagerClass)
 
 GBinderServiceManager*
 gbinder_servicemanager_new_with_type(
@@ -108,6 +111,7 @@ gbinder_servicemanager_exit(
 /* Derived types */
 
 GType gbinder_servicemanager_aidl_get_type(void) GBINDER_INTERNAL;
+GType gbinder_servicemanager_aidl2_get_type(void) GBINDER_INTERNAL;
 GType gbinder_servicemanager_hidl_get_type(void) GBINDER_INTERNAL;
 
 #endif /* GBINDER_SERVICEMANAGER_PRIVATE_H */

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -48,6 +48,7 @@ typedef struct gbinder_ipc_looper_tx GBinderIpcLooperTx;
 
 #define GBINDER_INLINE_FUNC static inline
 #define GBINDER_INTERNAL G_GNUC_INTERNAL
+#define GBINDER_DESTRUCTOR __attribute__((destructor))
 
 #define GBINDER_TRANSACTION(c2,c3,c4)     GBINDER_FOURCC('_',c2,c3,c4)
 #define GBINDER_PING_TRANSACTION          GBINDER_TRANSACTION('P','N','G')

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -5,6 +5,7 @@ all:
 	@$(MAKE) -C unit_buffer $*
 	@$(MAKE) -C unit_cleanup $*
 	@$(MAKE) -C unit_client $*
+	@$(MAKE) -C unit_config $*
 	@$(MAKE) -C unit_driver $*
 	@$(MAKE) -C unit_eventloop $*
 	@$(MAKE) -C unit_ipc $*

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -44,7 +44,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 
 CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
-WARNINGS += -Wall
+WARNINGS += -Wall -Wno-deprecated-declarations
 INCLUDES += -I$(COMMON_DIR) -I$(LIB_DIR)/src -I$(LIB_DIR)/include
 BASE_FLAGS = -fPIC
 BASE_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS)

--- a/unit/common/test_common.h
+++ b/unit/common/test_common.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -57,6 +57,12 @@ test_run(
 void
 test_quit_later(
     GMainLoop* loop);
+
+/* Quits the event loop after n iterations */
+void
+test_quit_later_n(
+    GMainLoop* loop,
+    guint n);
 
 #define TEST_TIMEOUT_SEC (20)
 

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -7,6 +7,7 @@ TESTS="\
 unit_buffer \
 unit_cleanup \
 unit_client \
+unit_config \
 unit_driver \
 unit_eventloop \
 unit_ipc \

--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -54,7 +54,7 @@ test_client_new(
     guint handle,
     const char* iface)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, handle);
     GBinderClient* client = gbinder_client_new(obj, iface);
@@ -97,7 +97,7 @@ void
 test_basic(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0);
     const char* iface = "foo";
@@ -123,7 +123,7 @@ void
 test_interfaces(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0);
     static const GBinderClientIfaceInfo ifaces[] = {

--- a/unit/unit_config/Makefile
+++ b/unit/unit_config/Makefile
@@ -1,0 +1,5 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = unit_config
+
+include ../common/Makefile

--- a/unit/unit_config/unit_config.c
+++ b/unit/unit_config/unit_config.c
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2020 Jolla Ltd.
+ * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_common.h"
+
+#include "gbinder_config.h"
+
+static TestOpt test_opt;
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-config-XXXXXX";
+
+/*==========================================================================*
+ * null
+ *==========================================================================*/
+
+static
+void
+test_null(
+    void)
+{
+    const char* default_name = gbinder_config_file;
+
+    /* Reset the state */
+    gbinder_config_exit();
+    gbinder_config_file = NULL;
+    g_assert(!gbinder_config_get());
+
+    /* Reset the state again */
+    gbinder_config_file = default_name;
+}
+
+/*==========================================================================*
+ * non_exist
+ *==========================================================================*/
+
+static
+void
+test_non_exit(
+    void)
+{
+    const char* default_name = gbinder_config_file;
+    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    char* file = g_build_filename(dir, "test.conf", NULL);
+
+    /* Reset the state */
+    gbinder_config_exit();
+
+    gbinder_config_file = file;
+    g_assert(!gbinder_config_get());
+
+    /* Reset the state again */
+    gbinder_config_file = default_name;
+
+    g_free(file);
+    remove(dir);
+    g_free(dir);
+}
+
+/*==========================================================================*
+ * bad_config
+ *==========================================================================*/
+
+static
+void
+test_bad_config(
+    void)
+{
+    const char* default_name = gbinder_config_file;
+    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    char* file = g_build_filename(dir, "test.conf", NULL);
+    static const char garbage[] = "foo";
+
+    /* Reset the state */
+    gbinder_config_exit();
+
+    /* Try to load the garbage */
+    g_assert(g_file_set_contents(file, garbage, -1, NULL));
+    gbinder_config_file = file;
+    g_assert(!gbinder_config_get());
+
+    /* Reset the state again */
+    gbinder_config_file = default_name;
+
+    remove(file);
+    g_free(file);
+
+    remove(dir);
+    g_free(dir);
+}
+
+/*==========================================================================*
+ * autorelease
+ *==========================================================================*/
+
+static
+void
+test_autorelease(
+    void)
+{
+    const char* default_name = gbinder_config_file;
+    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    char* file = g_build_filename(dir, "test.conf", NULL);
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GKeyFile* keyfile;
+    static const char config[] = "[Protocol]";
+
+    gbinder_config_exit(); /* Reset the state */
+
+    /* Load the file */
+    g_assert(g_file_set_contents(file, config, -1, NULL));
+    gbinder_config_file = file;
+    keyfile = gbinder_config_get();
+    g_assert(keyfile);
+
+    /* Second call returns the same pointer */
+    g_assert(keyfile == gbinder_config_get());
+
+    test_quit_later_n(loop, 2);
+    test_run(&test_opt, loop);
+    g_main_loop_unref(loop);
+
+    /* Reset the state again */
+    gbinder_config_exit();
+    gbinder_config_file = default_name;
+
+    remove(file);
+    g_free(file);
+
+    remove(dir);
+    g_free(dir);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_PREFIX "/config/"
+#define TEST_(t) TEST_PREFIX t
+
+int main(int argc, char* argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("non_exist"), test_non_exit);
+    g_test_add_func(TEST_("bad_config"), test_bad_config);
+    g_test_add_func(TEST_("autorelease"), test_autorelease);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -109,8 +109,8 @@ void
 test_basic(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderIpc* ipc2 = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
+    GBinderIpc* ipc2 = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
 
     g_assert(ipc);
     g_assert(ipc2);
@@ -119,14 +119,14 @@ test_basic(
     gbinder_ipc_unref(ipc2);
 
     /* Second gbinder_ipc_new returns the same (default) object */
-    g_assert(gbinder_ipc_new(NULL, NULL) == ipc);
-    g_assert(gbinder_ipc_new("", NULL) == ipc);
+    g_assert(gbinder_ipc_new(NULL) == ipc);
+    g_assert(gbinder_ipc_new("") == ipc);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_unref(ipc);
 
     /* Invalid path */
-    g_assert(!gbinder_ipc_new("invalid path", NULL));
+    g_assert(!gbinder_ipc_new("invalid path"));
 
     gbinder_ipc_exit();
 }
@@ -153,7 +153,7 @@ void
 test_async_oneway(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -180,7 +180,7 @@ void
 test_sync_oneway(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -202,7 +202,7 @@ void
 test_sync_reply_ok_status(
     int* status)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -258,7 +258,7 @@ void
 test_sync_reply_error(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -316,7 +316,7 @@ void
 test_transact_ok(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -374,7 +374,7 @@ void
 test_transact_dead(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -421,7 +421,7 @@ void
 test_transact_failed(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -470,7 +470,7 @@ void
 test_transact_status(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
@@ -512,7 +512,7 @@ void
 test_transact_custom(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id = gbinder_ipc_transact_custom(ipc, NULL,
         test_transact_custom_done, NULL, loop);
@@ -543,7 +543,7 @@ void
 test_transact_custom2(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id = gbinder_ipc_transact_custom(ipc, NULL, NULL,
         test_transact_custom_destroy, loop);
@@ -575,7 +575,7 @@ void
 test_transact_custom3(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     /* Reusing test_transact_cancel_done and test_transact_cancel_destroy */
     gulong id = gbinder_ipc_transact_custom(ipc, test_transact_custom3_exec,
@@ -624,7 +624,7 @@ void
 test_transact_cancel(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id = gbinder_ipc_transact_custom(ipc, test_transact_cancel_exec,
         test_transact_cancel_done, test_transact_cancel_destroy, loop);
@@ -669,7 +669,7 @@ void
 test_transact_cancel2(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     /* Reusing test_transact_cancel_done and test_transact_cancel_destroy */
     gulong id = gbinder_ipc_transact_custom(ipc, test_transact_cancel2_exec,
@@ -718,7 +718,7 @@ void
 test_transact_2way(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
@@ -803,7 +803,7 @@ void
 test_transact_incoming(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
@@ -873,7 +873,7 @@ void
 test_transact_status_reply(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
@@ -980,7 +980,7 @@ void
 test_transact_async(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
@@ -1053,7 +1053,7 @@ void
 test_transact_async_sync(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
@@ -1107,7 +1107,7 @@ void
 test_drop_remote_refs(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
@@ -1149,7 +1149,7 @@ void
 test_cancel_on_exit(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const GBinderIo* io = gbinder_driver_io(ipc->driver);
     GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -152,7 +152,7 @@ test_basic(
 {
     const char* const ifaces_foo[] = { "foo", NULL };
     const char* const ifaces_bar[] = { "bar", NULL };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderLocalObject* foo;
     GBinderLocalObject* bar;
@@ -201,7 +201,7 @@ test_ping(
     int status = INT_MAX;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
@@ -247,7 +247,7 @@ test_interface(
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
     const char* const ifaces[] = { "x", NULL };
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
@@ -296,7 +296,7 @@ test_hidl_ping(
     int status = INT_MAX;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
@@ -346,7 +346,7 @@ test_get_descriptor(
     int status = INT_MAX;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
@@ -402,7 +402,7 @@ test_descriptor_chain(
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const char* const ifaces[] = { "android.hidl.base@1.0::IBase", NULL };
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
@@ -476,7 +476,7 @@ test_custom_iface(
     int count = 0, status = INT_MAX;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces,
@@ -583,7 +583,7 @@ test_reply_status(
     int count = 0, status = 0;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteRequest* req = gbinder_remote_request_new(reg, prot, 0, 0);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces,
@@ -624,7 +624,7 @@ void
 test_increfs(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
@@ -666,7 +666,7 @@ void
 test_decrefs(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
@@ -708,7 +708,7 @@ void
 test_acquire(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
@@ -750,7 +750,7 @@ void
 test_release(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -399,7 +399,7 @@ test_local_object(
     GBinderLocalReply* reply;
     GBinderOutputData* data;
     GUtilIntArray* offsets;
-    GBinderIpc* ipc = gbinder_ipc_new(NULL, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(NULL);
     const char* const ifaces[] = { "android.hidl.base@1.0::IBase", NULL };
     GBinderLocalObject* obj = gbinder_local_object_new(ipc, ifaces, NULL, NULL);
 

--- a/unit/unit_protocol/unit_protocol.c
+++ b/unit/unit_protocol/unit_protocol.c
@@ -48,32 +48,113 @@ static const char TMP_DIR_TEMPLATE[] = "gbinder-test-protocol-XXXXXX";
 
 #define STRICT_MODE_PENALTY_GATHER (0x40 << 16)
 #define BINDER_RPC_FLAGS (STRICT_MODE_PENALTY_GATHER)
+#define UNSET_WORK_SOURCE (-1)
+
+typedef struct test_data {
+    const char* name;
+    const char* prot;
+    const char* dev;
+} TestData;
 
 typedef struct test_header_data {
     const char* name;
+    const char* prot;
     const char* dev;
     const char* iface;
     const guint8* header;
     guint header_size;
 } TestHeaderData;
 
-static const guint8 test_header_binder [] = {
+static const guint8 test_header_aidl [] = {
     TEST_INT32_BYTES(BINDER_RPC_FLAGS),
     TEST_INT32_BYTES(3),
     TEST_INT16_BYTES('f'), TEST_INT16_BYTES('o'),
     TEST_INT16_BYTES('o'), 0x00, 0x00
 };
 
-static const guint8 test_header_hwbinder [] = {
+static const guint8 test_header_aidl2 [] = {
+    TEST_INT32_BYTES(BINDER_RPC_FLAGS),
+    TEST_INT32_BYTES(UNSET_WORK_SOURCE),
+    TEST_INT32_BYTES(3),
+    TEST_INT16_BYTES('f'), TEST_INT16_BYTES('o'),
+    TEST_INT16_BYTES('o'), 0x00, 0x00
+};
+
+static const guint8 test_header_hidl [] = {
     'f', 'o', 'o', 0x00
 };
 
 static const TestHeaderData test_header_tests[] = {
-    { "binder", GBINDER_DEFAULT_BINDER, "foo",
-      TEST_ARRAY_AND_SIZE(test_header_binder) },
-    { "hwbinder", GBINDER_DEFAULT_HWBINDER, "foo",
-      TEST_ARRAY_AND_SIZE(test_header_hwbinder) }
+    { "aidl/ok", "aidl", GBINDER_DEFAULT_BINDER, "foo",
+      TEST_ARRAY_AND_SIZE(test_header_aidl) },
+    { "aidl/short", "aidl", GBINDER_DEFAULT_BINDER, NULL,
+      test_header_aidl, 8 }, /* Short packet */
+    { "aidl2/ok", "aidl2", GBINDER_DEFAULT_BINDER, "foo",
+      TEST_ARRAY_AND_SIZE(test_header_aidl2) },
+    { "aidl2/short/1", "aidl2", GBINDER_DEFAULT_BINDER, NULL,
+      test_header_aidl2, 1 }, /* Short packet */
+    { "aidl2/short/2", "aidl2", GBINDER_DEFAULT_BINDER, NULL,
+      test_header_aidl2, 5 }, /* Short packet */
+    { "aidl2/short/3", "adl2", GBINDER_DEFAULT_BINDER, NULL,
+      test_header_aidl2, 9 }, /* Short packet */
+    { "hidl/ok", "hidl", GBINDER_DEFAULT_HWBINDER, "foo",
+      TEST_ARRAY_AND_SIZE(test_header_hidl) },
+    { "hidl/short", "hidl", GBINDER_DEFAULT_HWBINDER, NULL,
+      test_header_hidl, 1 }
 };
+
+typedef struct test_config {
+    char* dir;
+    char* file;
+} TestConfig;
+
+static
+void
+test_config_init(
+    TestConfig* test,
+    const char* config)
+{
+    test->dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    test->file = g_build_filename(test->dir, "test.conf", NULL);
+
+    /* Reset the state */
+    gbinder_rpc_protocol_exit();
+    gbinder_config_exit();
+
+    /* Write the config */
+    g_assert(g_file_set_contents(test->file, config, -1, NULL));
+    gbinder_config_file = test->file;
+}
+
+static
+void
+test_config_init2(
+    TestConfig* test,
+    const char* dev,
+    const char* prot)
+{
+    char* config = g_strconcat("[Protocol]\n", dev, " = ", prot, "\n", NULL);
+
+    test_config_init(test, config);
+    g_free(config);
+}
+
+static
+void
+test_config_cleanup(
+    TestConfig* test)
+{
+    /* Undo the damage */
+    gbinder_rpc_protocol_exit();
+    gbinder_config_exit();
+    gbinder_config_file = NULL;
+
+    remove(test->file);
+    g_free(test->file);
+
+    remove(test->dir);
+    g_free(test->dir);
+}
 
 /*==========================================================================*
  * device
@@ -108,21 +189,13 @@ void
 test_config1(
     void)
 {
-    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
-    char* file = g_build_filename(dir, "test.conf", NULL);
     const GBinderRpcProtocol* p;
+    TestConfig config;
 
-    static const char config[] =
+    test_config_init(&config,
         "[Protocol]\n"
         "/dev/binder = hidl\n" /* Redefined name for /dev/binder */
-        "/dev/hwbinder = foo\n"; /* Invalid protocol name */
-
-    gbinder_rpc_protocol_exit(); /* Reset the state */
-    gbinder_config_exit();
-
-    /* Write the config file */
-    g_assert(g_file_set_contents(file, config, -1, NULL));
-    gbinder_config_file = file;
+        "/dev/hwbinder = foo\n"); /* Invalid protocol name */
 
     p = gbinder_rpc_protocol_for_device(NULL);
     g_assert(p);
@@ -140,15 +213,7 @@ test_config1(
     g_assert(p);
     g_assert_cmpstr(p->name, == ,"aidl");
 
-    gbinder_rpc_protocol_exit();
-    gbinder_config_exit();
-    gbinder_config_file = NULL;
-
-    remove(file);
-    g_free(file);
-
-    remove(dir);
-    g_free(dir);
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -160,22 +225,14 @@ void
 test_config2(
     void)
 {
-    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
-    char* file = g_build_filename(dir, "test.conf", NULL);
     const GBinderRpcProtocol* p;
+    TestConfig config;
 
-    static const char config[] =
+    test_config_init(&config,
         "[Protocol]\n"
         "Default = hidl\n"
         "/dev/vndbinder = hidl\n"
-        "/dev/hwbinder = foo\n"; /* Invalid protocol name */
-
-    gbinder_rpc_protocol_exit(); /* Reset the state */
-    gbinder_config_exit();
-
-    /* Write the config file */
-    g_assert(g_file_set_contents(file, config, -1, NULL));
-    gbinder_config_file = file;
+        "/dev/hwbinder = foo\n"); /* Invalid protocol name */
 
     p = gbinder_rpc_protocol_for_device(NULL);
     g_assert(p);
@@ -198,15 +255,7 @@ test_config2(
     g_assert(p);
     g_assert_cmpstr(p->name, == ,"hidl");
 
-    gbinder_rpc_protocol_exit();
-    gbinder_config_exit();
-    gbinder_config_file = NULL;
-
-    remove(file);
-    g_free(file);
-
-    remove(dir);
-    g_free(dir);
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -218,20 +267,12 @@ void
 test_config3(
     void)
 {
-    char* dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
-    char* file = g_build_filename(dir, "test.conf", NULL);
     const GBinderRpcProtocol* p;
+    TestConfig config;
 
-    static const char config[] =
+    test_config_init(&config,
         "[Whatever]\n"
-        "/dev/hwbinder = aidl\n"; /* Ignored, wrong section */
-
-    gbinder_rpc_protocol_exit(); /* Reset the state */
-    gbinder_config_exit();
-
-    /* Write the config file */
-    g_assert(g_file_set_contents(file, config, -1, NULL));
-    gbinder_config_file = file;
+        "/dev/hwbinder = aidl\n"); /* Ignored, wrong section */
 
     /* Just the default config */
     p = gbinder_rpc_protocol_for_device(NULL);
@@ -246,15 +287,7 @@ test_config3(
     g_assert(p);
     g_assert_cmpstr(p->name, == ,"aidl");
 
-    gbinder_rpc_protocol_exit();
-    gbinder_config_exit();
-    gbinder_config_file = NULL;
-
-    remove(file);
-    g_free(file);
-
-    remove(dir);
-    g_free(dir);
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -264,14 +297,21 @@ test_config3(
 static
 void
 test_no_header1(
-    void)
+    gconstpointer test_data)
 {
-    GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(GBINDER_DEFAULT_BINDER), 0, 0);
+    const TestData* test = test_data;
+    GBinderRemoteRequest* req;
+    TestConfig config;
 
+    test_config_init2(&config, test->dev, test->prot);
+
+    req = gbinder_remote_request_new(NULL, gbinder_rpc_protocol_for_device
+        (GBINDER_DEFAULT_BINDER), 0, 0);
     gbinder_remote_request_set_data(req, GBINDER_FIRST_CALL_TRANSACTION, NULL);
     g_assert(!gbinder_remote_request_interface(req));
     gbinder_remote_request_unref(req);
+
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -281,20 +321,34 @@ test_no_header1(
 static
 void
 test_no_header2(
-    void)
+    gconstpointer test_data)
 {
-    const GBinderRpcProtocol* p = gbinder_rpc_protocol_for_device(NULL);
-    GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, p);
-    GBinderRemoteRequest* req = gbinder_remote_request_new(NULL, p, 0, 0);
+    const TestData* test = test_data;
+    const GBinderRpcProtocol* p;
+    GBinderDriver* driver;
+    GBinderRemoteRequest* req;
+    TestConfig config;
+
+    test_config_init2(&config, test->dev, test->prot);
+
+    p = gbinder_rpc_protocol_for_device(test->dev);
+    driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, p);
+    req = gbinder_remote_request_new(NULL, p, 0, 0);
 
     gbinder_remote_request_set_data(req, GBINDER_DUMP_TRANSACTION,
         gbinder_buffer_new(driver,
-        g_memdup(TEST_ARRAY_AND_SIZE(test_header_binder)),
-        sizeof(test_header_binder), NULL));
+        g_memdup(TEST_ARRAY_AND_SIZE(test_header_aidl)),
+        sizeof(test_header_aidl), NULL));
     g_assert(!gbinder_remote_request_interface(req));
     gbinder_remote_request_unref(req);
     gbinder_driver_unref(driver);
+    test_config_cleanup(&config);
 }
+
+static const TestData test_no_header_data[] = {
+    { "aidl", "aidl", GBINDER_DEFAULT_BINDER },
+    { "aidl2", "aidl2", GBINDER_DEFAULT_BINDER },
+};
 
 /*==========================================================================*
  * write_header
@@ -306,17 +360,24 @@ test_write_header(
     gconstpointer test_data)
 {
     const TestHeaderData* test = test_data;
-    const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(test->dev);
-    GBinderLocalRequest* req = gbinder_local_request_new(&gbinder_io_32, NULL);
+    const GBinderRpcProtocol* prot;
+    GBinderLocalRequest* req;
     GBinderOutputData* data;
     GBinderWriter writer;
+    TestConfig config;
 
+    test_config_init2(&config, test->dev, test->prot);
+
+    prot = gbinder_rpc_protocol_for_device(test->dev);
+    req = gbinder_local_request_new(&gbinder_io_32, NULL);
     gbinder_local_request_init_writer(req, &writer);
     prot->write_rpc_header(&writer, test->iface);
     data = gbinder_local_request_data(req);
     g_assert(data->bytes->len == test->header_size);
     g_assert(!memcmp(data->bytes->data, test->header, test->header_size));
     gbinder_local_request_unref(req);
+
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -329,16 +390,23 @@ test_read_header(
     gconstpointer test_data)
 {
     const TestHeaderData* test = test_data;
-    GBinderDriver* driver = gbinder_driver_new(test->dev, NULL);
-    GBinderRemoteRequest* req = gbinder_remote_request_new(NULL,
-        gbinder_rpc_protocol_for_device(test->dev), 0, 0);
+    GBinderDriver* driver;
+    GBinderRemoteRequest* req;
+    TestConfig config;
 
+    test_config_init2(&config, test->dev, test->prot);
+
+    driver = gbinder_driver_new(test->dev, NULL);
+    req = gbinder_remote_request_new(NULL, gbinder_rpc_protocol_for_device
+        (test->dev), 0, 0);
     gbinder_remote_request_set_data(req, GBINDER_FIRST_CALL_TRANSACTION,
         gbinder_buffer_new(driver, g_memdup(test->header, test->header_size),
         test->header_size, NULL));
-    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), test->iface));
+    g_assert_cmpstr(gbinder_remote_request_interface(req), == ,test->iface);
     gbinder_remote_request_unref(req);
     gbinder_driver_unref(driver);
+
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -357,20 +425,33 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("config1"), test_config1);
     g_test_add_func(TEST_("config2"), test_config2);
     g_test_add_func(TEST_("config3"), test_config3);
-    g_test_add_func(TEST_("no_header1"), test_no_header1);
-    g_test_add_func(TEST_("no_header2"), test_no_header2);
+
+    for (i = 0; i < G_N_ELEMENTS(test_no_header_data); i++) {
+        const TestData* test = test_no_header_data + i;
+        char* path;
+
+        path = g_strconcat(TEST_("no_header1/"), test->name, NULL);
+        g_test_add_data_func(path, test, test_no_header1);
+        g_free(path);
+
+        path = g_strconcat(TEST_("no_header2/"), test->name, NULL);
+        g_test_add_data_func(path, test, test_no_header2);
+        g_free(path);
+    }
 
     for (i = 0; i < G_N_ELEMENTS(test_header_tests); i++) {
         const TestHeaderData* test = test_header_tests + i;
         char* path;
 
-        path = g_strconcat(TEST_PREFIX, test->name, "/read_header", NULL);
+        path = g_strconcat(TEST_("read_header/"), test->name, NULL);
         g_test_add_data_func(path, test, test_read_header);
         g_free(path);
 
-        path = g_strconcat(TEST_PREFIX, test->name, "/write_header", NULL);
-        g_test_add_data_func(path, test, test_write_header);
-        g_free(path);
+        if (test->iface) {
+            path = g_strconcat(TEST_("write_header/"), test->name, NULL);
+            g_test_add_data_func(path, test, test_write_header);
+            g_free(path);
+        }
     }
 
     test_init(&test_opt, argc, argv);

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -624,7 +624,7 @@ test_hidl_struct(
     gconstpointer test_data)
 {
     const TestHidlStruct* test = test_data;
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(test->in, test->in_size), test->in_size, NULL);
     GBinderReaderData data;
@@ -828,7 +828,7 @@ test_hidl_vec(
     gconstpointer test_data)
 {
     const TestHidlVec* test = test_data;
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(test->in, test->in_size), test->in_size, NULL);
     GBinderReaderData data;
@@ -934,7 +934,7 @@ test_hidl_string_err(
     gconstpointer test_data)
 {
     const TestHidlStringErr* test = test_data;
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(test->in, test->in_size), test->in_size, NULL);
     GBinderReaderData data;
@@ -968,7 +968,7 @@ test_hidl_string_err_skip(
     gconstpointer test_data)
 {
     const TestHidlStringErr* test = test_data;
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(test->in, test->in_size), test->in_size, NULL);
     GBinderReaderData data;
@@ -1013,7 +1013,7 @@ test_fd_ok(
         TEST_INT32_BYTES(fd), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1053,7 +1053,7 @@ test_fd_shortbuf(
         TEST_INT32_BYTES(BINDER_TYPE_FD),
         TEST_INT32_BYTES(0x7f | BINDER_FLAG_ACCEPTS_FDS)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1087,7 +1087,7 @@ test_fd_badtype(
         TEST_INT32_BYTES(fd), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1130,7 +1130,7 @@ test_dupfd_ok(
         TEST_INT32_BYTES(fd), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1177,7 +1177,7 @@ test_dupfd_badtype(
         TEST_INT32_BYTES(fd), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1220,7 +1220,7 @@ test_dupfd_badfd(
         TEST_INT32_BYTES(fd), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderReaderData data;
@@ -1259,7 +1259,7 @@ test_hidl_string(
     guint bufcount,
     const char* result)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver, g_memdup(input, size),
         size, NULL);
     GBinderRemoteObject* obj = NULL;
@@ -1530,7 +1530,7 @@ test_buffer(
         TEST_INT64_BYTES(0), TEST_INT64_BYTES(0),
         TEST_INT64_BYTES(0), TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderRemoteObject* obj = NULL;
@@ -1578,7 +1578,7 @@ test_object(
         TEST_INT32_BYTES(BINDER_TYPE_HANDLE), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(1 /* handle*/), TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderRemoteObject* obj = NULL;
@@ -1636,7 +1636,7 @@ test_object_invalid(
         TEST_INT32_BYTES(42 /* invalid type */), TEST_INT32_BYTES(0),
         TEST_INT64_BYTES(1 /* handle*/), TEST_INT64_BYTES(0)
     };
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderRemoteObject* obj = NULL;
@@ -1670,7 +1670,7 @@ test_vec(
     void)
 {
     /* Using 64-bit I/O */
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderReaderData data;
     GBinderReader reader;
     BinderObject64 obj;
@@ -1723,7 +1723,7 @@ test_hidl_string_vec(
     gsize size,
     const char* const* result)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver, g_memdup(input, size),
         size, NULL);
     GBinderRemoteObject* obj = NULL;

--- a/unit/unit_remote_object/unit_remote_object.c
+++ b/unit/unit_remote_object/unit_remote_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -68,7 +68,7 @@ void
 test_basic(
     void)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
     GBinderRemoteObject* obj1 = gbinder_object_registry_get_remote(reg, 1);
     GBinderRemoteObject* obj2 = gbinder_object_registry_get_remote(reg, 2);
@@ -112,7 +112,7 @@ test_dead(
 {
     const guint handle = 1;
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderRemoteObject* obj = gbinder_ipc_get_remote_object
         (ipc, handle, FALSE);

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -378,6 +378,13 @@ gbinder_servicemanager_aidl_get_type()
     return TEST_TYPE_DEFSERVICEMANAGER;
 }
 
+GType
+gbinder_servicemanager_aidl2_get_type()
+{
+    /* Avoid pulling in gbinder_servicemanager_aidl2 object */
+    return TEST_TYPE_DEFSERVICEMANAGER;
+}
+
 /*==========================================================================*
  * null
  *==========================================================================*/

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -291,12 +291,10 @@ test_hwservicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_hwservicemanager_finalize;
 }
 
-GBinderServiceManager*
-gbinder_hwservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_hidl_get_type()
 {
-    return gbinder_servicemanager_new_with_type(TEST_TYPE_HWSERVICEMANAGER,
-        dev);
+    return TEST_TYPE_HWSERVICEMANAGER;
 }
 
 /*==========================================================================*
@@ -372,12 +370,10 @@ test_defservicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_defservicemanager_finalize;
 }
 
-GBinderServiceManager*
-gbinder_defaultservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_aidl_get_type()
 {
-    return gbinder_servicemanager_new_with_type(TEST_TYPE_DEFSERVICEMANAGER,
-        dev);
+    return TEST_TYPE_DEFSERVICEMANAGER;
 }
 
 /*==========================================================================*

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -281,7 +281,6 @@ test_hwservicemanager_class_init(
 {
     klass->iface = TEST_HWSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_hwbinder;
     klass->list = test_servicemanager_list;
     klass->get_service = test_servicemanager_get_service;
     klass->add_service = test_servicemanager_add_service;
@@ -365,7 +364,6 @@ test_defservicemanager_class_init(
 {
     klass->iface = TEST_DEFSERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_BINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_binder;
     klass->list = test_servicemanager_list;
     klass->get_service = test_servicemanager_get_service;
     klass->add_service = test_servicemanager_add_service;
@@ -423,7 +421,7 @@ test_invalid(
 {
     int status = 0;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderServiceManager* sm;
     gulong id = 0;
 
@@ -468,7 +466,7 @@ test_basic(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderServiceManager* sm;
     GBinderLocalObject* obj;
 
@@ -496,7 +494,7 @@ test_not_present(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderServiceManager* sm;
 
@@ -521,7 +519,7 @@ test_wait(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     const glong forever = (test_opt.flags & TEST_FLAG_DEBUG) ?
         (TEST_TIMEOUT_SEC * 1000) : -1;
@@ -571,7 +569,7 @@ test_wait_long(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GBinderServiceManager* sm;
     gulong id;
@@ -616,7 +614,7 @@ test_wait_async(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
@@ -660,7 +658,7 @@ test_death(
     void)
 { 
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
@@ -728,7 +726,7 @@ test_reanimate(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
@@ -781,9 +779,9 @@ test_reuse(
     const char* binder_dev = GBINDER_DEFAULT_BINDER;
     const char* vndbinder_dev = "/dev/vpnbinder";
     const char* hwbinder_dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* binder_ipc = gbinder_ipc_new(binder_dev, NULL);
-    GBinderIpc* vndbinder_ipc = gbinder_ipc_new(vndbinder_dev, NULL);
-    GBinderIpc* hwbinder_ipc = gbinder_ipc_new(hwbinder_dev, NULL);
+    GBinderIpc* binder_ipc = gbinder_ipc_new(binder_dev);
+    GBinderIpc* vndbinder_ipc = gbinder_ipc_new(vndbinder_dev);
+    GBinderIpc* hwbinder_ipc = gbinder_ipc_new(hwbinder_dev);
     GBinderServiceManager* m1;
     GBinderServiceManager* m2;
     GBinderServiceManager* vnd1;
@@ -835,7 +833,7 @@ test_notify_type(
     GType t,
     const char* dev)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
     const char* name = "foo";
@@ -902,7 +900,7 @@ test_list(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
@@ -950,7 +948,7 @@ test_get(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
@@ -1011,7 +1009,7 @@ test_add(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServiceManager* sm;
     TestHwServiceManager* test;

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -211,14 +211,22 @@ test_servicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_servicemanager_finalize;
 }
 
+/* Avoid pulling in the actual objects */
+
 GType
-gbinder_servicemanager_hidl_get_type()
+gbinder_servicemanager_aidl_get_type()
 {
     return TEST_TYPE_SERVICEMANAGER;
 }
 
 GType
-gbinder_servicemanager_aidl_get_type()
+gbinder_servicemanager_aidl2_get_type()
+{
+    return TEST_TYPE_SERVICEMANAGER;
+}
+
+GType
+gbinder_servicemanager_hidl_get_type()
 {
     return TEST_TYPE_SERVICEMANAGER;
 }

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -211,18 +211,16 @@ test_servicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_servicemanager_finalize;
 }
 
-GBinderServiceManager*
-gbinder_defaultservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_hidl_get_type()
 {
-    return gbinder_servicemanager_new_with_type(TEST_TYPE_SERVICEMANAGER, dev);
+    return TEST_TYPE_SERVICEMANAGER;
 }
 
-GBinderServiceManager*
-gbinder_hwservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_aidl_get_type()
 {
-    return gbinder_servicemanager_new(dev);
+    return TEST_TYPE_SERVICEMANAGER;
 }
 
 /*==========================================================================*

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019 Jolla Ltd.
- * Copyright (C) 2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2020 Jolla Ltd.
+ * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -202,7 +202,6 @@ test_servicemanager_class_init(
 {
     klass->iface = TEST_SERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_binder;
     klass->list = test_servicemanager_list;
     klass->get_service = test_servicemanager_get_service;
     klass->add_service = test_servicemanager_add_service;
@@ -236,7 +235,7 @@ test_null(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderServiceManager* sm;
 
     test_setup_ping(ipc);
@@ -263,7 +262,7 @@ test_basic(
     const char* obj_name = "test";
     const char* dev = GBINDER_DEFAULT_BINDER;
     const char* const ifaces[] = { "interface", NULL };
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj;
     GBinderServiceManager* sm;
@@ -306,7 +305,7 @@ test_present(
     const char* obj_name = "test";
     const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj;
@@ -371,7 +370,7 @@ test_not_present(
     const char* obj_name = "test";
     const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj;
@@ -421,7 +420,7 @@ test_cancel(
     const char* obj_name = "test";
     const char* const ifaces[] = { "interface", NULL };
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj;

--- a/unit/unit_servicepoll/unit_servicepoll.c
+++ b/unit/unit_servicepoll/unit_servicepoll.c
@@ -183,18 +183,16 @@ test_servicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_servicemanager_finalize;
 }
 
-GBinderServiceManager*
-gbinder_defaultservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_hidl_get_type()
 {
-    return gbinder_servicemanager_new_with_type(TEST_TYPE_SERVICEMANAGER, dev);
+    return TEST_TYPE_SERVICEMANAGER;
 }
 
-GBinderServiceManager*
-gbinder_hwservicemanager_new(
-    const char* dev)
+GType
+gbinder_servicemanager_aidl_get_type()
 {
-    return gbinder_servicemanager_new(dev);
+    return TEST_TYPE_SERVICEMANAGER;
 }
 
 /*==========================================================================*

--- a/unit/unit_servicepoll/unit_servicepoll.c
+++ b/unit/unit_servicepoll/unit_servicepoll.c
@@ -183,14 +183,22 @@ test_servicemanager_class_init(
     G_OBJECT_CLASS(klass)->finalize = test_servicemanager_finalize;
 }
 
+/* Avoid pulling in the actual objects */
+
 GType
-gbinder_servicemanager_hidl_get_type()
+gbinder_servicemanager_aidl_get_type()
 {
     return TEST_TYPE_SERVICEMANAGER;
 }
 
 GType
-gbinder_servicemanager_aidl_get_type()
+gbinder_servicemanager_aidl2_get_type()
+{
+    return TEST_TYPE_SERVICEMANAGER;
+}
+
+GType
+gbinder_servicemanager_hidl_get_type()
 {
     return TEST_TYPE_SERVICEMANAGER;
 }

--- a/unit/unit_servicepoll/unit_servicepoll.c
+++ b/unit/unit_servicepoll/unit_servicepoll.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2020 Jolla Ltd.
+ * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -174,7 +174,6 @@ test_servicemanager_class_init(
 {
     klass->iface = TEST_SERVICEMANAGER_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
-    klass->rpc_protocol = &gbinder_rpc_protocol_binder;
     klass->list = test_servicemanager_list;
     klass->get_service = test_servicemanager_get_service;
     klass->add_service = test_servicemanager_add_service;
@@ -225,7 +224,7 @@ test_basic(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GBinderServicePoll* weakptr = NULL;
     GBinderServiceManager* manager;
     GBinderServicePoll* poll;
@@ -301,7 +300,7 @@ test_notify1(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServicePoll* weakptr = NULL;
     GBinderServiceManager* manager;
@@ -375,7 +374,7 @@ test_notify2(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServicePoll* weakptr = NULL;
     GBinderServiceManager* manager;
@@ -434,7 +433,7 @@ test_already_there(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderServicePoll* weakptr = NULL;
     GBinderServiceManager* manager;


### PR DESCRIPTION
Available service managers are `aidl`, `aidl2` (API level 28+) and `hidl`, protocols are `aidl`, `aidl2` (API level 29+) and `hidl`. Configuration is pulled from `/etc/gbinder.conf`, the default is
```ini
[Protocol]
Default = aidl
/dev/binder = aidl
/dev/hwbinder = hidl

[ServiceManager]
Default = aidl
/dev/binder = aidl
/dev/hwbinder = hidl
```
Alternatively, one could specify Android API level:
```ini
[General]
ApiLevel = 29
```
and that will choose protocol/servicemanager combination appropriate for that API level.