### PR TITLE
Fix a threading issue + assorted changes

### DIFF
--- a/src/gbinder_client_p.h
+++ b/src/gbinder_client_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -40,6 +40,24 @@
 struct gbinder_client {
     GBinderRemoteObject* remote;
 };
+
+GBinderRemoteReply*
+gbinder_client_transact_sync_reply2(
+    GBinderClient* self,
+    guint32 code,
+    GBinderLocalRequest* req,
+    int* status,
+    const GBinderIpcSyncApi* api)
+    G_GNUC_WARN_UNUSED_RESULT
+    GBINDER_INTERNAL;
+
+int
+gbinder_client_transact_sync_oneway2(
+    GBinderClient* self,
+    guint32 code,
+    GBinderLocalRequest* req,
+    const GBinderIpcSyncApi* api)
+    GBINDER_INTERNAL;
 
 #define gbinder_client_ipc(client) ((client)->remote->ipc)
 

--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -397,6 +397,15 @@ GBINDER_IO_FN(decode_binder_object)(
                 *out = gbinder_object_registry_get_remote(reg, obj->handle);
             }
             return sizeof(*obj);
+        case BINDER_TYPE_BINDER:
+            if (!obj->binder) {
+                /* That's a NULL reference */
+                if (out) {
+                    *out = NULL;
+                }
+                return sizeof(*obj);
+            }
+            /* fallthrough */
         default:
             GERR("Unsupported binder object type 0x%08x", obj->hdr.type);
             break;

--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -118,7 +118,7 @@ GBINDER_IO_FN(encode_pointer)(
     return sizeof(*dest);
 }
 
