### PR TITLE
Fix random unit text failures

### DIFF
--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -208,6 +208,7 @@ test_dead(
 
     gbinder_client_unref(client);
     g_main_loop_unref(loop);
+    gbinder_ipc_exit();
 }
 
 /*==========================================================================*

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -642,6 +642,7 @@ test_increfs(
     gbinder_local_object_remove_handler(obj, id);
     gbinder_local_object_unref(obj);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 
@@ -685,6 +686,7 @@ test_decrefs(
     gbinder_local_object_remove_handler(obj, id);
     gbinder_local_object_unref(obj);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 
@@ -726,6 +728,7 @@ test_acquire(
     gbinder_local_object_remove_handler(obj, id);
     gbinder_local_object_unref(obj);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 
@@ -768,6 +771,7 @@ test_release(
     gbinder_local_object_remove_handler(obj, id);
     gbinder_local_object_unref(obj);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 

--- a/unit/unit_remote_object/unit_remote_object.c
+++ b/unit/unit_remote_object/unit_remote_object.c
@@ -128,6 +128,7 @@ test_dead(
     gbinder_remote_object_remove_handler(obj, 0); /* has no effect */
     gbinder_remote_object_unref(obj);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -815,6 +815,7 @@ test_death(
     gbinder_servicemanager_remove_all_handlers(sm, id);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 
@@ -886,6 +887,7 @@ test_reanimate(
     gbinder_servicemanager_remove_all_handlers(sm, id);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 

--- a/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
+++ b/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
@@ -276,6 +276,7 @@ test_get()
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     test_binder_exit_wait();
     g_main_loop_unref(loop);
 }
@@ -353,6 +354,7 @@ test_list()
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     test_binder_exit_wait();
 
     g_strfreev(test.list);
@@ -415,6 +417,7 @@ test_notify()
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
     test_binder_exit_wait();
     g_main_loop_unref(loop);
 }

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -345,6 +345,7 @@ test_present(
     gbinder_ipc_unref(ipc);
     test_run(&test_opt, loop);
 
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 
@@ -474,6 +475,7 @@ test_cancel(
     gbinder_ipc_unref(ipc);
     test_run(&test_opt, loop);
 
+    gbinder_ipc_exit();
     g_main_loop_unref(loop);
 }
 


### PR DESCRIPTION
If a test calls `test_binder_set_looper_enabled(fd, TRUE)` to enable processing of incoming data by the looper thread, the same thread may get picked up by the next test and swallow the reply before the transaction (for which the reply was intended) has been submitted. Which may cause that next test to either fail or (if the transaction was synchronous) block forever, stalling the build.

Calling `gbinder_ipc_exit()` makes sure that looper thread terminates before the next test starts.
