### PR TITLE
Add GBinderBridge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,7 @@ LIB = $(LIB_NAME).a
 #
 
 SRC = \
+  gbinder_bridge.c \
   gbinder_buffer.c \
   gbinder_cleanup.c \
   gbinder_client.c \
@@ -88,6 +89,7 @@ SRC = \
   gbinder_local_reply.c \
   gbinder_local_request.c \
   gbinder_log.c \
+  gbinder_proxy_object.c \
   gbinder_reader.c \
   gbinder_remote_object.c \
   gbinder_remote_reply.c \

--- a/include/gbinder.h
+++ b/include/gbinder.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -35,6 +35,7 @@
 
 /* Convenience header to pull in everything at once */
 
+#include "gbinder_bridge.h"
 #include "gbinder_buffer.h"
 #include "gbinder_client.h"
 #include "gbinder_local_object.h"

--- a/include/gbinder_bridge.h
+++ b/include/gbinder_bridge.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,37 +30,51 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GBINDER_LOCAL_REQUEST_PRIVATE_H
-#define GBINDER_LOCAL_REQUEST_PRIVATE_H
+#ifndef GBINDER_BRIDGE_H
+#define GBINDER_BRIDGE_H
 
-#include <gbinder_local_request.h>
+#include "gbinder_types.h"
 
-#include "gbinder_types_p.h"
+/* Since 1.1.4 */
 
-GBinderLocalRequest*
-gbinder_local_request_new(
-    const GBinderIo* io,
-    GBytes* init)
-    GBINDER_INTERNAL;
+/*
+ * As of time of this writing, bridging only works for binder transactions
+ * which only involve passing serialized data back and forth. It doesn't
+ * work with transactions which pass references to remote objects.
+ */
 
-GBinderOutputData*
-gbinder_local_request_data(
-    GBinderLocalRequest* req)
-    GBINDER_INTERNAL;
+G_BEGIN_DECLS
 
-GBinderLocalRequest*
-gbinder_local_request_new_from_data(
-    GBinderBuffer* buffer)
-    GBINDER_INTERNAL;
+/*
+ * A binder bridge object.
+ *
+ * For example, bridging "foobar" with interfaces ["example@1.0::IFoo",
+ * "example@1.0::IBar"] would:
+ *
+ * 1. Watch "example@1.0::IFoo/foobar" and "example@1.0::IBar/foobar" on dest
+ * 2. When those names appears, register objects with the same name on src
+ * 3. Pass calls coming from src to the dest objects and replies in the
+ *    opposite direction
+ * 4. When dest objects disappear, remove the corresponding bridging objects
+ *    from src
+ *
+ * and so on.
+ */
+
+GBinderBridge*
+gbinder_bridge_new(
+    const char* name,
+    const char* const* ifaces,
+    GBinderServiceManager* src,
+    GBinderServiceManager* dest);
 
 void
-gbinder_local_request_append_contents(
-    GBinderLocalRequest* req,
-    GBinderBuffer* buffer,
-    gsize offset)
-    GBINDER_INTERNAL;
+gbinder_bridge_free(
+    GBinderBridge* bridge);
 
-#endif /* GBINDER_LOCAL_REQUEST_PRIVATE_H */
+G_END_DECLS
+
+#endif /* GBINDER_BRIDGE_H */
 
 /*
  * Local Variables:

--- a/include/gbinder_types.h
+++ b/include/gbinder_types.h
@@ -59,6 +59,7 @@ G_BEGIN_DECLS
  * 6. Reader parses the data coming with RemoteRequest and RemoteReply
  */
 
+typedef struct gbinder_bridge GBinderBridge;
 typedef struct gbinder_buffer GBinderBuffer;
 typedef struct gbinder_client GBinderClient;
 typedef struct gbinder_ipc GBinderIpc;

--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -6,7 +6,7 @@ License: BSD
 URL: https://github.com/mer-hybris/libgbinder
 Source: %{name}-%{version}.tar.bz2
 
-%define libglibutil_version 1.0.35
+%define libglibutil_version 1.0.49
 
 BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: pkgconfig(libglibutil) >= %{libglibutil_version}

--- a/src/gbinder_bridge.c
+++ b/src/gbinder_bridge.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gbinder_local_request.h"
+#include "gbinder_local_reply.h"
+#include "gbinder_proxy_object.h"
+#include "gbinder_remote_request_p.h"
+#include "gbinder_remote_reply.h"
+#include "gbinder_remote_object_p.h"
+#include "gbinder_servicename.h"
+#include "gbinder_servicemanager_p.h"
+#include "gbinder_client_p.h"
+#include "gbinder_bridge.h"
+#include "gbinder_ipc.h"
+#include "gbinder_log.h"
+
+#include <gutil_strv.h>
+#include <gutil_macros.h>
+
+#include <errno.h>
+
+typedef struct gbinder_bridge_interface {
+    GBinderBridge* bridge;
+    char* iface;
+    char* fqname;
+    char* name;
+    gulong dest_watch_id;
+    gulong dest_death_id;
+    GBinderRemoteObject* dest_obj;
+    GBinderServiceName* src_name;
+    GBinderProxyObject* proxy;
+} GBinderBridgeInterface;
+
+struct gbinder_bridge {
+    GBinderBridgeInterface** ifaces;
+    GBinderServiceManager* src;
+    GBinderServiceManager* dest;
+};
+
+/*==========================================================================*
+ * Implementation
+ *==========================================================================*/
+
+static
+void
+gbinder_bridge_dest_drop_remote_object(
+    GBinderBridgeInterface* bi)
+{
+    if (bi->dest_obj) {
+        GDEBUG("Detached from %s", bi->fqname);
+        gbinder_remote_object_remove_handler(bi->dest_obj, bi->dest_death_id);
+        gbinder_remote_object_unref(bi->dest_obj);
+        bi->dest_death_id = 0;
+        bi->dest_obj = NULL;
+    }
+}
+
+static
+void
+gbinder_bridge_interface_deactivate(
+    GBinderBridgeInterface* bi)
+{
+    gbinder_bridge_dest_drop_remote_object(bi);
+    if (bi->proxy) {
+        gbinder_local_object_drop(GBINDER_LOCAL_OBJECT(bi->proxy));
+        bi->proxy = NULL;
+    }
+    if (bi->src_name) {
+        gbinder_servicename_unref(bi->src_name);
+    }
+}
+
+static
+void
+gbinder_bridge_interface_free(
+    GBinderBridgeInterface* bi)
+{
+    GBinderBridge* bridge = bi->bridge;
+
+    gbinder_bridge_interface_deactivate(bi);
+    gbinder_servicemanager_remove_handler(bridge->dest, bi->dest_watch_id);
+    g_free(bi->iface);
+    g_free(bi->fqname);
+    g_free(bi->name);
+    gutil_slice_free(bi);
+}
+
+static
+void
+gbinder_bridge_dest_death_proc(
+    GBinderRemoteObject* obj,
+    void* user_data)
+{
+    GBinderBridgeInterface* bi = user_data;
+
+    GDEBUG("%s has died", bi->fqname);
+    gbinder_bridge_dest_drop_remote_object(bi);
+}
+
+static
+void
+gbinder_bridge_interface_activate(
+    GBinderBridgeInterface* bi)
+{
+    GBinderBridge* bridge = bi->bridge;
+    GBinderServiceManager* src = bridge->src;
+    GBinderServiceManager* dest = bridge->dest;
+
+    if (bi->dest_obj && gbinder_remote_object_is_dead(bi->dest_obj)) {
+        gbinder_bridge_dest_drop_remote_object(bi);
+    }
+    if (!bi->dest_obj) {
+        bi->dest_obj = gbinder_servicemanager_get_service_sync(dest,
+            bi->fqname, NULL);
+        if (bi->dest_obj) {
+            GDEBUG("Attached to %s", bi->fqname);
+            gbinder_remote_object_ref(bi->dest_obj);
+            bi->dest_death_id = gbinder_remote_object_add_death_handler
+                (bi->dest_obj, gbinder_bridge_dest_death_proc, bi);
+        }
+    }
+    if (bi->dest_obj && !bi->proxy) {
+        bi->proxy = gbinder_proxy_object_new(gbinder_servicemanager_ipc(src),
+            bi->dest_obj);
+    }
+    if (bi->proxy && !bi->src_name) {
+        bi->src_name = gbinder_servicename_new(src,
+            GBINDER_LOCAL_OBJECT(bi->proxy), bi->name);
+    }
+}
+
+static
+void
+gbinder_bridge_dest_registration_proc(
+    GBinderServiceManager* sm,
+    const char* name,
+    void* user_data)
+{
+    GBinderBridgeInterface* bi = user_data;
+
+    if (!g_strcmp0(name, bi->fqname)) {
+        GDEBUG("%s has been registered", bi->fqname);
+        gbinder_bridge_interface_activate(bi);
+    }
+}
+
+static
+GBinderBridgeInterface*
+gbinder_bridge_interface_new(
+    GBinderBridge* self,
+    const char* name,
+    const char* iface)
+{
+    GBinderBridgeInterface* bi = g_slice_new0(GBinderBridgeInterface);
+
+    bi->bridge = self;
+    bi->iface = g_strdup(iface);
+    bi->fqname = g_strconcat(iface, "/", name, NULL);
+    bi->name = g_strdup(name);
+    bi->dest_watch_id = gbinder_servicemanager_add_registration_handler
+        (self->dest, bi->fqname, gbinder_bridge_dest_registration_proc, bi);
+
+    /* Try to activate at startup */
+    gbinder_bridge_interface_activate(bi);
+    return bi;
+}
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+GBinderBridge*
+gbinder_bridge_new(
+    const char* name,
+    const char* const* ifaces,
+    GBinderServiceManager* src,
+    GBinderServiceManager* dest)
+{
+    const guint n = gutil_strv_length((const GStrV*)ifaces);
+
+    if (G_LIKELY(name) && G_LIKELY(n) && G_LIKELY(src) && G_LIKELY(dest)) {
+        GBinderBridge* self = g_slice_new0(GBinderBridge);
+        guint i;
+
+        self->src = gbinder_servicemanager_ref(src);
+        self->dest = gbinder_servicemanager_ref(dest);
+        self->ifaces = g_new(GBinderBridgeInterface*, n + 1);
+        for (i = 0; i < n; i++) {
+            self->ifaces[i] = gbinder_bridge_interface_new(self,
+                name, ifaces[i]);
+        }
+        self->ifaces[i] = NULL;
+        return self;
+    }
+    return NULL;
+}
+
+void
+gbinder_bridge_free(
+    GBinderBridge* self)
+{
+    if (G_LIKELY(self)) {
+        GBinderBridgeInterface** bi = self->ifaces;
+
+        while (*bi) {
+            gbinder_bridge_interface_free(*bi);
+            bi++;
+        }
+        gbinder_servicemanager_unref(self->src);
+        gbinder_servicemanager_unref(self->dest);
+        g_free(self->ifaces);
+        gutil_slice_free(self);
+    }
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -175,9 +175,11 @@ gbinder_driver_write(
         gbinder_driver_verbose_dump('<',
             buf->ptr +  buf->consumed,
             buf->size - buf->consumed);
-        GVERBOSE_("%u/%u", (guint)buf->consumed, (guint)buf->size);
+        GVERBOSE("gbinder_driver_write(%d) %u/%u", self->fd,
+            (guint)buf->consumed, (guint)buf->size);
         err = self->io->write_read(self->fd, buf, NULL);
-        GVERBOSE_("%u/%u err %d", (guint)buf->consumed, (guint)buf->size, err);
+        GVERBOSE("gbinder_driver_write(%d) %u/%u err %d", self->fd,
+            (guint)buf->consumed, (guint)buf->size, err);
     }
     return err;
 }
@@ -200,21 +202,23 @@ gbinder_driver_write_read(
                     write->ptr +  write->consumed,
                     write->size - write->consumed);
             }