-/* Encodes flat_buffer_object */
+/* Encodes flat_binder_object */
 static
 guint
 GBINDER_IO_FN(encode_local_object)(
@@ -163,12 +163,12 @@ GBINDER_IO_FN(encode_fd_object)(
     void* out,
     int fd)
 {
-    struct flat_binder_object* dest = out;
+    struct binder_fd_object* dest = out;
 
     memset(dest, 0, sizeof(*dest));
     dest->hdr.type = BINDER_TYPE_FD;
-    dest->flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
-    dest->handle = fd;
+    dest->pad_flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
+    dest->fd = fd;
     return sizeof(*dest);
 }
 
@@ -226,9 +226,7 @@ GBINDER_IO_FN(fill_transaction_data)(
     tr->code = code;
     tr->data_size = payload->len;
     tr->data.ptr.buffer = (uintptr_t)payload->data;
-    if (flags & GBINDER_TX_FLAG_ONEWAY) {
-        tr->flags |= TF_ONE_WAY;
-    }
+    tr->flags |= (flags & GBINDER_TX_FLAG_ONEWAY) ? TF_ONE_WAY : TF_ACCEPT_FDS;
     if (offsets && offsets->count) {
         guint i;
         binder_size_t* tx_offsets = g_new(binder_size_t, offsets->count);

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -67,6 +67,31 @@ void
     int status,
     void* user_data);
 
+typedef
+GBinderRemoteReply*
+(*GBinderIpcSyncReplyFunc)(
+    GBinderIpc* ipc,
+    guint32 handle,
+    guint32 code,
+    GBinderLocalRequest* req,
+    int* status);
+
+typedef
+int
+(*GBinderIpcSyncOnewayFunc)(
+    GBinderIpc* ipc,
+    guint32 handle,
+    guint32 code,
+    GBinderLocalRequest* req);
+
+struct gbinder_ipc_sync_api {
+    GBinderIpcSyncReplyFunc sync_reply;
+    GBinderIpcSyncOnewayFunc sync_oneway;
+};
+
+extern const GBinderIpcSyncApi gbinder_ipc_sync_main GBINDER_INTERNAL;
+extern const GBinderIpcSyncApi gbinder_ipc_sync_worker GBINDER_INTERNAL;
+
 GBinderIpc*
 gbinder_ipc_new(
     const char* dev)
@@ -109,23 +134,6 @@ void
 gbinder_ipc_invalidate_remote_handle(
     GBinderIpc* ipc,
     guint32 handle)
-    GBINDER_INTERNAL;
-
-GBinderRemoteReply*
-gbinder_ipc_transact_sync_reply(
-    GBinderIpc* ipc,
-    guint32 handle,
-    guint32 code,
-    GBinderLocalRequest* req,
-    int* status)
-    GBINDER_INTERNAL;
-
-int
-gbinder_ipc_transact_sync_oneway(
-    GBinderIpc* ipc,
-    guint32 handle,
-    guint32 code,
-    GBinderLocalRequest* req)
     GBINDER_INTERNAL;
 
 gulong

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -199,7 +199,8 @@ gbinder_servicemanager_list_tx_exec(
 {
     GBinderServiceManagerListTxData* data = tx->user_data;
 
-    data->result = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->list(data->sm);
+    data->result = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->
+        list(data->sm, &gbinder_ipc_sync_worker);
 }
 
 static
@@ -243,8 +244,9 @@ gbinder_servicemanager_get_service_tx_exec(
 {
     GBinderServiceManagerGetServiceTxData* data = tx->user_data;
 
-    data->obj = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->get_service
-            (data->sm, data->name, &data->status);
+    data->obj = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->
+        get_service(data->sm, data->name, &data->status,
+            &gbinder_ipc_sync_worker);
 }
 
 static
@@ -286,8 +288,8 @@ gbinder_servicemanager_add_service_tx_exec(
 {
     GBinderServiceManagerAddServiceTxData* data = tx->user_data;
 
-    data->status = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->add_service
-            (data->sm, data->name, data->obj);
+    data->status = GBINDER_SERVICEMANAGER_GET_CLASS(data->sm)->
+        add_service(data->sm, data->name, data->obj, &gbinder_ipc_sync_worker);
 }
 
 static
@@ -776,7 +778,8 @@ gbinder_servicemanager_list_sync(
     GBinderServiceManager* self)
 {
     if (G_LIKELY(self)) {
-        return GBINDER_SERVICEMANAGER_GET_CLASS(self)->list(self);
+        return GBINDER_SERVICEMANAGER_GET_CLASS(self)->
+            list(self, &gbinder_ipc_sync_main);
     }
     return NULL;
 }
@@ -815,8 +818,8 @@ gbinder_servicemanager_get_service_sync(
     GBinderRemoteObject* obj = NULL;
 
     if (G_LIKELY(self) && name) {
-        obj = GBINDER_SERVICEMANAGER_GET_CLASS(self)->get_service
-            (self, name, status);
+        obj = GBINDER_SERVICEMANAGER_GET_CLASS(self)->
+            get_service(self, name, status, &gbinder_ipc_sync_main);
         if (obj) {
             GBinderServiceManagerPriv* priv = self->priv;
 
@@ -866,8 +869,8 @@ gbinder_servicemanager_add_service_sync(
     GBinderLocalObject* obj)
 {
     if (G_LIKELY(self) && name && obj) {
-        return GBINDER_SERVICEMANAGER_GET_CLASS(self)->add_service
-            (self, name, obj);
+        return GBINDER_SERVICEMANAGER_GET_CLASS(self)->
+            add_service(self, name, obj, &gbinder_ipc_sync_main);
     } else {
         return (-EINVAL);
     }

--- a/src/gbinder_servicemanager_hidl.c
+++ b/src/gbinder_servicemanager_hidl.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -31,9 +31,9 @@
  */
 
 #include "gbinder_servicemanager_p.h"
+#include "gbinder_client_p.h"
 #include "gbinder_log.h"
 
-#include <gbinder_client.h>
 #include <gbinder_local_object.h>
 #include <gbinder_local_request.h>
 #include <gbinder_remote_reply.h>
@@ -147,11 +147,12 @@ gbinder_servicemanager_hidl_notification(
 static
 char**
 gbinder_servicemanager_hidl_list(
-    GBinderServiceManager* self)
+    GBinderServiceManager* self,
+    const GBinderIpcSyncApi* api)
 {
     GBinderLocalRequest* req = gbinder_client_new_request(self->client);
-    GBinderRemoteReply* reply = gbinder_client_transact_sync_reply
-        (self->client, LIST_TRANSACTION, req, NULL);
+    GBinderRemoteReply* reply = gbinder_client_transact_sync_reply2
+        (self->client, LIST_TRANSACTION, req, NULL, api);
 
     gbinder_local_request_unref(req);
     if (reply) {
@@ -178,7 +179,8 @@ GBinderRemoteObject*
 gbinder_servicemanager_hidl_get_service(
     GBinderServiceManager* self,
     const char* fqinstance,
-    int* status)
+    int* status,
+    const GBinderIpcSyncApi* api)
 {
     /* e.g. "android.hardware.radio@1.1::IRadio/slot1" */
     const char* sep = strchr(fqinstance, '/');
@@ -193,8 +195,8 @@ gbinder_servicemanager_hidl_get_service(
         gbinder_local_request_append_hidl_string(req, fqname);
         gbinder_local_request_append_hidl_string(req, name);
 
-        reply = gbinder_client_transact_sync_reply(self->client,
-            GET_TRANSACTION, req, status);
+        reply = gbinder_client_transact_sync_reply2(self->client,
+            GET_TRANSACTION, req, status, api);
 
         if (reply) {
             GBinderReader reader;
@@ -225,7 +227,8 @@ int
 gbinder_servicemanager_hidl_add_service(
     GBinderServiceManager* self,
     const char* name,
-    GBinderLocalObject* obj)
+    GBinderLocalObject* obj,
+    const GBinderIpcSyncApi* api)
 {
     int status;
     GBinderRemoteReply* reply;
@@ -235,8 +238,8 @@ gbinder_servicemanager_hidl_add_service(
     gbinder_local_request_append_hidl_string(req, name);
     gbinder_local_request_append_local_object(req, obj);
 
-    reply = gbinder_client_transact_sync_reply(self->client,
-        ADD_TRANSACTION, req, &status);
+    reply = gbinder_client_transact_sync_reply2(self->client,
+        ADD_TRANSACTION, req, &status, api);
 
     gbinder_remote_reply_unref(reply);
     gbinder_local_request_unref(req);

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -66,12 +66,11 @@ typedef struct gbinder_servicemanager_class {
     const char* default_device;
 
     /* Methods (synchronous) */
-    char** (*list)(GBinderServiceManager* self);
-    GBinderRemoteObject* (*get_service)
-        (GBinderServiceManager* self, const char* name, int* status);
-    int (*add_service)
-        (GBinderServiceManager* self, const char* name,
-            GBinderLocalObject* obj);
+    char** (*list)(GBinderServiceManager* self, const GBinderIpcSyncApi* api);
+    GBinderRemoteObject* (*get_service)(GBinderServiceManager* self,
+        const char* name, int* status, const GBinderIpcSyncApi* api);
+    int (*add_service)(GBinderServiceManager* self, const char* name,
+        GBinderLocalObject* obj, const GBinderIpcSyncApi* api);
 
     /* Checking/normalizing watch names */
     GBINDER_SERVICEMANAGER_NAME_CHECK (*check_name)

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -45,6 +45,7 @@ typedef struct gbinder_output_data GBinderOutputData;
 typedef struct gbinder_rpc_protocol GBinderRpcProtocol;
 typedef struct gbinder_servicepoll GBinderServicePoll;
 typedef struct gbinder_ipc_looper_tx GBinderIpcLooperTx;
+typedef struct gbinder_ipc_sync_api GBinderIpcSyncApi;
 
 #define GBINDER_INLINE_FUNC static inline
 #define GBINDER_INTERNAL G_GNUC_INTERNAL

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -21,6 +21,7 @@ all:
 	@$(MAKE) -C unit_servicemanager $*
 	@$(MAKE) -C unit_servicemanager_aidl $*
 	@$(MAKE) -C unit_servicemanager_aidl2 $*
+	@$(MAKE) -C unit_servicemanager_hidl $*
 	@$(MAKE) -C unit_servicename $*
 	@$(MAKE) -C unit_servicepoll $*
 	@$(MAKE) -C unit_writer $*

--- a/unit/common/test_servicemanager_hidl.c
+++ b/unit/common/test_servicemanager_hidl.c
@@ -1,0 +1,421 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_servicemanager_hidl.h"
+
+#include "gbinder_local_object_p.h"
+#include "gbinder_local_object_p.h"
+#include "gbinder_local_reply.h"
+#include "gbinder_local_request.h"
+#include "gbinder_remote_request.h"
+#include "gbinder_remote_object_p.h"
+#include "gbinder_reader.h"
+#include "gbinder_writer.h"
+#include "gbinder_cleanup.h"
+#include "gbinder_client_p.h"
+#include "gbinder_driver.h"
+#include "gbinder_ipc.h"
+
+#include <gutil_log.h>
+#include <gutil_strv.h>
+
+/*==========================================================================*
+ * Test service manager
+ *==========================================================================*/
+
+#define SVCMGR_IFACE "android.hidl.manager@1.0::IServiceManager"
+#define NOTIFICATION_IFACE "android.hidl.manager@1.0::IServiceNotification"
+
+const char* const servicemanager_hidl_ifaces[] = { SVCMGR_IFACE, NULL };
+
+enum servicemanager_hidl_tx {
+    GET_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION,
+    ADD_TRANSACTION,
+    GET_TRANSPORT_TRANSACTION,
+    LIST_TRANSACTION,
+    LIST_BY_INTERFACE_TRANSACTION,
+    REGISTER_FOR_NOTIFICATIONS_TRANSACTION,
+    DEBUG_DUMP_TRANSACTION,
+    REGISTER_PASSTHROUGH_CLIENT_TRANSACTION
+};
+
+enum servicemanager_hidl_notify_tx {
+    ON_REGISTRATION_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION
+};
+
+typedef GBinderLocalObjectClass TestServiceManagerHidlClass;
+struct test_servicemanager_hidl {
+    GBinderLocalObject parent;
+    GHashTable* objects;
+    GPtrArray* watchers;
+    GBinderCleanup* cleanup;
+    gboolean handle_on_looper_thread;
+};
+
+#define THIS_TYPE test_servicemanager_hidl_get_type()
+#define PARENT_CLASS test_servicemanager_hidl_parent_class
+#define THIS(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), THIS_TYPE, \
+    TestServiceManagerHidl))
+G_DEFINE_TYPE(TestServiceManagerHidl, test_servicemanager_hidl, \
+    GBINDER_TYPE_LOCAL_OBJECT)
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_get(
+    TestServiceManagerHidl* self,
+    GBinderRemoteRequest* req)
+{
+    GBinderRemoteObject* remote_obj;
+    GBinderLocalReply* reply =
+        gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
+    GBinderReader reader;
+    GBinderWriter writer;
+    const char* ifname;
+    const char* instance;
+    char* fqinstance;
+
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert((ifname = gbinder_reader_read_hidl_string_c(&reader)));
+    g_assert((instance = gbinder_reader_read_hidl_string_c(&reader)));
+    fqinstance = g_strconcat(ifname, "/", instance, NULL);
+
+    remote_obj = g_hash_table_lookup(self->objects, fqinstance);
+    gbinder_local_reply_init_writer(reply, &writer);
+    gbinder_local_reply_append_int32(reply, GBINDER_STATUS_OK);
+    if (remote_obj) {
+        GDEBUG("Found name '%s' => %p", fqinstance, remote_obj);
+    } else {
+        GDEBUG("Name '%s' not found", fqinstance);
+    }
+    gbinder_local_reply_append_remote_object(reply, remote_obj);
+    g_free(fqinstance);
+    return reply;
+}
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_add(
+    TestServiceManagerHidl* self,
+    GBinderRemoteRequest* req)
+{
+    GBinderRemoteObject* remote_obj;
+    GBinderLocalReply* reply =
+        gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
+    GBinderReader reader;
+    const char* fqname;
+    gboolean success;
+
+    gbinder_remote_request_init_reader(req, &reader);
+    fqname = gbinder_reader_read_hidl_string_c(&reader);
+    remote_obj = gbinder_reader_read_object(&reader);
+
+    if (fqname && remote_obj) {
+        const char* sep = strchr(fqname, '/');
+        GPtrArray* watchers = self->watchers;
+        guint i;
+
+        GDEBUG("Adding '%s'", fqname);
+        g_hash_table_replace(self->objects, g_strdup(fqname), remote_obj);
+
+        /* For unit test purposes, just always notify all watchers */
+        for (i = 0; i < watchers->len; i++) {
+            char* iface = g_strndup(fqname, sep - fqname);
+            char* name = g_strdup(sep + 1);
+            GBinderClient* client = watchers->pdata[i];
+            GBinderLocalRequest* notify = gbinder_client_new_request(client);
+            GBinderWriter writer;
+
+            gbinder_local_request_init_writer(notify, &writer);
+            gbinder_writer_append_hidl_string(&writer, iface);
+            gbinder_writer_append_hidl_string(&writer, name);
+            gbinder_writer_append_bool(&writer, FALSE);
+
+            gbinder_writer_add_cleanup(&writer, g_free, iface);
+            gbinder_writer_add_cleanup(&writer, g_free, name);
+            
+            gbinder_client_transact(client, ON_REGISTRATION_TRANSACTION,
+                GBINDER_TX_FLAG_ONEWAY, notify, NULL, NULL, NULL);
+
+            /* Keep it alive longer than libgbinder needs it */
+            self->cleanup = gbinder_cleanup_add(self->cleanup, (GDestroyNotify)
+                gbinder_local_request_unref, notify);
+        }
+        success = TRUE;
+    } else {
+        gbinder_remote_object_unref(remote_obj);
+        success = FALSE;
+    }
+
+    gbinder_local_reply_append_bool(reply, success);
+    return reply;
+}
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_list(
+    TestServiceManagerHidl* self,
+    GBinderRemoteRequest* req)
+{
+    GHashTableIter it;
+    GBinderReader reader;
+    GBinderWriter writer;
+    GBinderLocalReply* reply =
+        gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
+    gpointer key;
+    char** list = NULL;
+
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    g_hash_table_iter_init(&it, self->objects);
+    while (g_hash_table_iter_next(&it, &key, NULL)) {
+        list = gutil_strv_add(list, key);
+    }
+
+    gbinder_local_reply_init_writer(reply, &writer);
+    gbinder_writer_append_int32(&writer, 0);
+    gbinder_writer_append_hidl_string_vec(&writer, (const char**) list, -1);
+    gbinder_writer_add_cleanup(&writer, (GDestroyNotify) g_strfreev, list);
+    return reply;
+}
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_register_for_notifications(
+    TestServiceManagerHidl* self,
+    GBinderRemoteRequest* req)
+{
+    GBinderRemoteObject* watcher;
+    GBinderLocalReply* reply =
+        gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
+    GBinderReader reader;
+    const char* fqname;
+    const char* instance;
+    gboolean success;
+
+    gbinder_remote_request_init_reader(req, &reader);
+    fqname = gbinder_reader_read_hidl_string_c(&reader);
+    instance = gbinder_reader_read_hidl_string_c(&reader);
+    watcher = gbinder_reader_read_object(&reader);
+ 
+    if (watcher) {
+        GDEBUG("Registering watcher %s/%s", fqname, instance);
+        g_ptr_array_add(self->watchers, gbinder_client_new(watcher,
+            NOTIFICATION_IFACE));
+        gbinder_remote_object_unref(watcher); /* Client keeps the reference */
+        success = TRUE;
+    } else {
+        success = FALSE;
+    }
+
+    gbinder_local_reply_append_int32(reply, 0);
+    gbinder_local_reply_append_bool(reply, success);
+    return reply;
+}
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_handler(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    TestServiceManagerHidl* self = THIS(user_data);
+    GBinderLocalReply* reply = NULL;
+
+    g_assert(!flags);
+    g_assert_cmpstr(gbinder_remote_request_interface(req), == ,SVCMGR_IFACE);
+    *status = -1;
+    gbinder_cleanup_reset(self->cleanup);
+    switch (code) {
+    case GET_TRANSACTION:
+        reply = test_servicemanager_hidl_get(self, req);
+        break;
+    case ADD_TRANSACTION:
+        reply = test_servicemanager_hidl_add(self, req);
+        break;
+    case LIST_TRANSACTION:
+        reply = test_servicemanager_hidl_list(self, req);
+        break;
+    case REGISTER_FOR_NOTIFICATIONS_TRANSACTION:
+        reply = test_servicemanager_hidl_register_for_notifications(self, req);
+        break;
+    default:
+        GDEBUG("Unhandled command %u", code);
+        break;
+    }
+    /* If we don't defer deallocation of the reply, its buffers may get
+     * deallocated too early. */
+    if (reply) {
+        self->cleanup = gbinder_cleanup_add(self->cleanup, (GDestroyNotify)
+            gbinder_local_reply_unref, gbinder_local_reply_ref(reply));
+    }
+    return reply;
+}
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+TestServiceManagerHidl*
+test_servicemanager_hidl_new(
+    GBinderIpc* ipc,
+    gboolean handle_on_looper_thread)
+{
+    TestServiceManagerHidl* self = g_object_new(THIS_TYPE, NULL);
+    GBinderLocalObject* obj = GBINDER_LOCAL_OBJECT(self);
+
+    self->handle_on_looper_thread = handle_on_looper_thread;
+    gbinder_local_object_init_base(obj, ipc, servicemanager_hidl_ifaces,
+        test_servicemanager_hidl_handler, self);
+    gbinder_ipc_register_local_object(ipc, obj);
+    return self;
+}
+
+void
+test_servicemanager_hidl_free(
+    TestServiceManagerHidl* self)
+{
+    gbinder_cleanup_reset(self->cleanup);
+    gbinder_local_object_drop(GBINDER_LOCAL_OBJECT(self));
+}
+
+GBinderIpc*
+test_servicemanager_hidl_ipc(
+    TestServiceManagerHidl* self)
+{
+    return self ? self->parent.ipc : 0;
+}
+
+guint
+test_servicemanager_hidl_object_count(
+    TestServiceManagerHidl* self)
+{
+    return self ? g_hash_table_size(self->objects) : 0;
+}
+
+GBinderRemoteObject*
+test_servicemanager_hidl_lookup(
+    TestServiceManagerHidl* self,
+    const char* name)
+{
+    return self ? g_hash_table_lookup(self->objects, name) : NULL;
+}
+
+/*==========================================================================*
+ * Internals
+ *==========================================================================*/
+
+static
+GBINDER_LOCAL_TRANSACTION_SUPPORT
+test_servicemanager_hidl_can_handle_transaction(
+    GBinderLocalObject* object,
+    const char* iface,
+    guint code)
+{
+    TestServiceManagerHidl* self = THIS(object);
+
+    if (self->handle_on_looper_thread && !g_strcmp0(SVCMGR_IFACE, iface)) {
+        return GBINDER_LOCAL_TRANSACTION_LOOPER;
+    } else {
+        return GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->
+            can_handle_transaction(object, iface, code);
+    }
+}
+
+static
+GBinderLocalReply*
+test_servicemanager_hidl_handle_looper_transaction(
+    GBinderLocalObject* object,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status)
+{
+    if (!g_strcmp0(gbinder_remote_request_interface(req), SVCMGR_IFACE)) {
+        return GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->
+            handle_transaction(object, req, code, flags, status);
+    } else {
+        return GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->
+            handle_looper_transaction(object, req, code, flags, status);
+    }
+}
+
+static
+void
+test_servicemanager_hidl_finalize(
+    GObject* object)
+{
+    TestServiceManagerHidl* self = THIS(object);
+
+    gbinder_cleanup_free(self->cleanup);
+    g_hash_table_destroy(self->objects);
+    g_ptr_array_free(self->watchers, TRUE);
+    G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
+}
+
+static
+void
+test_servicemanager_hidl_init(
+    TestServiceManagerHidl* self)
+{
+    self->objects = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
+        (GDestroyNotify) gbinder_remote_object_unref);
+    self->watchers = g_ptr_array_new_with_free_func((GDestroyNotify)
+        gbinder_client_unref);
+}
+
+static
+void
+test_servicemanager_hidl_class_init(
+    TestServiceManagerHidlClass* klass)
+{
+    GObjectClass* object = G_OBJECT_CLASS(klass);
+    GBinderLocalObjectClass* local_object = GBINDER_LOCAL_OBJECT_CLASS(klass);
+
+    object->finalize = test_servicemanager_hidl_finalize;
+    local_object->can_handle_transaction =
+        test_servicemanager_hidl_can_handle_transaction;
+    local_object->handle_looper_transaction =
+        test_servicemanager_hidl_handle_looper_transaction;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/common/test_servicemanager_hidl.h
+++ b/unit/common/test_servicemanager_hidl.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef TEST_SERVICEMANAGER_HIDL_H
+#define TEST_SERVICEMANAGER_HIDL_H
+
+#include <gbinder_types.h>
+
+typedef struct test_servicemanager_hidl TestServiceManagerHidl;
+
+TestServiceManagerHidl*
+test_servicemanager_hidl_new(
+    GBinderIpc* ipc,
+    gboolean handle_on_looper_thread);
+
+void
+test_servicemanager_hidl_free(
+    TestServiceManagerHidl* sm);
+
+GBinderIpc*
+test_servicemanager_hidl_ipc(
+    TestServiceManagerHidl* self);
+
+guint
+test_servicemanager_hidl_object_count(
+    TestServiceManagerHidl* self);
+
+GBinderRemoteObject*
+test_servicemanager_hidl_lookup(
+    TestServiceManagerHidl* self,
+    const char* name);
+
+#endif /* TEST_SERVICEMANAGER_HIDL_H */
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -24,6 +24,7 @@ unit_remote_request \
 unit_servicemanager \
 unit_servicemanager_aidl \
 unit_servicemanager_aidl2 \
+unit_servicemanager_hidl \
 unit_servicename \
 unit_servicepoll \
 unit_writer"

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -157,7 +157,8 @@ typedef struct test_servicemanager {
 static
 char**
 test_servicemanager_list(
-    GBinderServiceManager* sm)
+    GBinderServiceManager* sm,
+    const GBinderIpcSyncApi* api)
 {
     TestServiceManager* self = TEST_SERVICEMANAGER(sm);
 
@@ -169,7 +170,8 @@ GBinderRemoteObject*
 test_servicemanager_get_service(
     GBinderServiceManager* sm,
     const char* name,
-    int* status)
+    int* status,
+    const GBinderIpcSyncApi* api)
 {
     TestServiceManager* self = TEST_SERVICEMANAGER(sm);
 
@@ -191,7 +193,8 @@ int
 test_servicemanager_add_service(
     GBinderServiceManager* sm,
     const char* name,
-    GBinderLocalObject* obj)
+    GBinderLocalObject* obj,
+    const GBinderIpcSyncApi* api)
 {
     TestServiceManager* self = TEST_SERVICEMANAGER(sm);
 

--- a/unit/unit_servicemanager_hidl/Makefile
+++ b/unit/unit_servicemanager_hidl/Makefile
@@ -1,0 +1,6 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = unit_servicemanager_hidl
+COMMON_SRC = test_binder.c test_main.c test_servicemanager_hidl.c
+
+include ../common/Makefile

--- a/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
+++ b/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
@@ -1,0 +1,470 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_binder.h"
+#include "test_servicemanager_hidl.h"
+
+#include "gbinder_ipc.h"
+#include "gbinder_cleanup.h"
+#include "gbinder_config.h"
+#include "gbinder_client_p.h"
+#include "gbinder_driver.h"
+#include "gbinder_reader.h"
+#include "gbinder_writer.h"
+#include "gbinder_servicemanager_p.h"
+#include "gbinder_local_object_p.h"
+#include "gbinder_local_reply.h"
+#include "gbinder_local_request.h"
+#include "gbinder_remote_request.h"
+#include "gbinder_remote_object_p.h"
+
+#include <gutil_log.h>
+#include <gutil_strv.h>
+
+static TestOpt test_opt;
+#define MAIN_DEV GBINDER_DEFAULT_HWBINDER
+#define OTHER_DEV GBINDER_DEFAULT_HWBINDER "-private"
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-svcmgr-hidl-XXXXXX";
+static const char DEFAULT_CONFIG_DATA[] =
+    "[Protocol]\n"
+    MAIN_DEV " = hidl\n"
+    OTHER_DEV " = hidl\n"
+    "[ServiceManager]\n"
+    MAIN_DEV " = hidl\n";
+
+typedef struct test_config {
+    char* dir;
+    char* file;
+} TestConfig;
+
+GType
+gbinder_servicemanager_aidl_get_type()
+{
+    /* Avoid pulling in gbinder_servicemanager_aidl object */
+    return 0;
+}
+
+GType
+gbinder_servicemanager_aidl2_get_type()
+{
+    /* Avoid pulling in gbinder_servicemanager_aidl2 object */
+    return 0;
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+static
+void
+test_config_init(
+    TestConfig* config,
+    char* config_data)
+{
+    config->dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    config->file = g_build_filename(config->dir, "test.conf", NULL);
+    g_assert(g_file_set_contents(config->file, config_data ? config_data :
+        DEFAULT_CONFIG_DATA, -1, NULL));
+
+    gbinder_config_exit();
+    gbinder_config_dir = config->dir;
+    gbinder_config_file = config->file;
+    GDEBUG("Wrote config to %s", config->file);
+}
+
+static
+void
+test_config_deinit(
+    TestConfig* config)
+{
+    gbinder_config_exit();
+
+    remove(config->file);
+    g_free(config->file);
+
+    remove(config->dir);
+    g_free(config->dir);
+}
+
+static
+TestServiceManagerHidl*
+test_servicemanager_impl_new(
+    const char* dev,
+    gboolean handle_on_looper_thread)
+{
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    TestServiceManagerHidl* sm =
+        test_servicemanager_hidl_new(ipc, handle_on_looper_thread);
+
+    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_register_object(fd, GBINDER_LOCAL_OBJECT(sm),
+        GBINDER_SERVICEMANAGER_HANDLE);
+    gbinder_ipc_unref(ipc);
+    return sm;
+}
+
+/*==========================================================================*
+ * get
+ *==========================================================================*/
+
+static
+void
+test_add_cb(
+    GBinderServiceManager* sm,
+    int status,
+    void* user_data)
+{
+    GDEBUG("Name added");
+    g_assert(status == GBINDER_STATUS_OK);
+    if (user_data) {
+        g_main_loop_quit(user_data);
+    }
+}
+
+static
+void
+test_get_none_cb(
+    GBinderServiceManager* sm,
+    GBinderRemoteObject* obj,
+    int status,
+    void* user_data)
+{
+    g_assert(!obj);
+    g_assert(status == GBINDER_STATUS_OK);
+    g_main_loop_quit(user_data);
+}
+
+static
+void
+test_get_cb(
+    GBinderServiceManager* sm,
+    GBinderRemoteObject* obj,
+    int status,
+    void* user_data)
+{
+    g_assert(obj);
+    g_assert(status == GBINDER_STATUS_OK);
+    g_main_loop_quit(user_data);
+}
+
+static
+void
+test_get()
+{
+    TestConfig config;
+    GBinderIpc* ipc;
+    TestServiceManagerHidl* smsvc;
+    GBinderLocalObject* obj;
+    int fd;
+    GBinderServiceManager* sm;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    const char* name = "android.hidl.base@1.0::IBase/test";
+
+    test_config_init(&config, NULL);
+    ipc = gbinder_ipc_new(MAIN_DEV);
+    smsvc = test_servicemanager_impl_new(OTHER_DEV, FALSE);
+    obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
+
+    /* Set up binder simulator */
+    test_binder_register_object(fd, obj, AUTO_HANDLE);
+    test_binder_set_passthrough(fd, TRUE);
+    sm = gbinder_servicemanager_new(MAIN_DEV);
+
+    /* This one fails because of unexpected name format */
+    g_assert(!gbinder_servicemanager_get_service_sync(sm, "test", NULL));
+
+    /* Query the object (it's not there yet) and wait for completion */
+    GDEBUG("Querying '%s'", name);
+    g_assert(gbinder_servicemanager_get_service(sm, name, test_get_none_cb,
+        loop));
+    test_run(&test_opt, loop);
+
+    /* Register object and wait for completion */
+    GDEBUG("Registering object '%s' => %p", name, obj);
+    g_assert(gbinder_servicemanager_add_service(sm, name, obj,
+        test_add_cb, loop));
+    test_run(&test_opt, loop);
+
+    g_assert_cmpuint(test_servicemanager_hidl_object_count(smsvc), == ,1);
+    g_assert(test_servicemanager_hidl_lookup(smsvc, name));
+
+    /* Query the object (this time it must be there) and wait for completion */
+    GDEBUG("Querying '%s' again", name);
+    g_assert(gbinder_servicemanager_get_service(sm, name, test_get_cb, loop));
+    test_run(&test_opt, loop);
+
+    test_binder_unregister_objects(fd);
+    gbinder_local_object_unref(obj);
+    test_servicemanager_hidl_free(smsvc);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
+    test_binder_exit_wait();
+    test_config_deinit(&config);
+    g_main_loop_unref(loop);
+}
+
+/*==========================================================================*
+ * list
+ *==========================================================================*/
+
+typedef struct test_list {
+    char** list;
+    GMainLoop* loop;
+} TestList;
+
+static
+gboolean
+test_list_cb(
+    GBinderServiceManager* sm,
+    char** services,
+    void* user_data)
+{
+    TestList* test = user_data;
+
+    GDEBUG("Got %u name(s)", gutil_strv_length(services));
+    g_strfreev(test->list);
+    test->list = services;
+    g_main_loop_quit(test->loop);
+    return TRUE;
+}
+
+static
+void
+test_list()
+{
+    TestList test;
+    TestConfig config;
+    GBinderIpc* ipc;
+    TestServiceManagerHidl* smsvc;
+    GBinderLocalObject* obj;
+    int fd;
+    GBinderServiceManager* sm;
+    const char* name = "android.hidl.base@1.0::IBase/test";
+
+    memset(&test, 0, sizeof(test));
+    test.loop = g_main_loop_new(NULL, FALSE);
+
+    test_config_init(&config, NULL);
+    ipc = gbinder_ipc_new(MAIN_DEV);
+    smsvc = test_servicemanager_impl_new(OTHER_DEV, FALSE);
+    obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
+
+    /* Set up binder simulator */
+    test_binder_register_object(fd, obj, AUTO_HANDLE);
+    test_binder_set_passthrough(fd, TRUE);
+    sm = gbinder_servicemanager_new(MAIN_DEV);
+
+    /* Request the list and wait for completion */
+    g_assert(gbinder_servicemanager_list(sm, test_list_cb, &test));
+    test_run(&test_opt, test.loop);
+
+    /* There's nothing there yet */
+    g_assert(test.list);
+    g_assert(!test.list[0]);
+
+    /* Register object and wait for completion */
+    g_assert(gbinder_servicemanager_add_service(sm, name, obj,
+        test_add_cb, test.loop));
+    test_run(&test_opt, test.loop);
+
+    /* Request the list again */
+    g_assert(gbinder_servicemanager_list(sm, test_list_cb, &test));
+    test_run(&test_opt, test.loop);
+
+    /* Now the name must be there */
+    g_assert_cmpuint(gutil_strv_length(test.list), == ,1);
+    g_assert_cmpstr(test.list[0], == ,name);
+
+    test_binder_unregister_objects(fd);
+    gbinder_local_object_unref(obj);
+    test_servicemanager_hidl_free(smsvc);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
+    test_binder_exit_wait();
+    test_config_deinit(&config);
+
+    g_strfreev(test.list);
+    g_main_loop_unref(test.loop);
+}
+
+/*==========================================================================*
+ * notify
+ *==========================================================================*/
+
+typedef struct test_notify {
+    GMainLoop* loop;
+    TestServiceManagerHidl* smsvc;
+    int notify_count;
+    gboolean name_added;
+} TestNotify;
+
+static
+void
+test_notify_never(
+    GBinderServiceManager* sm,
+    const char* name,
+    void* user_data)
+{
+    g_assert_not_reached();
+}
+
+static
+void
+test_notify_add_cb(
+    GBinderServiceManager* sm,
+    int status,
+    void* user_data)
+{
+    TestNotify* test = user_data;
+
+    GDEBUG("Name added");
+    g_assert(status == GBINDER_STATUS_OK);
+    g_assert(!test->name_added);
+    test->name_added = TRUE;
+    if (test->notify_count) {
+        g_main_loop_quit(test->loop);
+    }
+}
+
+static
+void
+test_notify_cb(
+    GBinderServiceManager* sm,
+    const char* name,
+    void* user_data)
+{
+    TestNotify* test = user_data;
+    GBinderIpc* ipc = test_servicemanager_hidl_ipc(test->smsvc);
+    int fd = gbinder_driver_fd(ipc->driver);
+    
+    g_assert(name);
+    GDEBUG("'%s' is registered", name);
+    g_assert_cmpint(test->notify_count, == ,0);
+    test->notify_count++;
+    /* We want BR_TRANSACTION_COMPLETE to be handled by the transaction
+     * thread, disable the looper before pushing the data. */
+    test_binder_set_looper_enabled(fd, FALSE);
+    test_binder_br_transaction_complete(fd);
+    /* Exit the loop after both things happen */
+    if (test->name_added) {
+        g_main_loop_quit(test->loop);
+    }
+}
+
+static
+void
+test_notify()
+{
+    TestNotify test;
+    TestConfig config;
+    GBinderIpc* ipc;
+    GBinderLocalObject* obj;
+    int fd;
+    GBinderServiceManager* sm;
+    const char* name = "android.hidl.base@1.0::IBase/test";
+    gulong id;
+
+    memset(&test, 0, sizeof(test));
+    test.loop = g_main_loop_new(NULL, FALSE);
+
+    test_config_init(&config, NULL);
+    ipc = gbinder_ipc_new(MAIN_DEV);
+    test.smsvc = test_servicemanager_impl_new(OTHER_DEV, TRUE);
+    obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
+
+    /* Set up binder simulator */
+    test_binder_register_object(fd, obj, AUTO_HANDLE);
+    test_binder_set_passthrough(fd, TRUE);
+    sm = gbinder_servicemanager_new(MAIN_DEV);
+
+    /* This one fails because of invalid names */
+    g_assert(!gbinder_servicemanager_add_registration_handler(sm, NULL,
+        test_notify_never, NULL));
+    g_assert(!gbinder_servicemanager_add_registration_handler(sm, "",
+        test_notify_never, NULL));
+    g_assert(!gbinder_servicemanager_add_registration_handler(sm, ",",
+        test_notify_never, NULL));
+
+    /* Start watching */
+    id = gbinder_servicemanager_add_registration_handler(sm, name,
+        test_notify_cb, &test);
+    g_assert(id);
+
+    /* Register the object and wait for completion */
+    GDEBUG("Registering object '%s' => %p", name, obj);
+    g_assert(gbinder_servicemanager_add_service(sm, name, obj,
+        test_notify_add_cb, &test));
+
+    /* The loop quits after the name is added and notification is received */
+    test_run(&test_opt, test.loop);
+    gbinder_servicemanager_remove_handler(sm, id);
+
+    test_binder_unregister_objects(fd);
+    gbinder_local_object_unref(obj);
+    test_servicemanager_hidl_free(test.smsvc);
+    gbinder_servicemanager_unref(sm);
+    gbinder_ipc_unref(ipc);
+    gbinder_ipc_exit();
+    test_binder_exit_wait();
+    test_config_deinit(&config);
+    g_main_loop_unref(test.loop);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_(t) "/servicemanager_hidl/" t
+
+int main(int argc, char* argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("get"), test_get);
+    g_test_add_func(TEST_("list"), test_list);
+    g_test_add_func(TEST_("notify"), test_notify);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2019-2020 Jolla Ltd.
- * Copyright (C) 2019-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2019-2021 Jolla Ltd.
+ * Copyright (C) 2019-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -101,7 +101,8 @@ G_DEFINE_TYPE(TestServiceManager, test_servicemanager,
 static
 char**
 test_servicemanager_list(
-    GBinderServiceManager* manager)
+    GBinderServiceManager* manager,
+    const GBinderIpcSyncApi* api)
 {
     char** ret;
     TestServiceManager* self = TEST_SERVICEMANAGER(manager);
@@ -118,7 +119,8 @@ GBinderRemoteObject*
 test_servicemanager_get_service(
     GBinderServiceManager* manager,
     const char* name,
-    int* status)
+    int* status,
+    const GBinderIpcSyncApi* api)
 {
     *status = (-ENOENT);
     return NULL;
@@ -129,7 +131,8 @@ int
 test_servicemanager_add_service(
     GBinderServiceManager* manager,
     const char* name,
-    GBinderLocalObject* obj)
+    GBinderLocalObject* obj,
+    const GBinderIpcSyncApi* api)
 {
     TestServiceManager* self = TEST_SERVICEMANAGER(manager);
 

--- a/unit/unit_servicepoll/unit_servicepoll.c
+++ b/unit/unit_servicepoll/unit_servicepoll.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -79,7 +79,8 @@ G_DEFINE_TYPE(TestServiceManager, test_servicemanager,
 static
 char**
 test_servicemanager_list(
-    GBinderServiceManager* manager)
+    GBinderServiceManager* manager,
+    const GBinderIpcSyncApi* api)
 {
     char** ret;
     TestServiceManager* self = TEST_SERVICEMANAGER(manager);
@@ -96,7 +97,8 @@ GBinderRemoteObject*
 test_servicemanager_get_service(
     GBinderServiceManager* manager,
     const char* name,
-    int* status)
+    int* status,
+    const GBinderIpcSyncApi* api)
 {
     *status = (-ENOENT);
     return NULL;
@@ -107,7 +109,8 @@ int
 test_servicemanager_add_service(
     GBinderServiceManager* manager,
     const char* name,
-    GBinderLocalObject* obj)
+    GBinderLocalObject* obj,
+    const GBinderIpcSyncApi* api)
 {
     TestServiceManager* self = TEST_SERVICEMANAGER(manager);
 


### PR DESCRIPTION
The main purpose of this PR is to prevent transaction handlers from being invoked on the worker thread. 

It was possible in cases if an incoming transaction arrives while we are waiting for response from an asynchronous call to servicemanager (which is actually a synchronous call made on a worker thread). It's a no-no. External callbacks must be invoked on the main thread.