-            GVERBOSE_("write %u/%u read %u/%u",
-              (guint)(write ? write->consumed : 0),
-              (guint)(write ? write->size : 0),
-              (guint)(read ? read->consumed : 0),
-              (guint)(read ? read->size : 0));
+            GVERBOSE("gbinder_driver_write_read(%d) "
+                "write %u/%u read %u/%u", self->fd,
+                (guint)(write ? write->consumed : 0),
+                (guint)(write ? write->size : 0),
+                (guint)(read ? read->consumed : 0),
+                (guint)(read ? read->size : 0));
         }
 #endif /* GUTIL_LOG_VERBOSE */
         err = self->io->write_read(self->fd, write, read);
 #if GUTIL_LOG_VERBOSE
         if (GLOG_ENABLED(GLOG_LEVEL_VERBOSE)) {
-            GVERBOSE_("write %u/%u read %u/%u err %d",
-              (guint)(write ? write->consumed : 0),
-              (guint)(write ? write->size : 0),
-              (guint)(read ? read->consumed : 0),
-              (guint)(read ? read->size : 0), err);
+            GVERBOSE("gbinder_driver_write_read(%d) "
+                "write %u/%u read %u/%u err %d", self->fd,
+                (guint)(write ? write->consumed : 0),
+                (guint)(write ? write->size : 0),
+                (guint)(read ? read->consumed : 0),
+                (guint)(read ? read->size : 0), err);
             if (read) {
                 gbinder_driver_verbose_dump('>',
                     read->ptr + were_consumed,

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -813,6 +813,13 @@ gbinder_driver_io(
     return self->io;
 }
 
+const GBinderRpcProtocol*
+gbinder_driver_protocol(
+    GBinderDriver* self)
+{
+    return self->protocol;
+}
+
 gboolean
 gbinder_driver_request_death_notification(
     GBinderDriver* self,

--- a/src/gbinder_driver.h
+++ b/src/gbinder_driver.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -74,6 +74,11 @@ gbinder_driver_io(
     GBinderDriver* driver)
     GBINDER_INTERNAL;
 
+const GBinderRpcProtocol*
+gbinder_driver_protocol(
+    GBinderDriver* driver)
+    GBINDER_INTERNAL;
+
 gboolean
 gbinder_driver_request_death_notification(
     GBinderDriver* driver,
@@ -112,7 +117,7 @@ gbinder_driver_release(
 
 void
 gbinder_driver_close_fds(
-    GBinderDriver* self,
+    GBinderDriver* driver,
     void** objects,
     const void* end)
     GBINDER_INTERNAL;
@@ -160,7 +165,7 @@ gbinder_driver_ping(
 
 GBinderLocalRequest*
 gbinder_driver_local_request_new(
-    GBinderDriver* self,
+    GBinderDriver* driver,
     const char* iface)
     GBINDER_INTERNAL;
 

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -76,6 +76,7 @@ typedef struct gbinder_local_object_class {
     GBinderLocalReply* (*handle_looper_transaction)
         (GBinderLocalObject* self, GBinderRemoteRequest* req, guint code,
             guint flags, int* status);
+    void (*drop)(GBinderLocalObject* self);
     /* Need to add some placeholders if this class becomes public */
 } GBinderLocalObjectClass;
 
@@ -88,6 +89,15 @@ GType gbinder_local_object_get_type(void) GBINDER_INTERNAL;
 
 #define gbinder_local_object_dev(obj) (gbinder_driver_dev((obj)->ipc->driver))
 #define gbinder_local_object_io(obj) (gbinder_driver_io((obj)->ipc->driver))
+
+GBinderLocalObject*
+gbinder_local_object_new_with_type(
+    GType type,
+    GBinderIpc* ipc,
+    const char* const* ifaces,
+    GBinderLocalTransactFunc txproc,
+    void* user_data)
+    GBINDER_INTERNAL;
 
 void
 gbinder_local_object_init_base(

--- a/src/gbinder_local_reply.c
+++ b/src/gbinder_local_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -94,12 +94,10 @@ gbinder_local_reply_new(
 }
 
 GBinderLocalReply*
-gbinder_local_reply_new_from_data(
+gbinder_local_reply_set_contents(
+    GBinderLocalReply* self,
     GBinderBuffer* buffer)
 {
-    const GBinderIo* io = gbinder_buffer_io(buffer);
-    GBinderLocalReply* self = gbinder_local_reply_new(io);
-
     if (self) {
         gbinder_writer_data_set_contents(&self->data, buffer);
     }

--- a/src/gbinder_local_reply_p.h
+++ b/src/gbinder_local_reply_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -48,7 +48,8 @@ gbinder_local_reply_data(
     GBINDER_INTERNAL;
 
 GBinderLocalReply*
-gbinder_local_reply_new_from_data(
+gbinder_local_reply_set_contents(
+    GBinderLocalReply* reply,
     GBinderBuffer* buffer)
     GBINDER_INTERNAL;
 

--- a/src/gbinder_local_request.c
+++ b/src/gbinder_local_request.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -111,9 +111,20 @@ gbinder_local_request_new_from_data(
         (gbinder_buffer_io(buffer), NULL);
 
     if (self) {
-        gbinder_writer_data_set_contents(&self->data, buffer);
+        gbinder_writer_data_append_contents(&self->data, buffer, 0);
     }
     return self;
+}
+
+void
+gbinder_local_request_append_contents(
+    GBinderLocalRequest* self,
+    GBinderBuffer* buffer,
+    gsize offset)
+{
+    if (self) {
+        gbinder_writer_data_append_contents(&self->data, buffer, offset);
+    }
 }
 
 static

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define GLIB_DISABLE_DEPRECATION_WARNINGS
+
+#include "gbinder_proxy_object.h"
+#include "gbinder_local_object_p.h"
+#include "gbinder_local_request.h"
+#include "gbinder_local_reply.h"
+#include "gbinder_remote_object_p.h"
+#include "gbinder_remote_request_p.h"
+#include "gbinder_remote_reply.h"
+#include "gbinder_ipc.h"
+
+#include <gutil_macros.h>
+
+#include <errno.h>
+
+typedef GBinderLocalObjectClass GBinderProxyObjectClass;
+typedef struct gbinder_proxy_tx GBinderProxyTx;
+
+struct gbinder_proxy_tx {
+    GBinderProxyTx* next;
+    GBinderRemoteRequest* req;
+    GBinderProxyObject* proxy;
+    gulong id;
+};
+
+struct gbinder_proxy_object_priv {
+    gboolean dropped;
+    GBinderProxyTx* tx;
+};
+
+GType gbinder_proxy_object_get_type(void) GBINDER_INTERNAL;
+
+G_DEFINE_TYPE(GBinderProxyObject, gbinder_proxy_object, \
+    GBINDER_TYPE_LOCAL_OBJECT)
+#define PARENT_CLASS gbinder_proxy_object_parent_class
+
+/*==========================================================================*
+ * Implementation
+ *==========================================================================*/
+
+static
+void
+gbinder_proxy_tx_dequeue(
+    GBinderProxyTx* tx)
+{
+    GBinderProxyObject* proxy = tx->proxy;
+
+    if (proxy) {
+        GBinderProxyObjectPriv* priv = proxy->priv;
+
+        if (priv->tx) {
+            if (priv->tx == tx) {
+                priv->tx = tx->next;
+            } else {
+                GBinderProxyTx* prev = priv->tx;
+
+                while (prev->next) {
+                    if (prev->next == tx) {
+                        prev->next = tx->next;
+                        break;
+                    }
+                    prev = prev->next;
+                }
+            }
+        }
+        tx->next = NULL;
+        tx->proxy = NULL;
+        g_object_unref(proxy);
+    }
+}
+
+static
+void
+gbinder_proxy_tx_reply(
+    GBinderIpc* ipc,
+    GBinderRemoteReply* reply,
+    int status,
+    void* user_data)
+{
+    GBinderProxyTx* tx = user_data;
+    GBinderLocalReply* fwd = gbinder_remote_reply_copy_to_local(reply);
+
+    tx->id = 0;
+    gbinder_proxy_tx_dequeue(tx);
+    gbinder_remote_request_complete(tx->req, fwd, status);
+    gbinder_local_reply_unref(fwd);
+}
+
+static
+void
+gbinder_proxy_tx_destroy(
+    gpointer user_data)
+{
+    GBinderProxyTx* tx = user_data;
+
+    gbinder_proxy_tx_dequeue(tx);
+    gbinder_remote_request_unref(tx->req);
+    gutil_slice_free(tx);
+}
+
+static
+GBinderLocalReply*
+gbinder_proxy_object_handle_transaction(
+    GBinderLocalObject* object,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status)
+{
+    GBinderProxyObject* self = GBINDER_PROXY_OBJECT(object);
+    GBinderProxyObjectPriv* priv = self->priv;
+    GBinderRemoteObject* remote = self->remote;
+
+    if (!priv->dropped && !gbinder_remote_object_is_dead(remote)) {
+        GBinderIpc* remote_ipc = remote->ipc;
+        GBinderDriver* remote_driver = remote_ipc->driver;
+        GBinderLocalRequest* fwd =
+            gbinder_remote_request_translate_to_local(req, remote_driver);
+        GBinderProxyTx* tx = g_slice_new0(GBinderProxyTx);
+
+        g_object_ref(tx->proxy = self);
+        tx->req = gbinder_remote_request_ref(req);
+        tx->next = priv->tx;
+        priv->tx = tx;
+
+        /* Mark the incoming request as pending */
+        gbinder_remote_request_block(req);
+
+        /* Forward the transaction */
+        tx->id = gbinder_ipc_transact(remote_ipc, remote->handle, code, flags,
+            fwd , gbinder_proxy_tx_reply, gbinder_proxy_tx_destroy, tx);
+        gbinder_local_request_unref(fwd);
+        *status = GBINDER_STATUS_OK;
+    } else {
+        *status = (-EBADMSG);
+    }
+    return NULL;
+}
+
+static
+GBINDER_LOCAL_TRANSACTION_SUPPORT
+gbinder_proxy_object_can_handle_transaction(
+    GBinderLocalObject* self,
+    const char* iface,
+    guint code)
+{
+    /* Process all transactions on the main thread */
+    return GBINDER_LOCAL_TRANSACTION_SUPPORTED;
+}
+
+static
+void
+gbinder_proxy_object_drop(
+    GBinderLocalObject* object)
+{
+    GBinderProxyObject* self = GBINDER_PROXY_OBJECT(object);
+    GBinderProxyObjectPriv* priv = self->priv;
+
+    priv->dropped = TRUE;
+    GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->drop(object);
+}
+
+/*==========================================================================*
+ * Interface
+ *==========================================================================*/
+
+GBinderProxyObject*
+gbinder_proxy_object_new(
+    GBinderIpc* src,
+    GBinderRemoteObject* remote)
+{
+    if (G_LIKELY(remote)) {
+        /*
+         * We don't need to specify the interface list because all
+         * transactions (including HIDL_GET_DESCRIPTOR_TRANSACTION
+         * and HIDL_DESCRIPTOR_CHAIN_TRANSACTION) are getting forwared
+         * to the remote object.
+         */
+        GBinderLocalObject* object = gbinder_local_object_new_with_type
+            (GBINDER_TYPE_PROXY_OBJECT, src, NULL, NULL, NULL);
+
+        if (object) {
+            GBinderProxyObject* self = GBINDER_PROXY_OBJECT(object);
+
+            self->remote = gbinder_remote_object_ref(remote);
+            return self;
+        }
+    }
+    return NULL;
+}
+
+/*==========================================================================*
+ * Internals
+ *==========================================================================*/
+
+static
+void
+gbinder_proxy_object_finalize(
+    GObject* object)
+{
+    GBinderProxyObject* self = GBINDER_PROXY_OBJECT(object);
+
+    gbinder_remote_object_unref(self->remote);
+    G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
+}
+
+static
+void
+gbinder_proxy_object_init(
+    GBinderProxyObject* self)
+{
+    self->priv = G_TYPE_INSTANCE_GET_PRIVATE(self, GBINDER_TYPE_PROXY_OBJECT,
+        GBinderProxyObjectPriv);
+}
+
+static
+void
+gbinder_proxy_object_class_init(
+    GBinderProxyObjectClass* klass)
+{
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
+
+    g_type_class_add_private(klass, sizeof(GBinderProxyObjectPriv));
+    object_class->finalize = gbinder_proxy_object_finalize;
+    klass->can_handle_transaction = gbinder_proxy_object_can_handle_transaction;
+    klass->handle_transaction = gbinder_proxy_object_handle_transaction;
+    klass->drop = gbinder_proxy_object_drop;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/src/gbinder_proxy_object.h
+++ b/src/gbinder_proxy_object.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,37 +30,32 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GBINDER_LOCAL_REQUEST_PRIVATE_H
-#define GBINDER_LOCAL_REQUEST_PRIVATE_H
+#ifndef GBINDER_PROXY_OBJECT_H
+#define GBINDER_PROXY_OBJECT_H
 
-#include <gbinder_local_request.h>
+#include "gbinder_local_object_p.h"
 
-#include "gbinder_types_p.h"
+typedef struct gbinder_proxy_object_priv GBinderProxyObjectPriv;
 
-GBinderLocalRequest*
-gbinder_local_request_new(
-    const GBinderIo* io,
-    GBytes* init)
+struct gbinder_proxy_object {
+    GBinderLocalObject parent;
+    GBinderProxyObjectPriv* priv;
+    GBinderRemoteObject* remote;
+};
+
+GType gbinder_proxy_object_get_type(void) GBINDER_INTERNAL;
+#define GBINDER_TYPE_PROXY_OBJECT gbinder_proxy_object_get_type()
+#define GBINDER_PROXY_OBJECT(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), \
+        GBINDER_TYPE_PROXY_OBJECT, GBinderProxyObject))
+
+/* Registers with src and forwards all transactions to the remote */
+GBinderProxyObject*
+gbinder_proxy_object_new(
+    GBinderIpc* src,
+    GBinderRemoteObject* remote)
     GBINDER_INTERNAL;
 
-GBinderOutputData*
-gbinder_local_request_data(
-    GBinderLocalRequest* req)
-    GBINDER_INTERNAL;
-
-GBinderLocalRequest*
-gbinder_local_request_new_from_data(
-    GBinderBuffer* buffer)
-    GBINDER_INTERNAL;
-
-void
-gbinder_local_request_append_contents(
-    GBinderLocalRequest* req,
-    GBinderBuffer* buffer,
-    gsize offset)
-    GBINDER_INTERNAL;
-
-#endif /* GBINDER_LOCAL_REQUEST_PRIVATE_H */
+#endif /* GBINDER_PROXY_OBJECT_H */
 
 /*
  * Local Variables:

--- a/src/gbinder_remote_reply.c
+++ b/src/gbinder_remote_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -120,8 +120,12 @@ gbinder_remote_reply_copy_to_local(
 {
     if (G_LIKELY(self)) {
         GBinderReaderData* d = &self->data;
+        GBinderObjectRegistry* reg = d->reg;
 
-        return gbinder_local_reply_new_from_data(d->buffer);
+        if (reg) {
+            return gbinder_local_reply_set_contents
+                (gbinder_local_reply_new(reg->io), d->buffer);
+        }
     }
     return NULL;
 }

--- a/src/gbinder_remote_request_p.h
+++ b/src/gbinder_remote_request_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -54,6 +54,12 @@ gbinder_remote_request_set_data(
     GBinderRemoteRequest* request,
     guint txcode,
     GBinderBuffer* buffer)
+    GBINDER_INTERNAL;
+
+GBinderLocalRequest*
+gbinder_remote_request_translate_to_local(
+    GBinderRemoteRequest* req,
+    GBinderDriver* driver)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_REMOTE_REQUEST_PRIVATE_H */

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -88,6 +88,8 @@ GType gbinder_servicemanager_get_type(void) GBINDER_INTERNAL;
     G_TYPE_CHECK_CLASS_CAST((klass), GBINDER_TYPE_SERVICEMANAGER, \
     GBinderServiceManagerClass)
 
+#define gbinder_servicemanager_ipc(sm) gbinder_client_ipc(sm->client)
+
 GBinderServiceManager*
 gbinder_servicemanager_new_with_type(
     GType type,

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -42,6 +42,7 @@ typedef struct gbinder_handler GBinderHandler;
 typedef struct gbinder_io GBinderIo;
 typedef struct gbinder_object_registry GBinderObjectRegistry;
 typedef struct gbinder_output_data GBinderOutputData;
+typedef struct gbinder_proxy_object GBinderProxyObject;
 typedef struct gbinder_rpc_protocol GBinderRpcProtocol;
 typedef struct gbinder_servicepoll GBinderServicePoll;
 typedef struct gbinder_ipc_looper_tx GBinderIpcLooperTx;

--- a/src/gbinder_writer_p.h
+++ b/src/gbinder_writer_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -55,6 +55,13 @@ void
 gbinder_writer_data_set_contents(
     GBinderWriterData* data,
     GBinderBuffer* buffer)
+    GBINDER_INTERNAL;
+
+void
+gbinder_writer_data_append_contents(
+    GBinderWriterData* data,
+    GBinderBuffer* buffer,
+    gsize data_offset)
     GBINDER_INTERNAL;
 
 void

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,6 +2,7 @@
 
 all:
 %:
+	@$(MAKE) -C binder-bridge $*
 	@$(MAKE) -C binder-client $*
 	@$(MAKE) -C binder-dump $*
 	@$(MAKE) -C binder-list $*

--- a/test/binder-bridge/Makefile
+++ b/test/binder-bridge/Makefile
@@ -1,0 +1,140 @@
+# -*- Mode: makefile-gmake -*-
+
+.PHONY: all debug release clean cleaner
+.PHONY: libgbinder-release libgbinder-debug
+
+#
+# Required packages
+#
+
+PKGS = glib-2.0 gio-2.0 gio-unix-2.0 libglibutil
+
+#
+# Default target
+#
+
+all: debug release
+
+#
+# Executable
+#
+
+EXE = binder-bridge
+
+#
+# Sources
+#
+
+SRC = $(EXE).c
+
+#
+# Directories
+#
+
+SRC_DIR = .
+BUILD_DIR = build
+LIB_DIR = ../..
+DEBUG_BUILD_DIR = $(BUILD_DIR)/debug
+RELEASE_BUILD_DIR = $(BUILD_DIR)/release
+
+#
+# Tools and flags
+#
+
+CC ?= $(CROSS_COMPILE)gcc
+LD = $(CC)
+WARNINGS = -Wall
+INCLUDES = -I$(LIB_DIR)/include
+BASE_FLAGS = -fPIC
+CFLAGS = $(BASE_FLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
+  $(shell pkg-config --cflags $(PKGS))
+LDFLAGS = $(BASE_FLAGS) $(shell pkg-config --libs $(PKGS))
+QUIET_MAKE = make --no-print-directory
+DEBUG_FLAGS = -g
+RELEASE_FLAGS =
+
+ifndef KEEP_SYMBOLS
+KEEP_SYMBOLS = 0
+endif
+
+ifneq ($(KEEP_SYMBOLS),0)
+RELEASE_FLAGS += -g
+SUBMAKE_OPTS += KEEP_SYMBOLS=1
+endif
+
+DEBUG_LDFLAGS = $(LDFLAGS) $(DEBUG_FLAGS)
+RELEASE_LDFLAGS = $(LDFLAGS) $(RELEASE_FLAGS)
+DEBUG_CFLAGS = $(CFLAGS) $(DEBUG_FLAGS) -DDEBUG
+RELEASE_CFLAGS = $(CFLAGS) $(RELEASE_FLAGS) -O2
+
+#
+# Files
+#
+
+DEBUG_OBJS = $(SRC:%.c=$(DEBUG_BUILD_DIR)/%.o)
+RELEASE_OBJS = $(SRC:%.c=$(RELEASE_BUILD_DIR)/%.o)
+DEBUG_SO_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_debug_so)
+RELEASE_SO_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_release_so)
+DEBUG_LINK_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_debug_link)
+RELEASE_LINK_FILE := $(shell $(QUIET_MAKE) -C $(LIB_DIR) print_release_link)
+DEBUG_SO = $(LIB_DIR)/$(DEBUG_SO_FILE)
+RELEASE_SO = $(LIB_DIR)/$(RELEASE_SO_FILE)
+
+#
+# Dependencies
+#
+
+DEPS = $(DEBUG_OBJS:%.o=%.d) $(RELEASE_OBJS:%.o=%.d)
+ifneq ($(MAKECMDGOALS),clean)
+ifneq ($(strip $(DEPS)),)
+-include $(DEPS)
+endif
+endif
+
+$(DEBUG_OBJS): | $(DEBUG_BUILD_DIR)
+$(RELEASE_OBJS): | $(RELEASE_BUILD_DIR)
+
+#
+# Rules
+#
+
+DEBUG_EXE = $(DEBUG_BUILD_DIR)/$(EXE)
+RELEASE_EXE = $(RELEASE_BUILD_DIR)/$(EXE)
+
+debug: libgbinder-debug $(DEBUG_EXE)
+
+release: libgbinder-release $(RELEASE_EXE)
+
+clean:
+	rm -f *~
+	rm -fr $(BUILD_DIR)
+
+cleaner: clean
+	@make -C $(LIB_DIR) clean
+
+$(DEBUG_BUILD_DIR):
+	mkdir -p $@
+
+$(RELEASE_BUILD_DIR):
+	mkdir -p $@
+
+$(DEBUG_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(DEBUG_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(RELEASE_BUILD_DIR)/%.o : $(SRC_DIR)/%.c
+	$(CC) -c $(RELEASE_CFLAGS) -MT"$@" -MF"$(@:%.o=%.d)" $< -o $@
+
+$(DEBUG_EXE): $(DEBUG_SO) $(DEBUG_BUILD_DIR) $(DEBUG_OBJS)
+	$(LD) $(DEBUG_OBJS) $(DEBUG_LDFLAGS) $< -o $@
+
+$(RELEASE_EXE): $(RELEASE_SO) $(RELEASE_BUILD_DIR) $(RELEASE_OBJS)
+	$(LD) $(RELEASE_OBJS) $(RELEASE_LDFLAGS) $< -o $@
+ifeq ($(KEEP_SYMBOLS),0)
+	strip $@
+endif
+
+libgbinder-debug:
+	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(DEBUG_SO_FILE) $(DEBUG_LINK_FILE)
+
+libgbinder-release:
+	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) $(RELEASE_SO_FILE) $(RELEASE_LINK_FILE)

--- a/test/binder-bridge/binder-bridge.c
+++ b/test/binder-bridge/binder-bridge.c
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <gbinder.h>
+
+#include <gutil_log.h>
+
+#include <glib-unix.h>
+
+#define RET_OK      (0)
+#define RET_NODEV   (1)
+#define RET_INVARG  (2)
+
+typedef struct app_options {
+    const char* src;
+    const char* dest;
+    const char* name;
+    const char** ifaces;
+} AppOptions;
+
+static
+gboolean
+app_signal(
+    gpointer loop)
+{
+    GINFO("Caught signal, shutting down...");
+    g_main_loop_quit(loop);
+    return G_SOURCE_CONTINUE;
+}
+
+static
+int
+app_run(
+    const AppOptions* opt)
+{
+    int ret = RET_NODEV;
+    GBinderServiceManager* src = gbinder_servicemanager_new(opt->src);
+
+    if (src) {
+        GBinderServiceManager* dest = gbinder_servicemanager_new(opt->dest);
+
+        if (dest) {
+            GMainLoop* loop = g_main_loop_new(NULL, TRUE);
+            guint sigtrm = g_unix_signal_add(SIGTERM, app_signal, loop);
+            guint sigint = g_unix_signal_add(SIGINT, app_signal, loop);
+            GBinderBridge* bridge = gbinder_bridge_new
+                (opt->name, opt->ifaces, src, dest);
+
+            g_main_loop_run(loop);
+
+            if (sigtrm) g_source_remove(sigtrm);
+            if (sigint) g_source_remove(sigint);
+            g_main_loop_unref(loop);
+            gbinder_bridge_free(bridge);
+            gbinder_servicemanager_unref(dest);
+            ret = RET_OK;
+        } else {
+            GERR("No servicemanager at %s", opt->dest);
+        }
+        gbinder_servicemanager_unref(src);
+    } else {
+        GERR("No servicemanager at %s", opt->src);
+    }
+    return ret;
+}
+
+static
+gboolean
+app_log_verbose(
+    const gchar* name,
+    const gchar* value,
+    gpointer data,
+    GError** error)
+{
+    gutil_log_default.level = GLOG_LEVEL_VERBOSE;
+    return TRUE;
+}
+
+static
+gboolean
+app_log_quiet(
+    const gchar* name,
+    const gchar* value,
+    gpointer data,
+    GError** error)
+{
+    gutil_log_default.level = GLOG_LEVEL_NONE;
+    return TRUE;
+}
+
+static
+gboolean
+app_init(
+    AppOptions* opt,
+    int argc,
+    char* argv[])
+{
+    gboolean ok = FALSE;
+    GOptionEntry entries[] = {
+        { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+          app_log_verbose, "Enable verbose output", NULL },
+        { "quiet", 'q', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
+          app_log_quiet, "Be quiet", NULL },
+        { NULL }
+    };
+
+    GError* error = NULL;
+    GOptionContext* options = g_option_context_new("SRC DST NAME IFACES...");
+
+    gutil_log_timestamp = FALSE;
+    gutil_log_default.level = GLOG_LEVEL_DEFAULT;
+
+    g_option_context_add_main_entries(options, entries, NULL);
+    g_option_context_set_summary(options,
+        "Forwards calls from device SRC to device DST.");
+
+    if (g_option_context_parse(options, &argc, &argv, &error)) {
+        if (argc >= 5) {
+            int i;
+            const int first_iface = 4;
+
+            opt->src = argv[1];
+            opt->dest = argv[2];
+            opt->name = argv[3];
+            opt->ifaces = g_new(const char*, argc - first_iface + 1);
+            for (i = first_iface; i < argc; i++) {
+                opt->ifaces[i - first_iface] = argv[i];
+            }
+            opt->ifaces[i - first_iface] = NULL;
+            ok = TRUE;
+        } else {
+            char* help = g_option_context_get_help(options, TRUE, NULL);
+
+            fprintf(stderr, "%s", help);
+            g_free(help);
+        }
+    } else {
+        GERR("%s", error->message);
+        g_error_free(error);
+    }
+    g_option_context_free(options);
+    return ok;
+}
+
+int main(int argc, char* argv[])
+{
+    AppOptions opt;
+    int ret = RET_INVARG;
+
+    memset(&opt, 0, sizeof(opt));
+    if (app_init(&opt, argc, argv)) {
+        ret = app_run(&opt);
+    }
+    g_free(opt.ifaces);
+    return ret;
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/Makefile
+++ b/unit/Makefile
@@ -2,6 +2,7 @@
 
 all:
 %:
+	@$(MAKE) -C unit_bridge $*
 	@$(MAKE) -C unit_buffer $*
 	@$(MAKE) -C unit_cleanup $*
 	@$(MAKE) -C unit_client $*
@@ -14,6 +15,7 @@ all:
 	@$(MAKE) -C unit_local_request $*
 	@$(MAKE) -C unit_log $*
 	@$(MAKE) -C unit_protocol $*
+	@$(MAKE) -C unit_proxy_object $*
 	@$(MAKE) -C unit_reader $*
 	@$(MAKE) -C unit_remote_object $*
 	@$(MAKE) -C unit_remote_reply $*

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -149,7 +149,8 @@ test_binder_set_destroy(
 
 void
 test_binder_exit_wait(
-    void);
+    const TestOpt* opt,
+    GMainLoop* loop);
 
 #endif /* TEST_BINDER_H */
 

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -113,10 +113,16 @@ test_binder_br_reply_status_later(
     int fd,
     gint32 status);
 
+typedef enum test_looper {
+    TEST_LOOPER_DISABLE,
+    TEST_LOOPER_ENABLE,
+    TEST_LOOPER_ENABLE_ONE
+} TEST_LOOPER;
+
 void
 test_binder_set_looper_enabled(
     int fd,
-    gboolean enabled);
+    TEST_LOOPER value);
 
 void
 test_binder_set_passthrough(

--- a/unit/common/test_servicemanager_hidl.c
+++ b/unit/common/test_servicemanager_hidl.c
@@ -33,16 +33,14 @@
 #include "test_servicemanager_hidl.h"
 
 #include "gbinder_local_object_p.h"
-#include "gbinder_local_object_p.h"
 #include "gbinder_local_reply.h"
 #include "gbinder_local_request.h"
 #include "gbinder_remote_request.h"
-#include "gbinder_remote_object_p.h"
+#include "gbinder_remote_reply.h"
+#include "gbinder_remote_object.h"
 #include "gbinder_reader.h"
 #include "gbinder_writer.h"
-#include "gbinder_cleanup.h"
-#include "gbinder_client_p.h"
-#include "gbinder_driver.h"
+#include "gbinder_client.h"
 #include "gbinder_ipc.h"
 
 #include <gutil_log.h>
@@ -52,10 +50,11 @@
  * Test service manager
  *==========================================================================*/
 
-#define SVCMGR_IFACE "android.hidl.manager@1.0::IServiceManager"
+#define BASE_IFACE "android.hidl.base@1.0::IBase"
+#define MANAGER_IFACE "android.hidl.manager@1.0::IServiceManager"
 #define NOTIFICATION_IFACE "android.hidl.manager@1.0::IServiceNotification"
 
-const char* const servicemanager_hidl_ifaces[] = { SVCMGR_IFACE, NULL };
+const char* const servicemanager_hidl_ifaces[] = { MANAGER_IFACE, NULL };
 
 enum servicemanager_hidl_tx {
     GET_TRANSACTION = GBINDER_FIRST_CALL_TRANSACTION,
@@ -77,9 +76,20 @@ struct test_servicemanager_hidl {
     GBinderLocalObject parent;
     GHashTable* objects;
     GPtrArray* watchers;
-    GBinderCleanup* cleanup;
-    gboolean handle_on_looper_thread;
+    GMutex mutex;
 };
+
+typedef struct test_servicemanager_hidl_add {
+    TestServiceManagerHidl* manager;
+    GBinderRemoteObject* object;
+    char* instance;
+} TestServiceManagerHidlAdd;
+
+struct test_servicemanager_hidl_watcher {
+    GBinderClient* client;
+    char* iface;
+    char* name;
+} TestServiceManagerHidlWatcher;
 
 #define THIS_TYPE test_servicemanager_hidl_get_type()
 #define PARENT_CLASS test_servicemanager_hidl_parent_class
@@ -87,6 +97,128 @@ struct test_servicemanager_hidl {
     TestServiceManagerHidl))
 G_DEFINE_TYPE(TestServiceManagerHidl, test_servicemanager_hidl, \
     GBINDER_TYPE_LOCAL_OBJECT)
+
+static
+void
+test_servicemanager_hidl_notify(
+    TestServiceManagerHidl* self,
+    GBinderClient* watcher,
+    const char* iface,
+    const char* instance,
+    gboolean preexisting)
+{
+    GBinderLocalRequest* notify = gbinder_client_new_request(watcher);
+    GBinderWriter writer;
+    char* iface2 = g_strdup(iface);
+    char* instance2 = g_strdup(instance);
+
+    gbinder_local_request_init_writer(notify, &writer);
+    gbinder_writer_append_hidl_string(&writer, iface2);
+    gbinder_writer_append_hidl_string(&writer, instance2);
+    gbinder_writer_append_bool(&writer, preexisting);
+
+    gbinder_writer_add_cleanup(&writer, g_free, iface2);
+    gbinder_writer_add_cleanup(&writer, g_free, instance2);
+
+    gbinder_client_transact(watcher, ON_REGISTRATION_TRANSACTION,
+        GBINDER_TX_FLAG_ONEWAY, notify, NULL, NULL, NULL);
+    gbinder_local_request_unref(notify);
+}
+
+static
+void
+test_servicemanager_hidl_notify_all(
+    TestServiceManagerHidl* self,
+    const char* iface,
+    const char* instance,
+    gboolean preexisting)
+{
+    GPtrArray* watchers = self->watchers;
+    guint i;
+
+    /* For unit test purposes, just always notify all watchers */
+    for (i = 0; i < watchers->len; i++) {
+        test_servicemanager_hidl_notify(self, watchers->pdata[i],
+            iface, instance, preexisting);
+    }
+}
+
+static
+void
+test_servicemanager_hidl_add_complete2(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* user_data)
+{
+    TestServiceManagerHidlAdd* add = user_data;
+    TestServiceManagerHidl* self = add->manager;
+    const char* instance = add->instance;
+
+    g_mutex_lock(&self->mutex);
+    /* Remove the temporary entry */
+    GDEBUG("Dropping '%s'", instance);
+    g_hash_table_remove(self->objects, instance);
+    if (reply) {
+        GBinderReader reader;
+        gint32 status;
+
+        gbinder_remote_reply_init_reader(reply, &reader);
+        if (gbinder_reader_read_int32(&reader, &status) && status == 0) {
+            char** ifaces = gbinder_reader_read_hidl_string_vec(&reader);
+
+            if (ifaces) {
+                char** ptr = ifaces;
+
+                while (*ptr) {
+                    const char* iface = *ptr++;
+                    char* fqinstance = g_strconcat(iface, "/", instance, NULL);
+
+                    /* Add permanent entries */
+                    GDEBUG("Adding '%s'", fqinstance);
+                    g_hash_table_replace(self->objects, fqinstance,
+                        gbinder_remote_object_ref(add->object));
+                    test_servicemanager_hidl_notify_all(self, iface,
+                        instance, FALSE);
+                }
+                g_strfreev(ifaces);
+            }
+        }
+    }
+    g_mutex_unlock(&self->mutex);
+}
+
+static
+void
+test_servicemanager_hidl_add_done(
+    gpointer data)
+{
+    TestServiceManagerHidlAdd* add = data;
+
+    gbinder_remote_object_unref(add->object);
+    g_object_unref(add->manager);
+    g_free(add->instance);
+    g_free(add);
+}
+
+static
+gboolean
+test_servicemanager_hidl_add_complete(
+    gpointer data)
+{
+    TestServiceManagerHidlAdd* add = data;
+    GBinderClient* client = gbinder_client_new(add->object, BASE_IFACE);
+
+    gbinder_client_transact(client, HIDL_DESCRIPTOR_CHAIN_TRANSACTION, 0, NULL,
+        test_servicemanager_hidl_add_complete2,
+        test_servicemanager_hidl_add_done, add);
+    gbinder_client_unref(client);
+    return G_SOURCE_REMOVE;
+}
+
+/*==========================================================================*
+ * Call handlers
+ *==========================================================================*/
 
 static
 GBinderLocalReply*
@@ -109,6 +241,9 @@ test_servicemanager_hidl_get(
     fqinstance = g_strconcat(ifname, "/", instance, NULL);
 
     remote_obj = g_hash_table_lookup(self->objects, fqinstance);
+    if (!remote_obj) {
+        remote_obj = g_hash_table_lookup(self->objects, instance);
+    }
     gbinder_local_reply_init_writer(reply, &writer);
     gbinder_local_reply_append_int32(reply, GBINDER_STATUS_OK);
     if (remote_obj) {
@@ -131,43 +266,32 @@ test_servicemanager_hidl_add(
     GBinderLocalReply* reply =
         gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
     GBinderReader reader;
-    const char* fqname;
+    const char* instance;
     gboolean success;
 
     gbinder_remote_request_init_reader(req, &reader);
-    fqname = gbinder_reader_read_hidl_string_c(&reader);
+    instance = gbinder_reader_read_hidl_string_c(&reader);
     remote_obj = gbinder_reader_read_object(&reader);
 
-    if (fqname && remote_obj) {
-        const char* sep = strchr(fqname, '/');
-        GPtrArray* watchers = self->watchers;
-        guint i;
+    if (instance && remote_obj) {
+        const char* sep = strrchr(instance, '/');
 
-        GDEBUG("Adding '%s'", fqname);
-        g_hash_table_replace(self->objects, g_strdup(fqname), remote_obj);
+        GDEBUG("Adding '%s'", instance);
+        g_hash_table_replace(self->objects, g_strdup(instance), remote_obj);
+        if (sep) {
+            /* Alread know the interface */
+            char* iface = g_strndup(instance, sep - instance);
 
-        /* For unit test purposes, just always notify all watchers */
-        for (i = 0; i < watchers->len; i++) {
-            char* iface = g_strndup(fqname, sep - fqname);
-            char* name = g_strdup(sep + 1);
-            GBinderClient* client = watchers->pdata[i];
-            GBinderLocalRequest* notify = gbinder_client_new_request(client);
-            GBinderWriter writer;
+            test_servicemanager_hidl_notify_all(self, iface, sep + 1, FALSE);
+            g_free(iface);
+        } else {
+            /* Query interface chain on the main thread */
+            TestServiceManagerHidlAdd* add = g_new(TestServiceManagerHidlAdd,1);
 
-            gbinder_local_request_init_writer(notify, &writer);
-            gbinder_writer_append_hidl_string(&writer, iface);
-            gbinder_writer_append_hidl_string(&writer, name);
-            gbinder_writer_append_bool(&writer, FALSE);
-
-            gbinder_writer_add_cleanup(&writer, g_free, iface);
-            gbinder_writer_add_cleanup(&writer, g_free, name);
-            
-            gbinder_client_transact(client, ON_REGISTRATION_TRANSACTION,
-                GBINDER_TX_FLAG_ONEWAY, notify, NULL, NULL, NULL);
-
-            /* Keep it alive longer than libgbinder needs it */
-            self->cleanup = gbinder_cleanup_add(self->cleanup, (GDestroyNotify)
-                gbinder_local_request_unref, notify);
+            g_object_ref(add->manager = self);
+            add->object = gbinder_remote_object_ref(remote_obj);
+            add->instance = g_strdup(instance);
+            g_idle_add(test_servicemanager_hidl_add_complete, add);
         }
         success = TRUE;
     } else {
@@ -218,20 +342,37 @@ test_servicemanager_hidl_register_for_notifications(
     GBinderLocalReply* reply =
         gbinder_local_object_new_reply(GBINDER_LOCAL_OBJECT(self));
     GBinderReader reader;
-    const char* fqname;
+    const char* iface;
     const char* instance;
     gboolean success;
 
     gbinder_remote_request_init_reader(req, &reader);
-    fqname = gbinder_reader_read_hidl_string_c(&reader);
+    iface = gbinder_reader_read_hidl_string_c(&reader);
     instance = gbinder_reader_read_hidl_string_c(&reader);
     watcher = gbinder_reader_read_object(&reader);
  
     if (watcher) {
-        GDEBUG("Registering watcher %s/%s", fqname, instance);
-        g_ptr_array_add(self->watchers, gbinder_client_new(watcher,
-            NOTIFICATION_IFACE));
+        GBinderClient* wc = gbinder_client_new(watcher, NOTIFICATION_IFACE);
+        GHashTableIter it;
+        gpointer key;
+
+        GDEBUG("Registering watcher %s/%s", iface, instance);
+        g_ptr_array_add(self->watchers, wc);
         gbinder_remote_object_unref(watcher); /* Client keeps the reference */
+
+        /* Send notifications for pre-existing services */
+        g_hash_table_iter_init(&it, self->objects);
+        while (g_hash_table_iter_next(&it, &key, NULL)) {
+            const char* name = key;
+            const char* sep = strrchr(name, '/');
+
+            if (sep) {
+                char* intf = g_strndup(name, sep - name);
+
+                test_servicemanager_hidl_notify(self, wc, intf, sep + 1, TRUE);
+                g_free(intf);
+            }
+        }
         success = TRUE;
     } else {
         success = FALSE;
@@ -256,9 +397,9 @@ test_servicemanager_hidl_handler(
     GBinderLocalReply* reply = NULL;
 
     g_assert(!flags);
-    g_assert_cmpstr(gbinder_remote_request_interface(req), == ,SVCMGR_IFACE);
+    g_assert_cmpstr(gbinder_remote_request_interface(req), == ,MANAGER_IFACE);
     *status = -1;
-    gbinder_cleanup_reset(self->cleanup);
+    g_mutex_lock(&self->mutex);
     switch (code) {
     case GET_TRANSACTION:
         reply = test_servicemanager_hidl_get(self, req);
@@ -276,12 +417,7 @@ test_servicemanager_hidl_handler(
         GDEBUG("Unhandled command %u", code);
         break;
     }
-    /* If we don't defer deallocation of the reply, its buffers may get
-     * deallocated too early. */
-    if (reply) {
-        self->cleanup = gbinder_cleanup_add(self->cleanup, (GDestroyNotify)
-            gbinder_local_reply_unref, gbinder_local_reply_ref(reply));
-    }
+    g_mutex_unlock(&self->mutex);
     return reply;
 }
 
@@ -291,13 +427,11 @@ test_servicemanager_hidl_handler(
 
 TestServiceManagerHidl*
 test_servicemanager_hidl_new(
-    GBinderIpc* ipc,
-    gboolean handle_on_looper_thread)
+    GBinderIpc* ipc)
 {
     TestServiceManagerHidl* self = g_object_new(THIS_TYPE, NULL);
     GBinderLocalObject* obj = GBINDER_LOCAL_OBJECT(self);
 
-    self->handle_on_looper_thread = handle_on_looper_thread;
     gbinder_local_object_init_base(obj, ipc, servicemanager_hidl_ifaces,
         test_servicemanager_hidl_handler, self);
     gbinder_ipc_register_local_object(ipc, obj);
@@ -308,7 +442,6 @@ void
 test_servicemanager_hidl_free(
     TestServiceManagerHidl* self)
 {
-    gbinder_cleanup_reset(self->cleanup);
     gbinder_local_object_drop(GBINDER_LOCAL_OBJECT(self));
 }
 
@@ -323,7 +456,14 @@ guint
 test_servicemanager_hidl_object_count(
     TestServiceManagerHidl* self)
 {
-    return self ? g_hash_table_size(self->objects) : 0;
+    guint count = 0;
+
+    if (self) {
+        g_mutex_lock(&self->mutex);
+        count = g_hash_table_size(self->objects);
+        g_mutex_unlock(&self->mutex);
+    }
+    return count;
 }
 
 GBinderRemoteObject*
@@ -331,7 +471,14 @@ test_servicemanager_hidl_lookup(
     TestServiceManagerHidl* self,
     const char* name)
 {
-    return self ? g_hash_table_lookup(self->objects, name) : NULL;
+    GBinderRemoteObject* object = NULL;
+
+    if (self) {
+        g_mutex_lock(&self->mutex);
+        object = g_hash_table_lookup(self->objects, name);
+        g_mutex_unlock(&self->mutex);
+    }
+    return object;
 }
 
 /*==========================================================================*
@@ -345,14 +492,12 @@ test_servicemanager_hidl_can_handle_transaction(
     const char* iface,
     guint code)
 {
-    TestServiceManagerHidl* self = THIS(object);
-
-    if (self->handle_on_looper_thread && !g_strcmp0(SVCMGR_IFACE, iface)) {
-        return GBINDER_LOCAL_TRANSACTION_LOOPER;
-    } else {
-        return GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->
-            can_handle_transaction(object, iface, code);
-    }
+    /*
+     * Handle all transactions on the looper thread to avoid deadlocks.
+     * Unlike the real situation, binder simulation has one main thread
+     * shared by both sides of the binder socket connection.
+     */
+    return GBINDER_LOCAL_TRANSACTION_LOOPER;
 }
 
 static
@@ -364,7 +509,7 @@ test_servicemanager_hidl_handle_looper_transaction(
     guint flags,
     int* status)
 {
-    if (!g_strcmp0(gbinder_remote_request_interface(req), SVCMGR_IFACE)) {
+    if (!g_strcmp0(gbinder_remote_request_interface(req), MANAGER_IFACE)) {
         return GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->
             handle_transaction(object, req, code, flags, status);
     } else {
@@ -380,7 +525,7 @@ test_servicemanager_hidl_finalize(
 {
     TestServiceManagerHidl* self = THIS(object);
 
-    gbinder_cleanup_free(self->cleanup);
+    g_mutex_clear(&self->mutex);
     g_hash_table_destroy(self->objects);
     g_ptr_array_free(self->watchers, TRUE);
     G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
@@ -391,6 +536,7 @@ void
 test_servicemanager_hidl_init(
     TestServiceManagerHidl* self)
 {
+    g_mutex_init(&self->mutex);
     self->objects = g_hash_table_new_full(g_str_hash, g_str_equal, g_free,
         (GDestroyNotify) gbinder_remote_object_unref);
     self->watchers = g_ptr_array_new_with_free_func((GDestroyNotify)

--- a/unit/common/test_servicemanager_hidl.h
+++ b/unit/common/test_servicemanager_hidl.h
@@ -39,8 +39,7 @@ typedef struct test_servicemanager_hidl TestServiceManagerHidl;
 
 TestServiceManagerHidl*
 test_servicemanager_hidl_new(
-    GBinderIpc* ipc,
-    gboolean handle_on_looper_thread);
+    GBinderIpc* ipc);
 
 void
 test_servicemanager_hidl_free(

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -5,6 +5,7 @@
 #
 
 TESTS="\
+unit_bridge \
 unit_buffer \
 unit_cleanup \
 unit_client \
@@ -17,6 +18,7 @@ unit_local_reply \
 unit_local_request \
 unit_log \
 unit_protocol \
+unit_proxy_object \
 unit_reader \
 unit_remote_object \
 unit_remote_reply \

--- a/unit/unit_bridge/Makefile
+++ b/unit/unit_bridge/Makefile
@@ -1,0 +1,6 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = unit_bridge
+COMMON_SRC = test_binder.c test_main.c test_servicemanager_hidl.c
+
+include ../common/Makefile

--- a/unit/unit_bridge/unit_bridge.c
+++ b/unit/unit_bridge/unit_bridge.c
@@ -1,0 +1,458 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_binder.h"
+#include "test_servicemanager_hidl.h"
+
+#include "gbinder_ipc.h"
+#include "gbinder_client.h"
+#include "gbinder_config.h"
+#include "gbinder_driver.h"
+#include "gbinder_bridge.h"
+#include "gbinder_reader.h"
+#include "gbinder_local_reply.h"
+#include "gbinder_local_request.h"
+#include "gbinder_proxy_object.h"
+#include "gbinder_remote_object_p.h"
+#include "gbinder_remote_reply.h"
+#include "gbinder_remote_request.h"
+#include "gbinder_servicemanager_p.h"
+
+#include <gutil_log.h>
+
+static TestOpt test_opt;
+
+#define SRC_DEV "/dev/srcbinder"
+#define SRC_PRIV_DEV  SRC_DEV "-private"
+#define DEST_DEV "/dev/dstbinder"
+#define DEST_PRIV_DEV  DEST_DEV "-private"
+#define TEST_IFACE "gbinder@1.0::ITest"
+
+#define TX_CODE   GBINDER_FIRST_CALL_TRANSACTION
+#define TX_PARAM  0x11111111
+#define TX_RESULT 0x22222222
+
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-bridge-XXXXXX";
+static const char* TEST_IFACES[] =  { TEST_IFACE, NULL };
+static const char DEFAULT_CONFIG_DATA[] =
+    "[Protocol]\n"
+    "Default = hidl\n"
+    "[ServiceManager]\n"
+    "Default = hidl\n";
+
+typedef struct test_config {
+    char* dir;
+    char* file;
+} TestConfig;
+
+/*==========================================================================*
+ * Test object (registered with two GBinderIpc's)
+ *==========================================================================*/
+
+typedef GBinderLocalObjectClass TestLocalObjectClass;
+typedef struct test_local_object {
+    GBinderLocalObject parent;
+    GBinderIpc* ipc2;
+} TestLocalObject;
+G_DEFINE_TYPE(TestLocalObject, test_local_object, GBINDER_TYPE_LOCAL_OBJECT)
+#define TEST_TYPE_LOCAL_OBJECT test_local_object_get_type()
+#define TEST_LOCAL_OBJECT(obj) (G_TYPE_CHECK_INSTANCE_CAST((obj), \
+        TEST_TYPE_LOCAL_OBJECT, TestLocalObject))
+
+TestLocalObject*
+test_local_object_new(
+    GBinderIpc* ipc,
+    GBinderIpc* ipc2,
+    const char* const* ifaces,
+    GBinderLocalTransactFunc txproc,
+    void* user_data)
+{
+    TestLocalObject* self = TEST_LOCAL_OBJECT
+        (gbinder_local_object_new_with_type(TEST_TYPE_LOCAL_OBJECT,
+            ipc, ifaces, txproc, user_data));
+
+    self->ipc2 = gbinder_ipc_ref(ipc2);
+    gbinder_ipc_register_local_object(ipc2, &self->parent);
+    return self;
+}
+
+static
+void
+test_local_object_dispose(
+    GObject* object)
+{
+    TestLocalObject* self = TEST_LOCAL_OBJECT(object);
+
+    gbinder_ipc_local_object_disposed(self->ipc2, &self->parent);
+    G_OBJECT_CLASS(test_local_object_parent_class)->dispose(object);
+}
+
+static
+void
+test_local_object_finalize(
+    GObject* object)
+{
+    gbinder_ipc_unref(TEST_LOCAL_OBJECT(object)->ipc2);
+    G_OBJECT_CLASS(test_local_object_parent_class)->finalize(object);
+}
+
+static
+void
+test_local_object_init(
+    TestLocalObject* self)
+{
+}
+
+static
+void
+test_local_object_class_init(
+    TestLocalObjectClass* klass)
+{
+    GObjectClass* object_class = G_OBJECT_CLASS(klass);
+
+    object_class->dispose = test_local_object_dispose;
+    object_class->finalize = test_local_object_finalize;
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+static
+void
+test_config_init(
+    TestConfig* config,
+    char* config_data)
+{
+    config->dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    config->file = g_build_filename(config->dir, "test.conf", NULL);
+    g_assert(g_file_set_contents(config->file, config_data ? config_data :
+        DEFAULT_CONFIG_DATA, -1, NULL));
+
+    gbinder_config_exit();
+    gbinder_config_dir = config->dir;
+    gbinder_config_file = config->file;
+    GDEBUG("Wrote config to %s", config->file);
+}
+
+static
+void
+test_config_deinit(
+    TestConfig* config)
+{
+    gbinder_config_exit();
+
+    remove(config->file);
+    g_free(config->file);
+
+    remove(config->dir);
+    g_free(config->dir);
+}
+
+static
+TestServiceManagerHidl*
+test_servicemanager_impl_new(
+    const char* dev)
+{
+    GBinderIpc* ipc = gbinder_ipc_new(dev);
+    const int fd = gbinder_driver_fd(ipc->driver);
+    TestServiceManagerHidl* sm = test_servicemanager_hidl_new(ipc);
+
+    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_register_object(fd, GBINDER_LOCAL_OBJECT(sm),
+        GBINDER_SERVICEMANAGER_HANDLE);
+    gbinder_ipc_unref(ipc);
+    return sm;
+}
+
+/*==========================================================================*
+ * null
+ *==========================================================================*/
+
+static
+void
+test_null(
+    void)
+{
+    static const char* ifaces[] = { "foo", "bar", NULL};
+
+    g_assert(!gbinder_bridge_new(NULL, NULL, NULL, NULL));
+    g_assert(!gbinder_bridge_new("foo", NULL, NULL, NULL));
+    g_assert(!gbinder_bridge_new("foo", ifaces, NULL, NULL));
+    gbinder_bridge_free(NULL);
+}
+
+/*==========================================================================*
+ * basic
+ *==========================================================================*/
+
+typedef struct test_basic {
+    GMainLoop* loop;
+    TestServiceManagerHidl* src_impl;
+    int src_notify_count;
+    gboolean dest_name_added;
+} TestBasic;
+
+static
+GBinderLocalReply*
+test_basic_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    int* count = user_data;
+    GBinderReader reader;
+    gint32 param = 0;
+
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE));
+    g_assert(code == TX_CODE);
+
+    /* Make sure that parameter got delivered intact */
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert(gbinder_reader_read_int32(&reader, &param));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpint(param, == ,TX_PARAM);
+
+    *status = GBINDER_STATUS_OK;
+    (*count)++;
+    GDEBUG("Got a request, replying");
+    return gbinder_local_reply_append_int32
+        (gbinder_local_object_new_reply(obj), TX_RESULT);
+}
+
+static
+void
+test_basic_add_cb(
+    GBinderServiceManager* sm,
+    int status,
+    void* user_data)
+{
+    TestBasic* test = user_data;
+
+    GDEBUG("Name added");
+    g_assert(status == GBINDER_STATUS_OK);
+    g_assert(!test->dest_name_added);
+    test->dest_name_added = TRUE;
+    if (test->src_notify_count) {
+        g_main_loop_quit(test->loop);
+    }
+}
+
+static
+void
+test_basic_notify_cb(
+    GBinderServiceManager* sm,
+    const char* name,
+    void* user_data)
+{
+    TestBasic* test = user_data;
+
+    g_assert(name);
+    GDEBUG("'%s' is registered", name);
+    g_assert_cmpint(test->src_notify_count, == ,0);
+    test->src_notify_count++;
+    /* Exit the loop after both things happen */
+    if (test->dest_name_added) {
+        g_main_loop_quit(test->loop);
+    }
+}
+
+static
+void
+test_basic_reply(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* loop)
+{
+    GBinderReader reader;
+    gint32 result = 0;
+
+    g_assert(reply);
+    GDEBUG("Reply received");
+
+    /* Make sure that result got delivered intact */
+    gbinder_remote_reply_init_reader(reply, &reader);
+    g_assert(gbinder_reader_read_int32(&reader, &result));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpint(result, == ,TX_RESULT);
+
+    /* Exit the loop */
+    g_main_loop_quit((GMainLoop*)loop);
+}
+
+static
+void
+test_basic(
+    void)
+{
+    TestBasic test;
+    TestConfig config;
+    TestServiceManagerHidl* dest_impl;
+    GBinderServiceManager* src;
+    GBinderServiceManager* dest;
+    GBinderIpc* src_ipc;
+    GBinderIpc* src_priv_ipc;
+    GBinderIpc* dest_ipc;
+    GBinderIpc* dest_priv_ipc;
+    GBinderBridge* bridge;
+    TestLocalObject* obj;
+    GBinderRemoteObject* src_obj;
+    GBinderLocalRequest* req;
+    GBinderClient* src_client;
+    const char* name = "test";
+    const char* fqname = TEST_IFACE "/test";
+    int src_fd, dest_fd, n = 0;
+    gulong id;
+
+    test_config_init(&config, NULL);
+    memset(&test, 0, sizeof(test));
+    test.loop = g_main_loop_new(NULL, FALSE);
+
+    /* obj (DEST) <=> bridge <=> (SRC) mirror */
+    src_ipc = gbinder_ipc_new(SRC_DEV);
+    src_priv_ipc = gbinder_ipc_new(SRC_PRIV_DEV);
+    dest_ipc = gbinder_ipc_new(DEST_DEV);
+    dest_priv_ipc = gbinder_ipc_new(DEST_PRIV_DEV);
+    test.src_impl = test_servicemanager_impl_new(SRC_PRIV_DEV);
+    dest_impl = test_servicemanager_impl_new(DEST_PRIV_DEV);
+    src_fd = gbinder_driver_fd(src_ipc->driver);
+    dest_fd = gbinder_driver_fd(dest_ipc->driver);
+    obj = test_local_object_new(dest_ipc, dest_priv_ipc, TEST_IFACES,
+        test_basic_cb, &n);
+
+    /* Set up binder simulator */
+    test_binder_set_passthrough(src_fd, TRUE);
+    test_binder_set_passthrough(dest_fd, TRUE);
+    test_binder_set_looper_enabled(src_fd, TEST_LOOPER_ENABLE);
+    test_binder_set_looper_enabled(dest_fd, TEST_LOOPER_ENABLE);
+    src = gbinder_servicemanager_new(SRC_DEV);
+    dest = gbinder_servicemanager_new(DEST_DEV);
+
+    /* Both src and dest are required */
+    g_assert(!gbinder_bridge_new(name, TEST_IFACES, src, NULL));
+    bridge = gbinder_bridge_new(name, TEST_IFACES, src, dest);
+
+    /* Start watching the name */
+    id = gbinder_servicemanager_add_registration_handler(src, fqname,
+        test_basic_notify_cb, &test);
+    g_assert(id);
+
+    /* Register the object and wait for completion */
+    GDEBUG("Registering object '%s' => %p", name, obj);
+    g_assert(gbinder_servicemanager_add_service(dest, name, &obj->parent,
+        test_basic_add_cb, &test));
+
+    /* This loop quits after the name is added and notification is received */
+    test_run(&test_opt, test.loop);
+
+    GDEBUG("Bridge object has been registered on source");
+    g_assert_cmpint(test.src_notify_count, == ,1);
+    gbinder_servicemanager_remove_handler(src, id);
+
+    /* Get a remote reference to the object created by the bridge */
+    src_obj = gbinder_servicemanager_get_service_sync(src, fqname, NULL);
+    g_assert(src_obj); /* autoreleased */
+    g_assert(!src_obj->dead);
+
+    /*
+     * This is a trick specific to test_binder simulation. We need to
+     * associate src_obj with the other side of the socket, so that the
+     * call goes like this:
+     *
+     * src_obj (src_priv) => (src) bridge (dest) => (dest_priv) => obj
+     *
+     * Note that the original src_obj gets autoreleased and doesn't need
+     * to be explicitly unreferenced.
+     */
+    src_obj = gbinder_remote_object_new(src_priv_ipc, src_obj->handle, FALSE);
+
+    /* Make a call */
+    GDEBUG("Submitting a call");
+    src_client = gbinder_client_new(src_obj, TEST_IFACE);
+    req = gbinder_client_new_request(src_client);
+    gbinder_local_request_append_int32(req, TX_PARAM);
+    g_assert(gbinder_client_transact(src_client, TX_CODE, 0, req,
+        test_basic_reply, NULL, test.loop));
+    gbinder_local_request_unref(req);
+
+    /* Wait for completion */
+    test_run(&test_opt, test.loop);
+
+    GDEBUG("Done");
+    gbinder_bridge_free(bridge);
+
+    gbinder_local_object_unref(&obj->parent);
+    gbinder_remote_object_unref(src_obj);
+    test_servicemanager_hidl_free(test.src_impl);
+    test_servicemanager_hidl_free(dest_impl);
+    gbinder_servicemanager_unref(src);
+    gbinder_servicemanager_unref(dest);
+    gbinder_client_unref(src_client);
+    test_binder_unregister_objects(src_fd);
+    test_binder_unregister_objects(dest_fd);
+    gbinder_ipc_unref(src_ipc);
+    gbinder_ipc_unref(src_priv_ipc);
+    gbinder_ipc_unref(dest_ipc);
+    gbinder_ipc_unref(dest_priv_ipc);
+    gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, test.loop);
+    test_config_deinit(&config);
+    g_main_loop_unref(test.loop);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_(t) "/bridge/" t
+
+int main(int argc, char* argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("basic"), test_basic);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/unit_driver/unit_driver.c
+++ b/unit/unit_driver/unit_driver.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -36,6 +36,7 @@
 #include "gbinder_handler.h"
 #include "gbinder_local_request_p.h"
 #include "gbinder_output_data.h"
+#include "gbinder_rpc_protocol.h"
 
 #include <poll.h>
 
@@ -60,6 +61,9 @@ test_basic(
     driver = gbinder_driver_new(dev, NULL);
     g_assert(driver);
     g_assert(!g_strcmp0(dev, gbinder_driver_dev(driver)));
+    g_assert(gbinder_driver_protocol(driver));
+    g_assert(gbinder_driver_protocol(driver) ==
+        gbinder_rpc_protocol_for_device(dev));
     g_assert(gbinder_driver_ref(driver) == driver);
     gbinder_driver_unref(driver);
     gbinder_driver_free_buffer(driver, NULL);

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -135,7 +135,7 @@ test_basic(
     g_assert(!gbinder_ipc_new("invalid path"));
 
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, NULL);
 }
 
 /*==========================================================================*
@@ -197,7 +197,7 @@ test_sync_oneway(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, NULL);
 }
 
 /*==========================================================================*
@@ -242,7 +242,7 @@ test_sync_reply_ok_status(
     gbinder_local_reply_unref(reply);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, NULL);
 }
 
 static
@@ -286,7 +286,7 @@ test_sync_reply_error(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, NULL);
 }
 
 /*==========================================================================*
@@ -357,7 +357,7 @@ test_transact_ok(
     gbinder_local_reply_unref(reply);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -405,7 +405,7 @@ test_transact_dead(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -453,7 +453,7 @@ test_transact_failed(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -503,7 +503,7 @@ test_transact_status(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -535,8 +535,8 @@ test_transact_custom(
 
     gbinder_ipc_exit();
     gbinder_ipc_unref(ipc);
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
-    test_binder_exit_wait();
 }
 
 /*==========================================================================*
@@ -567,8 +567,8 @@ test_transact_custom2(
 
     gbinder_ipc_exit();
     gbinder_ipc_unref(ipc);
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
-    test_binder_exit_wait();
 }
 
 /*==========================================================================*
@@ -601,7 +601,7 @@ test_transact_custom3(
 
     /* Reference to GBinderIpc is released by test_transact_custom3_exec */
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -651,7 +651,7 @@ test_transact_cancel(
 
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -697,7 +697,7 @@ test_transact_cancel2(
 
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -786,8 +786,8 @@ test_transact_2way(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
-    test_binder_exit_wait();
 }
 
 /*==========================================================================*
@@ -859,7 +859,7 @@ test_transact_incoming(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -924,7 +924,7 @@ test_transact_status_reply(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -1032,7 +1032,7 @@ test_transact_async(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -1106,7 +1106,7 @@ test_transact_async_sync(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -1149,7 +1149,7 @@ test_drop_remote_refs(
     /* gbinder_ipc_exit will drop the remote reference */
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -1187,7 +1187,7 @@ test_cancel_on_exit(
     gbinder_local_request_unref(req);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -88,7 +88,7 @@ test_null(
     gbinder_local_reply_init_writer(NULL, NULL);
     gbinder_local_reply_init_writer(NULL, &writer);
     g_assert(!gbinder_local_reply_data(NULL));
-    g_assert(!gbinder_local_reply_new_from_data(NULL));
+    g_assert(!gbinder_local_reply_set_contents(NULL, NULL));
 
     gbinder_local_reply_cleanup(NULL, NULL, &count);
     gbinder_local_reply_cleanup(NULL, test_int_inc, &count);
@@ -479,7 +479,8 @@ test_remote_reply(
 
     /* Copy flat structures (no binder objects) */
     buffer = test_buffer_from_bytes(driver, bytes);
-    req2 = gbinder_local_reply_new_from_data(buffer);
+    req2 = gbinder_local_reply_new(io);
+    g_assert(gbinder_local_reply_set_contents(req2, buffer) == req2);
     gbinder_buffer_free(buffer);
 
     data2 = gbinder_local_reply_data(req2);

--- a/unit/unit_proxy_object/Makefile
+++ b/unit/unit_proxy_object/Makefile
@@ -1,0 +1,6 @@
+# -*- Mode: makefile-gmake -*-
+
+EXE = unit_proxy_object
+COMMON_SRC = test_binder.c test_main.c test_servicemanager_hidl.c
+
+include ../common/Makefile

--- a/unit/unit_proxy_object/unit_proxy_object.c
+++ b/unit/unit_proxy_object/unit_proxy_object.c
@@ -1,0 +1,426 @@
+/*
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ *
+ * You may use this file under the terms of BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_binder.h"
+
+#include "gbinder_ipc.h"
+#include "gbinder_client.h"
+#include "gbinder_config.h"
+#include "gbinder_driver.h"
+#include "gbinder_proxy_object.h"
+#include "gbinder_remote_object_p.h"
+#include "gbinder_remote_request.h"
+#include "gbinder_remote_reply.h"
+#include "gbinder_local_request.h"
+#include "gbinder_local_reply.h"
+
+#include <gutil_log.h>
+
+#include <errno.h>
+
+static TestOpt test_opt;
+
+#define DEV "/dev/xbinder"
+#define DEV_PRIV  DEV "-private"
+#define DEV2 "/dev/ybinder"
+#define DEV2_PRIV  DEV2 "-private"
+
+#define TX_CODE (GBINDER_FIRST_CALL_TRANSACTION + 1)
+#define TX_PARAM_REPLY 0x11111111
+#define TX_PARAM_DONT_REPLY 0x22222222
+#define TX_RESULT 0x33333333
+
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-proxy-XXXXXX";
+const char TEST_IFACE[] = "test@1.0::ITest";
+static const char* TEST_IFACES[] =  { TEST_IFACE, NULL };
+static const char DEFAULT_CONFIG_DATA[] =
+    "[Protocol]\n"
+    "Default = hidl\n"
+    "[ServiceManager]\n"
+    "Default = hidl\n";
+
+typedef struct test_config {
+    char* dir;
+    char* file;
+} TestConfig;
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+static
+void
+test_config_init(
+    TestConfig* config,
+    char* config_data)
+{
+    config->dir = g_dir_make_tmp(TMP_DIR_TEMPLATE, NULL);
+    config->file = g_build_filename(config->dir, "test.conf", NULL);
+    g_assert(g_file_set_contents(config->file, config_data ? config_data :
+        DEFAULT_CONFIG_DATA, -1, NULL));
+
+    gbinder_config_exit();
+    gbinder_config_dir = config->dir;
+    gbinder_config_file = config->file;
+    GDEBUG("Wrote config to %s", config->file);
+}
+
+static
+void
+test_config_deinit(
+    TestConfig* config)
+{
+    gbinder_config_exit();
+
+    remove(config->file);
+    g_free(config->file);
+
+    remove(config->dir);
+    g_free(config->dir);
+}
+
+/*==========================================================================*
+ * null
+ *==========================================================================*/
+
+static
+void
+test_null(
+    void)
+{
+    g_assert(!gbinder_proxy_object_new(NULL, NULL));
+}
+
+/*==========================================================================*
+ * basic
+ *==========================================================================*/
+
+static
+GBinderLocalReply*
+test_basic_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    int* count = user_data;
+    GBinderReader reader;
+
+    GDEBUG("Request handled");
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE));
+    g_assert(code == TX_CODE);
+
+    /* No parameters are expected */
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    *status = GBINDER_STATUS_OK;
+    (*count)++;
+    return gbinder_local_object_new_reply(obj);
+}
+
+static
+void
+test_basic_reply(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* loop)
+{
+    GBinderReader reader;
+
+    GDEBUG("Reply received");
+
+    /* No parameters are expected */
+    gbinder_remote_reply_init_reader(reply, &reader);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    g_main_loop_quit((GMainLoop*)loop);
+}
+
+static
+void
+test_basic(
+    void)
+{
+    TestConfig config;
+    GBinderLocalObject* obj;
+    GBinderProxyObject* proxy;
+    GBinderRemoteObject* remote_obj;
+    GBinderRemoteObject* remote_proxy;
+    GBinderClient* proxy_client;
+    GBinderIpc* ipc_obj;
+    GBinderIpc* ipc_proxy;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    int fd_obj, fd_proxy, n = 0;
+
+    test_config_init(&config, NULL);
+    ipc_proxy = gbinder_ipc_new(DEV);
+    ipc_obj = gbinder_ipc_new(DEV_PRIV);
+    fd_proxy = gbinder_driver_fd(ipc_proxy->driver);
+    fd_obj = gbinder_driver_fd(ipc_obj->driver);
+    obj = gbinder_local_object_new(ipc_obj, TEST_IFACES, test_basic_cb, &n);
+    remote_obj = gbinder_remote_object_new(ipc_proxy,
+        test_binder_register_object(fd_obj, obj, AUTO_HANDLE), FALSE);
+
+    /* remote_proxy(DEV_PRIV) => proxy (DEV) => obj (DEV) => DEV_PRIV */
+    g_assert(!gbinder_proxy_object_new(NULL, remote_obj));
+    g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    remote_proxy = gbinder_remote_object_new(ipc_obj,
+        test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
+        FALSE);
+    proxy_client = gbinder_client_new(remote_proxy, TEST_IFACE);
+
+    test_binder_set_passthrough(fd_obj, TRUE);
+    test_binder_set_passthrough(fd_proxy, TRUE);
+    test_binder_set_looper_enabled(fd_obj, TEST_LOOPER_ENABLE);
+    test_binder_set_looper_enabled(fd_proxy, TEST_LOOPER_ENABLE);
+
+    /* Perform a transaction via proxy */
+    g_assert(gbinder_client_transact(proxy_client, TX_CODE, 0, NULL,
+        test_basic_reply, NULL, loop));
+
+    test_run(&test_opt, loop);
+    g_assert_cmpint(n, == ,1);
+
+    test_binder_unregister_objects(fd_obj);
+    test_binder_unregister_objects(fd_proxy);
+    gbinder_local_object_drop(obj);
+    gbinder_local_object_drop(&proxy->parent);
+    gbinder_remote_object_unref(remote_obj);
+    gbinder_remote_object_unref(remote_proxy);
+    gbinder_client_unref(proxy_client);
+    gbinder_ipc_unref(ipc_obj);
+    gbinder_ipc_unref(ipc_proxy);
+    gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
+    test_config_deinit(&config);
+    g_main_loop_unref(loop);
+}
+
+/*==========================================================================*
+ * param
+ *==========================================================================*/
+
+static
+gboolean
+test_param_cancel(
+    gpointer req)
+{
+    gbinder_remote_request_complete(req, NULL, -ECANCELED);
+    return G_SOURCE_REMOVE;
+}
+
+static
+GBinderLocalReply*
+test_param_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    int* count = user_data;
+    GBinderReader reader;
+    gint32 param = 0;
+
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE));
+    g_assert(code == TX_CODE);
+
+    /* Make sure that parameter got delivered intact */
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert(gbinder_reader_read_int32(&reader, &param));
+    g_assert(gbinder_reader_at_end(&reader));
+
+    *status = GBINDER_STATUS_OK;
+    (*count)++;
+    if (param == TX_PARAM_REPLY) {
+        GDEBUG("Replying to request 0x%08x", param);
+        return gbinder_local_reply_append_int32
+            (gbinder_local_object_new_reply(obj), TX_RESULT);
+    } else {
+        g_assert_cmpint(param, == ,TX_PARAM_DONT_REPLY);
+        GDEBUG("Suspending request 0x%08x", param);
+        gbinder_remote_request_block(req);
+        g_timeout_add_full(G_PRIORITY_DEFAULT, 50, test_param_cancel,
+             gbinder_remote_request_ref(req), (GDestroyNotify)
+             gbinder_remote_request_unref);
+        return NULL;
+    }
+}
+
+static
+void
+test_param_reply(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* loop)
+{
+    /*
+     * Due to limitations of our binder simulation, the result can be
+     * delivered to a wrong thread. As a result, we only known that one
+     * of the callbacks get NULL result and one gets NULL loop, but we
+     * don't really know which one gets what, i.e. we have to be ready
+     * for any combination of these parameters.
+     *
+     * It's too difficult to fix (without writing almost a full-blown
+     * binder implementation), let's just live with it for now :/
+     */
+    if (reply) {
+        GBinderReader reader;
+        gint32 result = 0;
+
+        GDEBUG("Reply received");
+
+        /* Make sure that result got delivered intact */
+        gbinder_remote_reply_init_reader(reply, &reader);
+        g_assert(gbinder_reader_read_int32(&reader, &result));
+        g_assert(gbinder_reader_at_end(&reader));
+        g_assert_cmpint(result, == ,TX_RESULT);
+    } else {
+        /* The cancelled one */
+        GDEBUG("Transaction cancelled");
+    }
+
+    if (loop) {
+        g_main_loop_quit((GMainLoop*)loop);
+    }
+}
+
+static
+void
+test_param(
+    void)
+{
+    TestConfig config;
+    GBinderLocalObject* obj;
+    GBinderProxyObject* proxy;
+    GBinderRemoteObject* remote_obj;
+    GBinderRemoteObject* remote_proxy;
+    GBinderClient* proxy_client;
+    GBinderLocalRequest* req;
+    GBinderIpc* ipc_obj;
+    GBinderIpc* ipc_remote_obj;
+    GBinderIpc* ipc_proxy;
+    GBinderIpc* ipc_remote_proxy;
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    int fd_obj, fd_proxy, n = 0;
+
+    test_config_init(&config, NULL);
+    ipc_obj = gbinder_ipc_new(DEV);
+    ipc_remote_obj = gbinder_ipc_new(DEV_PRIV);
+    ipc_proxy = gbinder_ipc_new(DEV2);
+    ipc_remote_proxy = gbinder_ipc_new(DEV2_PRIV);
+    fd_proxy = gbinder_driver_fd(ipc_proxy->driver);
+    fd_obj = gbinder_driver_fd(ipc_obj->driver);
+    obj = gbinder_local_object_new(ipc_obj, TEST_IFACES, test_param_cb, &n);
+    remote_obj = gbinder_remote_object_new(ipc_remote_obj,
+        test_binder_register_object(fd_obj, obj, AUTO_HANDLE), FALSE);
+
+    /* remote_proxy(DEV2_PRIV) => proxy (DEV2) => obj (DEV) => DEV_PRIV */
+    g_assert(!gbinder_proxy_object_new(NULL, remote_obj));
+    g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    remote_proxy = gbinder_remote_object_new(ipc_remote_proxy,
+        test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
+        FALSE);
+    proxy_client = gbinder_client_new(remote_proxy, TEST_IFACE);
+
+    test_binder_set_passthrough(fd_obj, TRUE);
+    test_binder_set_passthrough(fd_proxy, TRUE);
+    test_binder_set_looper_enabled(fd_obj, TEST_LOOPER_ENABLE);
+    test_binder_set_looper_enabled(fd_proxy, TEST_LOOPER_ENABLE);
+
+    /*
+     * Perform two transactions via proxy. First one never gets completed
+     * and eventually is cancelled, and the seconf one is replied to.
+     */
+    req = gbinder_client_new_request(proxy_client);
+    gbinder_local_request_append_int32(req, TX_PARAM_DONT_REPLY);
+    gbinder_client_transact(proxy_client, TX_CODE, 0, req, test_param_reply,
+        NULL, NULL);
+    gbinder_local_request_unref(req);
+
+    req = gbinder_client_new_request(proxy_client);
+    gbinder_local_request_append_int32(req, TX_PARAM_REPLY);
+    g_assert(gbinder_client_transact(proxy_client, TX_CODE, 0, req,
+        test_param_reply, NULL, loop));
+    gbinder_local_request_unref(req);
+
+    test_run(&test_opt, loop);
+    g_assert_cmpint(n, == ,2);
+
+    test_binder_unregister_objects(fd_obj);
+    test_binder_unregister_objects(fd_proxy);
+    gbinder_local_object_drop(obj);
+    gbinder_local_object_drop(&proxy->parent);
+    gbinder_remote_object_unref(remote_obj);
+    gbinder_remote_object_unref(remote_proxy);
+    gbinder_client_unref(proxy_client);
+    gbinder_ipc_unref(ipc_obj);
+    gbinder_ipc_unref(ipc_remote_obj);
+    gbinder_ipc_unref(ipc_proxy);
+    gbinder_ipc_unref(ipc_remote_proxy);
+    gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
+    test_config_deinit(&config);
+    g_main_loop_unref(loop);
+}
+
+/*==========================================================================*
+ * Common
+ *==========================================================================*/
+
+#define TEST_(t) "/proxy_object/" t
+
+int main(int argc, char* argv[])
+{
+    g_test_init(&argc, &argv, NULL);
+    g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("basic"), test_basic);
+    g_test_add_func(TEST_("param"), test_param);
+    test_init(&test_opt, argc, argv);
+    return g_test_run();
+}
+
+/*
+ * Local Variables:
+ * mode: C
+ * c-basic-offset: 4
+ * indent-tabs-mode: nil
+ * End:
+ */

--- a/unit/unit_remote_request/unit_remote_request.c
+++ b/unit/unit_remote_request/unit_remote_request.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -87,6 +87,7 @@ test_null(
     g_assert(!gbinder_remote_request_read_string8(NULL));
     g_assert(!gbinder_remote_request_read_string16(NULL));
     g_assert(!gbinder_remote_request_read_object(NULL));
+    g_assert(!gbinder_remote_request_translate_to_local(NULL, NULL));
 }
 
 /*==========================================================================*

--- a/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
+++ b/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2021 Jolla Ltd.
+ * Copyright (C) 2020-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -351,7 +351,7 @@ test_get()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -429,7 +429,7 @@ test_list()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, test.loop);
 
     g_strfreev(test.list);
     g_main_loop_unref(test.loop);
@@ -492,7 +492,7 @@ test_notify()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -551,7 +551,7 @@ test_notify2()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 

--- a/unit/unit_servicemanager_aidl2/unit_servicemanager_aidl2.c
+++ b/unit/unit_servicemanager_aidl2/unit_servicemanager_aidl2.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2021 Jolla Ltd.
+ * Copyright (C) 2020-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -327,7 +327,7 @@ test_context_deinit(
     gbinder_local_object_drop(GBINDER_LOCAL_OBJECT(test->service));
     gbinder_servicemanager_unref(test->client);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, NULL);
     remove(test->config_file);
     remove(test->config_dir);
     g_free(test->config_file);

--- a/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
+++ b/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
@@ -221,7 +221,7 @@ test_get()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, loop);
     test_config_deinit(&config);
     g_main_loop_unref(loop);
 }
@@ -306,7 +306,7 @@ test_list()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, test.loop);
     test_config_deinit(&config);
 
     g_strfreev(test.list);
@@ -427,7 +427,7 @@ test_notify()
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
-    test_binder_exit_wait();
+    test_binder_exit_wait(&test_opt, test.loop);
     test_config_deinit(&config);
     g_main_loop_unref(test.loop);
 }

--- a/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
+++ b/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
@@ -34,18 +34,10 @@
 #include "test_servicemanager_hidl.h"
 
 #include "gbinder_ipc.h"
-#include "gbinder_cleanup.h"
 #include "gbinder_config.h"
-#include "gbinder_client_p.h"
 #include "gbinder_driver.h"
-#include "gbinder_reader.h"
-#include "gbinder_writer.h"
 #include "gbinder_servicemanager_p.h"
 #include "gbinder_local_object_p.h"
-#include "gbinder_local_reply.h"
-#include "gbinder_local_request.h"
-#include "gbinder_remote_request.h"
-#include "gbinder_remote_object_p.h"
 
 #include <gutil_log.h>
 #include <gutil_strv.h>
@@ -118,15 +110,13 @@ test_config_deinit(
 static
 TestServiceManagerHidl*
 test_servicemanager_impl_new(
-    const char* dev,
-    gboolean handle_on_looper_thread)
+    const char* dev)
 {
     GBinderIpc* ipc = gbinder_ipc_new(dev);
     const int fd = gbinder_driver_fd(ipc->driver);
-    TestServiceManagerHidl* sm =
-        test_servicemanager_hidl_new(ipc, handle_on_looper_thread);
+    TestServiceManagerHidl* sm = test_servicemanager_hidl_new(ipc);
 
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_binder_register_object(fd, GBINDER_LOCAL_OBJECT(sm),
         GBINDER_SERVICEMANAGER_HANDLE);
     gbinder_ipc_unref(ipc);
@@ -192,13 +182,14 @@ test_get()
 
     test_config_init(&config, NULL);
     ipc = gbinder_ipc_new(MAIN_DEV);
-    smsvc = test_servicemanager_impl_new(OTHER_DEV, FALSE);
+    smsvc = test_servicemanager_impl_new(OTHER_DEV);
     obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     fd = gbinder_driver_fd(ipc->driver);
 
     /* Set up binder simulator */
     test_binder_register_object(fd, obj, AUTO_HANDLE);
     test_binder_set_passthrough(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     sm = gbinder_servicemanager_new(MAIN_DEV);
 
     /* This one fails because of unexpected name format */
@@ -278,13 +269,14 @@ test_list()
 
     test_config_init(&config, NULL);
     ipc = gbinder_ipc_new(MAIN_DEV);
-    smsvc = test_servicemanager_impl_new(OTHER_DEV, FALSE);
+    smsvc = test_servicemanager_impl_new(OTHER_DEV);
     obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     fd = gbinder_driver_fd(ipc->driver);
 
     /* Set up binder simulator */
     test_binder_register_object(fd, obj, AUTO_HANDLE);
     test_binder_set_passthrough(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     sm = gbinder_servicemanager_new(MAIN_DEV);
 
     /* Request the list and wait for completion */
@@ -368,17 +360,11 @@ test_notify_cb(
     void* user_data)
 {
     TestNotify* test = user_data;
-    GBinderIpc* ipc = test_servicemanager_hidl_ipc(test->smsvc);
-    int fd = gbinder_driver_fd(ipc->driver);
-    
+
     g_assert(name);
     GDEBUG("'%s' is registered", name);
     g_assert_cmpint(test->notify_count, == ,0);
     test->notify_count++;
-    /* We want BR_TRANSACTION_COMPLETE to be handled by the transaction
-     * thread, disable the looper before pushing the data. */
-    test_binder_set_looper_enabled(fd, FALSE);
-    test_binder_br_transaction_complete(fd);
     /* Exit the loop after both things happen */
     if (test->name_added) {
         g_main_loop_quit(test->loop);
@@ -403,13 +389,14 @@ test_notify()
 
     test_config_init(&config, NULL);
     ipc = gbinder_ipc_new(MAIN_DEV);
-    test.smsvc = test_servicemanager_impl_new(OTHER_DEV, TRUE);
+    test.smsvc = test_servicemanager_impl_new(OTHER_DEV);
     obj = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     fd = gbinder_driver_fd(ipc->driver);
 
     /* Set up binder simulator */
     test_binder_register_object(fd, obj, AUTO_HANDLE);
     test_binder_set_passthrough(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     sm = gbinder_servicemanager_new(MAIN_DEV);
 
     /* This one fails because of invalid names */


### PR DESCRIPTION
`GBinderBridge` acts as a proxy between two binder devices.
    
This version works for binder transactions which only pass serialized data back and forth. Passing remote object references is not yet supported.