### PR TITLE
Support for passing object references over the bridge

### DIFF
--- a/include/gbinder_bridge.h
+++ b/include/gbinder_bridge.h
@@ -37,12 +37,6 @@
 
 /* Since 1.1.5 */
 
-/*
- * As of time of this writing, bridging only works for binder transactions
- * which only involve passing serialized data back and forth. It doesn't
- * work with transactions which pass references to remote objects.
- */
-
 G_BEGIN_DECLS
 
 /*
@@ -67,6 +61,15 @@ gbinder_bridge_new(
     const char* const* ifaces,
     GBinderServiceManager* src,
     GBinderServiceManager* dest) /* Since 1.1.5 */
+    G_GNUC_WARN_UNUSED_RESULT;
+
+GBinderBridge*
+gbinder_bridge_new2(
+    const char* src_name,
+    const char* dest_name,
+    const char* const* ifaces,
+    GBinderServiceManager* src,
+    GBinderServiceManager* dest) /* Since 1.1.6 */
     G_GNUC_WARN_UNUSED_RESULT;
 
 void

--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -30,9 +30,9 @@ This package contains the development library for %{name}.
 
 %build
 make LIBDIR=%{_libdir} KEEP_SYMBOLS=1 release pkgconfig
-make -C test/binder-bridge release
-make -C test/binder-list release
-make -C test/binder-ping release
+make -C test/binder-bridge KEEP_SYMBOLS=1 release
+make -C test/binder-list KEEP_SYMBOLS=1 release
+make -C test/binder-ping KEEP_SYMBOLS=1 release
 
 %install
 rm -rf %{buildroot}

--- a/src/gbinder_bridge.c
+++ b/src/gbinder_bridge.c
@@ -96,6 +96,7 @@ gbinder_bridge_interface_deactivate(
     }
     if (bi->src_name) {
         gbinder_servicename_unref(bi->src_name);
+        bi->src_name = NULL;
     }
 }
 
@@ -123,7 +124,7 @@ gbinder_bridge_dest_death_proc(
     GBinderBridgeInterface* bi = user_data;
 
     GDEBUG("%s has died", bi->fqname);
-    gbinder_bridge_dest_drop_remote_object(bi);
+    gbinder_bridge_interface_deactivate(bi);
 }
 
 static

--- a/src/gbinder_buffer.c
+++ b/src/gbinder_buffer.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -110,6 +110,47 @@ gbinder_buffer_contents_unref(
             gbinder_buffer_contents_free(self);
         }
     }
+}
+
+/*==========================================================================*
+ * GBinderBufferContentsList
+ * It's actually a GSList containing GBinderBufferContents refs.
+ *==========================================================================*/
+
+GBinderBufferContentsList*
+gbinder_buffer_contents_list_add(
+    GBinderBufferContentsList* list,
+    GBinderBufferContents* contents)
+{
+    /* Prepend rather than append for better efficiency */
+    return contents ? (GBinderBufferContentsList*) g_slist_prepend((GSList*)
+            list, gbinder_buffer_contents_ref(contents)) : list;
+}
+
+GBinderBufferContentsList*
+gbinder_buffer_contents_list_dup(
+    GBinderBufferContentsList* list)
+{
+    GSList* out = NULL;
+
+    if (list) {
+        GSList* l = (GSList*) list;
+
+        /* The order gets reversed but it doesn't matter */
+        while (l) {
+            out = g_slist_prepend(out, gbinder_buffer_contents_ref(l->data));
+            l = l->next;
+        }
+    }
+    return (GBinderBufferContentsList*) out;
+}
+
+void
+gbinder_buffer_contents_list_free(
+    GBinderBufferContentsList* list)
+{
+    g_slist_free_full((GSList*) list, (GDestroyNotify)
+        gbinder_buffer_contents_unref);
 }
 
 /*==========================================================================*

--- a/src/gbinder_buffer_p.h
+++ b/src/gbinder_buffer_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -86,6 +86,22 @@ gbinder_buffer_contents_ref(
 void
 gbinder_buffer_contents_unref(
     GBinderBufferContents* contents)
+    GBINDER_INTERNAL;
+
+GBinderBufferContentsList*
+gbinder_buffer_contents_list_add(
+    GBinderBufferContentsList* list,
+    GBinderBufferContents* contents)
+    GBINDER_INTERNAL;
+
+GBinderBufferContentsList*
+gbinder_buffer_contents_list_dup(
+    GBinderBufferContentsList* list)
+    GBINDER_INTERNAL;
+
+void
+gbinder_buffer_contents_list_free(
+    GBinderBufferContentsList* list)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_BUFFER_PRIVATE_H */

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -401,18 +401,18 @@ gbinder_driver_reply_data(
     GUtilIntArray* offsets = gbinder_output_data_offsets(data);
     void* offsets_buf = NULL;
 
-    /* Build BC_TRANSACTION */
+    /* Build BC_REPLY */
     if (extra_buffers) {
         GVERBOSE("< BC_REPLY_SG %u bytes", (guint)extra_buffers);
         gbinder_driver_verbose_dump_bytes(' ', data->bytes);
         *cmd = io->bc.reply_sg;
-        len += io->encode_transaction_sg(buf + len, 0, 0, data->bytes, 0,
+        len += io->encode_reply_sg(buf + len, 0, 0, data->bytes,
             offsets, &offsets_buf, extra_buffers);
     } else {
         GVERBOSE("< BC_REPLY");
         gbinder_driver_verbose_dump_bytes(' ', data->bytes);
         *cmd = io->bc.reply;
-        len += io->encode_transaction(buf + len, 0, 0, data->bytes, 0,
+        len += io->encode_reply(buf + len, 0, 0, data->bytes,
             offsets, &offsets_buf);
     }
 

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -870,11 +870,23 @@ gbinder_driver_unref(
 {
     GASSERT(self->refcount > 0);
     if (g_atomic_int_dec_and_test(&self->refcount)) {
+        gbinder_driver_close(self);
+        g_free(self->dev);
+        g_slice_free(GBinderDriver, self);
+    }
+}
+
+void
+gbinder_driver_close(
+    GBinderDriver* self)
+{
+    if (self->vm) {
         GDEBUG("Closing %s", self->dev);
         gbinder_system_munmap(self->vm, self->vmsize);
         gbinder_system_close(self->fd);
-        g_free(self->dev);
-        g_slice_free(GBinderDriver, self);
+        self->fd = -1;
+        self->vm = NULL;
+        self->vmsize = 0;
     }
 }
 

--- a/src/gbinder_driver.h
+++ b/src/gbinder_driver.h
@@ -53,6 +53,11 @@ gbinder_driver_unref(
     GBinderDriver* driver)
     GBINDER_INTERNAL;
 
+void
+gbinder_driver_close(
+    GBinderDriver* driver)
+    GBINDER_INTERNAL;
+
 int
 gbinder_driver_fd(
     GBinderDriver* driver)

--- a/src/gbinder_driver.h
+++ b/src/gbinder_driver.h
@@ -85,6 +85,18 @@ gbinder_driver_protocol(
     GBINDER_INTERNAL;
 
 gboolean
+gbinder_driver_acquire_done(
+    GBinderDriver* driver,
+    GBinderLocalObject* obj)
+    GBINDER_INTERNAL;
+
+gboolean
+gbinder_driver_dead_binder_done(
+    GBinderDriver* driver,
+    GBinderRemoteObject* obj)
+    GBINDER_INTERNAL;
+
+gboolean
 gbinder_driver_request_death_notification(
     GBinderDriver* driver,
     GBinderRemoteObject* obj)
@@ -161,17 +173,15 @@ gbinder_driver_transact(
     GBinderRemoteReply* reply)
     GBINDER_INTERNAL;
 
-int
-gbinder_driver_ping(
-    GBinderDriver* driver,
-    GBinderObjectRegistry* reg,
-    guint32 handle)
-    GBINDER_INTERNAL;
-
 GBinderLocalRequest*
 gbinder_driver_local_request_new(
     GBinderDriver* driver,
     const char* iface)
+    GBINDER_INTERNAL;
+
+GBinderLocalRequest*
+gbinder_driver_local_request_new_ping(
+    GBinderDriver* self)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_DRIVER_H */

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -149,17 +149,24 @@ struct gbinder_io {
 #define GBINDER_MAX_DEATH_NOTIFICATION_SIZE (12)
     guint (*encode_death_notification)(void* out, GBinderRemoteObject* obj);
 
-    /* Encode BC_TRANSACTION/REPLY data */
+    /* Encode BC_TRANSACTION/BC_TRANSACTION_SG data */
 #define GBINDER_MAX_BC_TRANSACTION_SIZE (64)
     guint (*encode_transaction)(void* out, guint32 handle, guint32 code,
         const GByteArray* data, guint flags /* See below */,
         GUtilIntArray* offsets, void** offsets_buf);
-
-    /* Encode BC_TRANSACTION_SG/REPLY_SG data */
 #define GBINDER_MAX_BC_TRANSACTION_SG_SIZE (72)
     guint (*encode_transaction_sg)(void* out, guint32 handle, guint32 code,
         const GByteArray* data, guint flags /* GBINDER_TX_FLAG_xxx */,
         GUtilIntArray* offsets, void** offsets_buf,
+        gsize buffers_size);
+
+    /* Encode BC_REPLY/REPLY_SG data */
+#define GBINDER_MAX_BC_REPLY_SIZE GBINDER_MAX_BC_TRANSACTION_SIZE
+    guint (*encode_reply)(void* out, guint32 handle, guint32 code,
+        const GByteArray* data, GUtilIntArray* offsets, void** offsets_buf);
+#define GBINDER_MAX_BC_REPLY_SG_SIZE GBINDER_MAX_BC_TRANSACTION_SG_SIZE
+    guint (*encode_reply_sg)(void* out, guint32 handle, guint32 code,
+        const GByteArray* data, GUtilIntArray* offsets, void** offsets_buf,
         gsize buffers_size);
 
     /* Encode BC_REPLY */

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2019 Jolla Ltd.
- * Copyright (C) 2018-2019 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -125,7 +125,8 @@ struct gbinder_io {
         guint failed_reply;
     } br;
 
-    /* Size of the object's extra data */
+    /* Size of the object and its extra data */
+    gsize (*object_size)(const void* obj);
     gsize (*object_data_size)(const void* obj);
 
     /* Writes pointer to the buffer. The destination buffer must have
@@ -133,6 +134,12 @@ struct gbinder_io {
      * actual size is returned. */
 #define GBINDER_MAX_POINTER_SIZE (8)
     guint (*encode_pointer)(void* out, const void* pointer);
+
+    /* Writes cookie to the buffer. The destination buffer must have
+     * at least GBINDER_IO_MAX_COOKIE_SIZE bytes available. The
+     * actual size is returned. */
+#define GBINDER_MAX_COOKIE_SIZE GBINDER_MAX_POINTER_SIZE
+    guint (*encode_cookie)(void* out, guint64 cookie);
 
     /* Encode flat_buffer_object */
 #define GBINDER_MAX_BINDER_OBJECT_SIZE (24)
@@ -145,9 +152,13 @@ struct gbinder_io {
     guint (*encode_buffer_object)(void* out, const void* data, gsize size,
         const GBinderParent* parent);
 
-    /* Encode death notification */
-#define GBINDER_MAX_DEATH_NOTIFICATION_SIZE (12)
-    guint (*encode_death_notification)(void* out, GBinderRemoteObject* obj);
+    /* Encode binder_handle_cookie */
+#define GBINDER_MAX_HANDLE_COOKIE_SIZE (12)
+    guint (*encode_handle_cookie)(void* out, GBinderRemoteObject* obj);
+
+    /* Encode binder_ptr_cookie */
+#define GBINDER_MAX_PTR_COOKIE_SIZE (16)
+    guint (*encode_ptr_cookie)(void* out, GBinderLocalObject* obj);
 
     /* Encode BC_TRANSACTION/BC_TRANSACTION_SG data */
 #define GBINDER_MAX_BC_TRANSACTION_SIZE (64)
@@ -174,10 +185,9 @@ struct gbinder_io {
 
     /* Decoders */
     void (*decode_transaction_data)(const void* data, GBinderIoTxData* tx);
-
-#define GBINDER_MAX_PTR_COOKIE_SIZE (16)
-    void* (*decode_binder_ptr_cookie)(const void* data);
+    void* (*decode_ptr_cookie)(const void* data);
     guint (*decode_cookie)(const void* data, guint64* cookie);
+    guint (*decode_binder_handle)(const void* obj, guint32* handle);
     guint (*decode_binder_object)(const void* data, gsize size,
         GBinderObjectRegistry* reg, GBinderRemoteObject** obj);
     guint (*decode_buffer_object)(GBinderBuffer* buf, gsize offset,

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -64,6 +64,7 @@ struct gbinder_ipc_priv {
     GThreadPool* tx_pool;
     GHashTable* tx_table;
     char* key;
+    const char* name;
     GBinderObjectRegistry object_registry;
 
     GMutex remote_objects_mutex;
@@ -207,7 +208,7 @@ typedef struct gbinder_ipc_tx_custom {
 } GBinderIpcTxCustom;
 
 GBINDER_INLINE_FUNC const char* gbinder_ipc_name(GBinderIpc* self)
-    { return gbinder_driver_dev(self->driver); }
+    { return self->priv->name; }
 
 static
 GBinderIpcLooper*
@@ -685,7 +686,7 @@ gbinder_ipc_looper_transact(
             /* Lock */
             g_mutex_lock(&priv->looper_mutex);
             if (gbinder_ipc_looper_remove_primary(looper)) {
-                GDEBUG("Primary looper %s is blocked", looper->name);
+                GVERBOSE("Primary looper %s is blocked", looper->name);
                 looper->next = priv->blocked_loopers;
                 priv->blocked_loopers = looper;
                 was_blocked = TRUE;
@@ -712,7 +713,7 @@ gbinder_ipc_looper_transact(
             /* Block until asynchronous transaction gets completed. */
             done = 0;
             if (gbinder_ipc_wait(looper->pipefd[0], tx->pipefd[0], &done)) {
-                GDEBUG("Looper %s is released", looper->name);
+                GVERBOSE("Looper %s is released", looper->name);
                 GASSERT(done == TX_DONE);
             }
         }
@@ -1115,16 +1116,24 @@ gbinder_ipc_tx_handler_transact(
 static
 void
 gbinder_ipc_invalidate_remote_handle_locked(
-    GBinderIpcPriv* priv,
+    GBinderIpc* self,
     guint32 handle)
 {
+    GBinderIpcPriv* priv = self->priv;
+
     /* Caller holds priv->remote_objects_mutex */
     if (priv->remote_objects) {
-        GVERBOSE_("handle %u", handle);
-        g_hash_table_remove(priv->remote_objects, GINT_TO_POINTER(handle));
-        if (g_hash_table_size(priv->remote_objects) == 0) {
-            g_hash_table_unref(priv->remote_objects);
-            priv->remote_objects = NULL;
+        const gpointer key = GINT_TO_POINTER(handle);
+#if GUTIL_LOG_VERBOSE
+        const gpointer obj = g_hash_table_lookup(priv->remote_objects, key);
+#endif
+
+        if (g_hash_table_remove(priv->remote_objects, key)) {
+            GVERBOSE_("handle %u %p %s", handle, obj, gbinder_ipc_name(self));
+            if (g_hash_table_size(priv->remote_objects) == 0) {
+                g_hash_table_unref(priv->remote_objects);
+                priv->remote_objects = NULL;
+            }
         }
     }
 }
@@ -1138,7 +1147,7 @@ gbinder_ipc_invalidate_remote_handle(
 
     /* Lock */
     g_mutex_lock(&priv->remote_objects_mutex);
-    gbinder_ipc_invalidate_remote_handle_locked(priv, handle);
+    gbinder_ipc_invalidate_remote_handle_locked(self, handle);
     g_mutex_unlock(&priv->remote_objects_mutex);
     /* Unlock */
 }
@@ -1173,10 +1182,12 @@ gbinder_ipc_local_object_disposed(
     /* Lock */
     g_mutex_lock(&priv->local_objects_mutex);
     if (obj->object.ref_count == 1 && priv->local_objects) {
-        g_hash_table_remove(priv->local_objects, obj);
-        if (g_hash_table_size(priv->local_objects) == 0) {
-            g_hash_table_unref(priv->local_objects);
-            priv->local_objects = NULL;
+        if (g_hash_table_remove(priv->local_objects, obj)) {
+            GVERBOSE_("%p %s", obj, gbinder_ipc_name(self));
+            if (g_hash_table_size(priv->local_objects) == 0) {
+                g_hash_table_unref(priv->local_objects);
+                priv->local_objects = NULL;
+            }
         }
     }
     g_mutex_unlock(&priv->local_objects_mutex);
@@ -1193,7 +1204,7 @@ gbinder_ipc_remote_object_disposed(
     /* Lock */
     g_mutex_lock(&priv->remote_objects_mutex);
     if (obj->object.ref_count == 1) {
-        gbinder_ipc_invalidate_remote_handle_locked(priv, obj->handle);
+        gbinder_ipc_invalidate_remote_handle_locked(self, obj->handle);
     }
     g_mutex_unlock(&priv->remote_objects_mutex);
     /* Unlock */
@@ -1211,11 +1222,13 @@ gbinder_ipc_register_local_object(
     if (!priv->local_objects) {
         priv->local_objects = g_hash_table_new(g_direct_hash, g_direct_equal);
     }
-    g_hash_table_insert(priv->local_objects, obj, obj);
+    if (!g_hash_table_contains(priv->local_objects, obj)) {
+        g_hash_table_insert(priv->local_objects, obj, obj);
+        GVERBOSE_("%p %s", obj, gbinder_ipc_name(self));
+    }
     g_mutex_unlock(&priv->local_objects_mutex);
     /* Unlock */
 
-    GVERBOSE_("%p", obj);
     gbinder_ipc_looper_check(self);
 }
 
@@ -1252,6 +1265,7 @@ GBinderRemoteObject*
 gbinder_ipc_priv_get_remote_object(
     GBinderIpcPriv* priv,
     guint32 handle,
+    REMOTE_REGISTRY_CREATE create,
     gboolean maybe_dead)
 {
     GBinderRemoteObject* obj = NULL;
@@ -1264,16 +1278,22 @@ gbinder_ipc_priv_get_remote_object(
     }
     if (obj) {
         gbinder_remote_object_ref(obj);
-    } else {
+    } else if (create != REMOTE_REGISTRY_DONT_CREATE) {
+        GBinderIpc* self = priv->self;
+
         /*
          * If maybe_dead is TRUE, the caller is supposed to try reanimating
          * the object on the main thread not holding any global locks.
          */
-        obj = gbinder_remote_object_new(priv->self, handle, maybe_dead);
+        obj = gbinder_remote_object_new(self, handle, maybe_dead ?
+            REMOTE_OBJECT_CREATE_DEAD : (create == REMOTE_REGISTRY_CAN_CREATE) ?
+            REMOTE_OBJECT_CREATE_ALIVE :
+            REMOTE_OBJECT_CREATE_ACQUIRED);
         if (!priv->remote_objects) {
             priv->remote_objects = g_hash_table_new
                 (g_direct_hash, g_direct_equal);
         }
+        GVERBOSE_("%p handle %u %s", obj, handle, gbinder_ipc_name(self));
         g_hash_table_replace(priv->remote_objects, key, obj);
     }
     g_mutex_unlock(&priv->remote_objects_mutex);
@@ -1282,14 +1302,47 @@ gbinder_ipc_priv_get_remote_object(
     return obj;
 }
 
-GBinderRemoteObject*
-gbinder_ipc_get_remote_object(
+GBinderLocalObject*
+gbinder_ipc_find_local_object(
     GBinderIpc* self,
-    guint32 handle,
-    gboolean maybe_dead)
+    GBinderIpcLocalObjectCheckFunc func,
+    void* user_data)
+{
+    GBinderLocalObject* found = NULL;
+
+    if (self)  {
+        GBinderIpcPriv* priv = self->priv;
+
+        /* Lock */
+        g_mutex_lock(&priv->local_objects_mutex);
+        if (priv->local_objects) {
+            GHashTableIter it;
+            gpointer value;
+
+            g_hash_table_iter_init(&it, priv->local_objects);
+            while (g_hash_table_iter_next(&it, NULL, &value)) {
+                GBinderLocalObject* obj = GBINDER_LOCAL_OBJECT(value);
+
+                if (func(obj, user_data)) {
+                    found = gbinder_local_object_ref(obj);
+                    break;
+                }
+            }
+        }
+        g_mutex_unlock(&priv->local_objects_mutex);
+        /* Unlock */
+    }
+
+    return found;
+}
+
+GBinderRemoteObject*
+gbinder_ipc_get_service_manager(
+    GBinderIpc* self)
 {
     /* GBinderServiceManager makes sure that GBinderIpc pointer is not NULL */
-    return gbinder_ipc_priv_get_remote_object(self->priv, handle, maybe_dead);
+    return gbinder_ipc_priv_get_remote_object(self->priv,
+        GBINDER_SERVICEMANAGER_HANDLE, REMOTE_REGISTRY_CAN_CREATE, TRUE);
 }
 
 GBINDER_INLINE_FUNC
@@ -1338,10 +1391,11 @@ static
 GBinderRemoteObject*
 gbinder_ipc_object_registry_get_remote(
     GBinderObjectRegistry* reg,
-    guint32 handle)
+    guint32 handle,
+    REMOTE_REGISTRY_CREATE create)
 {
     return gbinder_ipc_priv_get_remote_object
-        (gbinder_ipc_priv_from_object_registry(reg), handle, FALSE);
+        (gbinder_ipc_priv_from_object_registry(reg), handle, create, FALSE);
 }
 
 /*==========================================================================*
@@ -1769,6 +1823,9 @@ gbinder_ipc_new(
                 gbinder_ipc_table = g_hash_table_new(g_str_hash, g_str_equal);
             }
             g_hash_table_replace(gbinder_ipc_table, priv->key, self);
+            /* With "/dev/" prefix, it may be too long to be a thread name */
+            priv->name = priv->key +
+                (g_str_has_prefix(priv->key, "/dev/") ? 5 : 0);
         }
     }
     pthread_mutex_unlock(&gbinder_ipc_mutex);
@@ -1801,8 +1858,37 @@ GBinderObjectRegistry*
 gbinder_ipc_object_registry(
     GBinderIpc* self)
 {
-    /* Only used by unit tests */
     return G_LIKELY(self) ? &self->priv->object_registry : NULL;
+}
+
+const GBinderIo*
+gbinder_ipc_io(
+    GBinderIpc* self)
+{
+    return G_LIKELY(self) ? gbinder_driver_io(self->driver) : NULL;
+}
+
+const GBinderRpcProtocol*
+gbinder_ipc_protocol(
+    GBinderIpc* self)
+{
+    return G_LIKELY(self) ? gbinder_driver_protocol(self->driver) : NULL;
+}
+
+int
+gbinder_ipc_ping_sync(
+    GBinderIpc* ipc,
+    guint32 handle,
+    const GBinderIpcSyncApi* api)
+{
+    GBinderDriver* driver = ipc->driver;
+    GBinderLocalRequest* req = gbinder_driver_local_request_new_ping(driver);
+    guint32 code = gbinder_driver_protocol(driver)->ping_tx;
+    int ret;
+
+    gbinder_remote_reply_unref(api->sync_reply(ipc, handle, code, req, &ret));
+    gbinder_local_request_unref(req);
+    return ret;
 }
 
 gulong
@@ -1951,7 +2037,11 @@ gbinder_ipc_dispose(
     GVERBOSE_("%s", self->dev);
     /* Lock */
     pthread_mutex_lock(&gbinder_ipc_mutex);
-    GASSERT(gbinder_ipc_table);
+    /*
+     * gbinder_ipc_dispose() can be invoked more than once (typically
+     * at shutdown) and gbinder_ipc_table here may actually happen to
+     * be NULL, hence the check.
+     */
     if (gbinder_ipc_table) {
         GBinderIpcPriv* priv = self->priv;
 

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -60,6 +60,12 @@ struct gbinder_ipc_tx {
 };
 
 typedef
+gboolean
+(*GBinderIpcLocalObjectCheckFunc)(
+    GBinderLocalObject* obj,
+    void* user_data);
+
+typedef
 void
 (*GBinderIpcReplyFunc)(
     GBinderIpc* ipc,
@@ -109,13 +115,31 @@ gbinder_ipc_unref(
 
 void
 gbinder_ipc_looper_check(
-   GBinderIpc* ipc)
+    GBinderIpc* ipc)
     GBINDER_INTERNAL;
 
 GBinderObjectRegistry*
 gbinder_ipc_object_registry(
     GBinderIpc* ipc)
     GBINDER_INTERNAL;
+
+const GBinderIo*
+gbinder_ipc_io(
+    GBinderIpc* ipc)
+    GBINDER_INTERNAL;
+
+const GBinderRpcProtocol*
+gbinder_ipc_protocol(
+    GBinderIpc* ipc)
+    GBINDER_INTERNAL;
+
+GBinderLocalObject*
+gbinder_ipc_find_local_object(
+    GBinderIpc* ipc,
+    GBinderIpcLocalObjectCheckFunc func,
+    void* user_data)
+    GBINDER_INTERNAL
+    G_GNUC_WARN_UNUSED_RESULT;
 
 void
 gbinder_ipc_register_local_object(
@@ -124,16 +148,22 @@ gbinder_ipc_register_local_object(
     GBINDER_INTERNAL;
 
 GBinderRemoteObject*
-gbinder_ipc_get_remote_object(
-    GBinderIpc* ipc,
-    guint32 handle,
-    gboolean maybe_dead)
-    GBINDER_INTERNAL;
+gbinder_ipc_get_service_manager(
+    GBinderIpc* self)
+    GBINDER_INTERNAL
+    G_GNUC_WARN_UNUSED_RESULT;
 
 void
 gbinder_ipc_invalidate_remote_handle(
     GBinderIpc* ipc,
     guint32 handle)
+    GBINDER_INTERNAL;
+
+int
+gbinder_ipc_ping_sync(
+    GBinderIpc* ipc,
+    guint32 handle,
+    const GBinderIpcSyncApi* api)
     GBINDER_INTERNAL;
 
 gulong

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -77,6 +77,8 @@ typedef struct gbinder_local_object_class {
     GBinderLocalReply* (*handle_looper_transaction)
         (GBinderLocalObject* self, GBinderRemoteRequest* req, guint code,
             guint flags, int* status);
+    void (*acquire)(GBinderLocalObject* self);
+    void (*release)(GBinderLocalObject* self);
     void (*drop)(GBinderLocalObject* self);
     /* Need to add some placeholders if this class becomes public */
 } GBinderLocalObjectClass;
@@ -166,7 +168,8 @@ gbinder_local_object_handle_decrefs(
 
 void
 gbinder_local_object_handle_acquire(
-    GBinderLocalObject* obj)
+    GBinderLocalObject* obj,
+    GBinderBufferContentsList* bufs)
     GBINDER_INTERNAL;
 
 void

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -40,8 +40,9 @@
 #include <glib-object.h>
 
 /*
- * Some if this stuff may become public if we decide to allow the clients
- * to derive their classes from GBinderLocalObject
+ * Some of this stuff may become public if we decide to allow the clients
+ * to derive their own classes from GBinderLocalObject. For now it's all
+ * private.
  */
 
 typedef

--- a/src/gbinder_local_request_p.h
+++ b/src/gbinder_local_request_p.h
@@ -43,21 +43,30 @@ gbinder_local_request_new(
     GBytes* init)
     GBINDER_INTERNAL;
 
-GBinderOutputData*
-gbinder_local_request_data(
-    GBinderLocalRequest* req)
+GBinderLocalRequest*
+gbinder_local_request_new_iface(
+    const GBinderIo* io,
+    const GBinderRpcProtocol* protocol,
+    const char* iface)
     GBINDER_INTERNAL;
 
 GBinderLocalRequest*
 gbinder_local_request_new_from_data(
-    GBinderBuffer* buffer)
+    GBinderBuffer* buffer,
+    GBinderObjectConverter* convert)
+    GBINDER_INTERNAL;
+
+GBinderOutputData*
+gbinder_local_request_data(
+    GBinderLocalRequest* req)
     GBINDER_INTERNAL;
 
 void
 gbinder_local_request_append_contents(
     GBinderLocalRequest* req,
     GBinderBuffer* buffer,
-    gsize offset)
+    gsize offset,
+    GBinderObjectConverter* convert)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_LOCAL_REQUEST_PRIVATE_H */

--- a/src/gbinder_object_converter.h
+++ b/src/gbinder_object_converter.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2021 Jolla Ltd.
+ * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -30,36 +30,33 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef GBINDER_LOCAL_REPLY_PRIVATE_H
-#define GBINDER_LOCAL_REPLY_PRIVATE_H
-
-#include <gbinder_local_reply.h>
+#ifndef GBINDER_OBJECT_CONVERTER_H
+#define GBINDER_OBJECT_CONVERTER_H
 
 #include "gbinder_types_p.h"
 
-GBinderLocalReply*
-gbinder_local_reply_new(
-    const GBinderIo* io)
-    GBINDER_INTERNAL;
+typedef struct gbinder_object_converter_functions {
+    GBinderLocalObject* (*handle_to_local)(GBinderObjectConverter*, guint32);
+} GBinderObjectConverterFunctions;
 
-GBinderOutputData*
-gbinder_local_reply_data(
-    GBinderLocalReply* reply)
-    GBINDER_INTERNAL;
+struct gbinder_object_converter {
+    const GBinderObjectConverterFunctions* f;
+    const GBinderIo* io;
+    const GBinderRpcProtocol* protocol;
+};
 
-GBinderBufferContents*
-gbinder_local_reply_contents(
-    GBinderLocalReply* reply)
-    GBINDER_INTERNAL;
+/* Inline wrappers */
 
-GBinderLocalReply*
-gbinder_local_reply_set_contents(
-    GBinderLocalReply* reply,
-    GBinderBuffer* buffer,
-    GBinderObjectConverter* convert)
-    GBINDER_INTERNAL;
+GBINDER_INLINE_FUNC
+GBinderLocalObject*
+gbinder_object_converter_handle_to_local(
+    GBinderObjectConverter* convert,
+    guint32 handle)
+{
+    return convert ? convert->f->handle_to_local(convert, handle) : NULL;
+}
 
-#endif /* GBINDER_LOCAL_REPLY_PRIVATE_H */
+#endif /* GBINDER_OBJECT_CONVERTER_H */
 
 /*
  * Local Variables:

--- a/src/gbinder_object_registry.h
+++ b/src/gbinder_object_registry.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -35,13 +35,19 @@
 
 #include "gbinder_types_p.h"
 
+typedef enum gbinder_remote_registry_create {
+    REMOTE_REGISTRY_DONT_CREATE,
+    REMOTE_REGISTRY_CAN_CREATE,
+    REMOTE_REGISTRY_CAN_CREATE_AND_ACQUIRE
+} REMOTE_REGISTRY_CREATE;
+
 typedef struct gbinder_object_registry_functions {
     void (*ref)(GBinderObjectRegistry* reg);
     void (*unref)(GBinderObjectRegistry* reg);
     GBinderLocalObject* (*get_local)(GBinderObjectRegistry* reg,
         void* pointer);
     GBinderRemoteObject* (*get_remote)(GBinderObjectRegistry* reg,
-        guint32 handle);
+        guint32 handle, REMOTE_REGISTRY_CREATE create);
 } GBinderObjectRegistryFunctions;
 
 struct gbinder_object_registry {
@@ -81,9 +87,10 @@ GBINDER_INLINE_FUNC
 GBinderRemoteObject*
 gbinder_object_registry_get_remote(
     GBinderObjectRegistry* reg,
-    guint32 handle)
+    guint32 handle,
+    REMOTE_REGISTRY_CREATE create)
 {
-    return reg ? reg->f->get_remote(reg, handle) : NULL;
+    return reg ? reg->f->get_remote(reg, handle, create) : NULL;
 }
 
 #endif /* GBINDER_OBJECT_REGISTRY_H */

--- a/src/gbinder_remote_object_p.h
+++ b/src/gbinder_remote_object_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -51,11 +51,17 @@ struct gbinder_remote_object {
 #define gbinder_remote_object_dev(obj) (gbinder_driver_dev((obj)->ipc->driver))
 #define gbinder_remote_object_io(obj) (gbinder_driver_io((obj)->ipc->driver))
 
+typedef enum gbinder_remote_object_create {
+    REMOTE_OBJECT_CREATE_DEAD,
+    REMOTE_OBJECT_CREATE_ALIVE,
+    REMOTE_OBJECT_CREATE_ACQUIRED
+} REMOTE_OBJECT_CREATE;
+
 GBinderRemoteObject*
 gbinder_remote_object_new(
     GBinderIpc* ipc,
     guint32 handle,
-    gboolean maybe_dead)
+    REMOTE_OBJECT_CREATE create)
     GBINDER_INTERNAL;
 
 gboolean
@@ -66,6 +72,11 @@ gbinder_remote_object_reanimate(
 void
 gbinder_remote_object_handle_death_notification(
     GBinderRemoteObject* obj)
+    GBINDER_INTERNAL;
+
+void
+gbinder_remote_object_commit_suicide(
+    GBinderRemoteObject* self)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_REMOTE_OBJECT_PRIVATE_H */

--- a/src/gbinder_remote_reply.c
+++ b/src/gbinder_remote_reply.c
@@ -118,13 +118,21 @@ GBinderLocalReply*
 gbinder_remote_reply_copy_to_local(
     GBinderRemoteReply* self)
 {
+    return gbinder_remote_reply_convert_to_local(self, NULL);
+}
+
+GBinderLocalReply*
+gbinder_remote_reply_convert_to_local(
+    GBinderRemoteReply* self,
+    GBinderObjectConverter* convert)
+{
     if (G_LIKELY(self)) {
         GBinderReaderData* d = &self->data;
         GBinderObjectRegistry* reg = d->reg;
 
         if (reg) {
             return gbinder_local_reply_set_contents
-                (gbinder_local_reply_new(reg->io), d->buffer);
+                (gbinder_local_reply_new(reg->io), d->buffer, convert);
         }
     }
     return NULL;

--- a/src/gbinder_remote_reply_p.h
+++ b/src/gbinder_remote_reply_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -40,6 +40,12 @@
 GBinderRemoteReply*
 gbinder_remote_reply_new(
     GBinderObjectRegistry* reg)
+    GBINDER_INTERNAL;
+
+GBinderLocalReply*
+gbinder_remote_reply_convert_to_local(
+    GBinderRemoteReply* reply,
+    GBinderObjectConverter* convert)
     GBINDER_INTERNAL;
 
 void

--- a/src/gbinder_remote_request.c
+++ b/src/gbinder_remote_request.c
@@ -34,6 +34,7 @@
 #include "gbinder_reader_p.h"
 #include "gbinder_rpc_protocol.h"
 #include "gbinder_local_request_p.h"
+#include "gbinder_object_converter.h"
 #include "gbinder_object_registry.h"
 #include "gbinder_buffer_p.h"
 #include "gbinder_driver.h"
@@ -86,31 +87,31 @@ gbinder_remote_request_copy_to_local(
     if (G_LIKELY(self)) {
         GBinderReaderData* d = &self->data;
 
-        return gbinder_local_request_new_from_data(d->buffer);
+        return gbinder_local_request_new_from_data(d->buffer, NULL);
     }
     return NULL;
 }
 
 GBinderLocalRequest*
-gbinder_remote_request_translate_to_local(
+gbinder_remote_request_convert_to_local(
     GBinderRemoteRequest* req,
-    GBinderDriver* driver)
+    GBinderObjectConverter* convert)
 {
     GBinderRemoteRequestPriv* self = gbinder_remote_request_cast(req);
 
     if (G_LIKELY(self)) {
         GBinderReaderData* data = &self->data;
 
-        if (!driver || (gbinder_driver_protocol(driver) == self->protocol)) {
+        if (!convert || convert->protocol == self->protocol) {
             /* The same protocol, the same format of RPC header */
-            return gbinder_local_request_new_from_data(data->buffer);
+            return gbinder_local_request_new_from_data(data->buffer, convert);
         } else {
             /* Need to translate to another format */
-            GBinderLocalRequest* local = gbinder_driver_local_request_new
-                (driver, self->iface);
+            GBinderLocalRequest* local = gbinder_local_request_new_iface
+                (convert->io, convert->protocol, self->iface);
 
             gbinder_local_request_append_contents(local, data->buffer,
-                self->header_size);
+                self->header_size, convert);
             return local;
         }
     }

--- a/src/gbinder_remote_request_p.h
+++ b/src/gbinder_remote_request_p.h
@@ -57,9 +57,9 @@ gbinder_remote_request_set_data(
     GBINDER_INTERNAL;
 
 GBinderLocalRequest*
-gbinder_remote_request_translate_to_local(
+gbinder_remote_request_convert_to_local(
     GBinderRemoteRequest* req,
-    GBinderDriver* driver)
+    GBinderObjectConverter* convert)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_REMOTE_REQUEST_PRIVATE_H */

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -529,9 +529,8 @@ gbinder_servicemanager_new_with_type(
         if (!dev) dev = klass->default_device;
         ipc = gbinder_ipc_new(dev);
         if (ipc) {
-            /* Create a possibly dead remote object */
-            GBinderRemoteObject* object = gbinder_ipc_get_remote_object
-                (ipc, GBINDER_SERVICEMANAGER_HANDLE, TRUE);
+            /* Create a (possibly) dead service manager object */
+            GBinderRemoteObject* object = gbinder_ipc_get_service_manager(ipc);
 
             if (object) {
                 gboolean first_ref;

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -39,9 +39,6 @@
 
 #include <glib-object.h>
 
-/* As a special case, ServiceManager's handle is zero */
-#define GBINDER_SERVICEMANAGER_HANDLE (0)
-
 typedef struct gbinder_servicemanager_priv GBinderServiceManagerPriv;
 
 typedef struct gbinder_servicemanager {

--- a/src/gbinder_system.c
+++ b/src/gbinder_system.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Contact: Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -34,6 +34,7 @@
 
 #include <unistd.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 
@@ -58,7 +59,10 @@ gbinder_system_ioctl(
     int request,
     void* data)
 {
-    return ioctl(fd, request, data);
+    int ret;
+
+    while ((ret = ioctl(fd, request, data)) < 0 && errno == EINTR);
+    return ret >= 0 ? 0 : -errno;
 }
 
 void*

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -36,10 +36,12 @@
 #include <gbinder_types.h>
 
 typedef struct gbinder_buffer_contents GBinderBufferContents;
+typedef struct gbinder_buffer_contents_list GBinderBufferContentsList;
 typedef struct gbinder_cleanup GBinderCleanup;
 typedef struct gbinder_driver GBinderDriver;
 typedef struct gbinder_handler GBinderHandler;
 typedef struct gbinder_io GBinderIo;
+typedef struct gbinder_object_converter GBinderObjectConverter;
 typedef struct gbinder_object_registry GBinderObjectRegistry;
 typedef struct gbinder_output_data GBinderOutputData;
 typedef struct gbinder_proxy_object GBinderProxyObject;
@@ -71,6 +73,9 @@ typedef struct gbinder_ipc_sync_api GBinderIpcSyncApi;
 #define HIDL_GET_REF_INFO_TRANSACTION             HIDL_FOURCC('R','E','F')
 #define HIDL_DEBUG_TRANSACTION                    HIDL_FOURCC('D','B','G')
 #define HIDL_HASH_CHAIN_TRANSACTION               HIDL_FOURCC('H','S','H')
+
+/* As a special case, ServiceManager's handle is zero */
+#define GBINDER_SERVICEMANAGER_HANDLE (0)
 
 #endif /* GBINDER_TYPES_PRIVATE_H */
 

--- a/src/gbinder_writer_p.h
+++ b/src/gbinder_writer_p.h
@@ -54,14 +54,16 @@ gbinder_writer_init(
 void
 gbinder_writer_data_set_contents(
     GBinderWriterData* data,
-    GBinderBuffer* buffer)
+    GBinderBuffer* buffer,
+    GBinderObjectConverter* convert)
     GBINDER_INTERNAL;
 
 void
 gbinder_writer_data_append_contents(
     GBinderWriterData* data,
     GBinderBuffer* buffer,
-    gsize data_offset)
+    gsize data_offset,
+    GBinderObjectConverter* convert)
     GBINDER_INTERNAL;
 
 void

--- a/test/binder-bridge/binder-bridge.c
+++ b/test/binder-bridge/binder-bridge.c
@@ -43,7 +43,8 @@
 typedef struct app_options {
     const char* src;
     const char* dest;
-    const char* name;
+    char* src_name;
+    const char* dest_name;
     const char** ifaces;
 } AppOptions;
 
@@ -72,8 +73,8 @@ app_run(
             GMainLoop* loop = g_main_loop_new(NULL, TRUE);
             guint sigtrm = g_unix_signal_add(SIGTERM, app_signal, loop);
             guint sigint = g_unix_signal_add(SIGINT, app_signal, loop);
-            GBinderBridge* bridge = gbinder_bridge_new
-                (opt->name, opt->ifaces, src, dest);
+            GBinderBridge* bridge = gbinder_bridge_new2
+                (opt->src_name, opt->dest_name, opt->ifaces, src, dest);
 
             g_main_loop_run(loop);
 
@@ -126,6 +127,8 @@ app_init(
 {
     gboolean ok = FALSE;
     GOptionEntry entries[] = {
+        { "source", 's', 0, G_OPTION_ARG_STRING, &opt->src_name,
+          "Register a different name on source", "NAME" },
         { "verbose", 'v', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
           app_log_verbose, "Enable verbose output", NULL },
         { "quiet", 'q', G_OPTION_FLAG_NO_ARG, G_OPTION_ARG_CALLBACK,
@@ -149,7 +152,7 @@ app_init(
 
             opt->src = argv[1];
             opt->dest = argv[2];
-            opt->name = argv[3];
+            opt->dest_name = argv[3];
             opt->ifaces = g_new(const char*, argc - first_iface + 1);
             for (i = first_iface; i < argc; i++) {
                 opt->ifaces[i - first_iface] = argv[i];
@@ -179,6 +182,7 @@ int main(int argc, char* argv[])
     if (app_init(&opt, argc, argv)) {
         ret = app_run(&opt);
     }
+    g_free(opt.src_name);
     g_free(opt.ifaces);
     return ret;
 }

--- a/test/binder-bridge/binder-bridge.c
+++ b/test/binder-bridge/binder-bridge.c
@@ -136,7 +136,6 @@ app_init(
     GError* error = NULL;
     GOptionContext* options = g_option_context_new("SRC DST NAME IFACES...");
 
-    gutil_log_timestamp = FALSE;
     gutil_log_default.level = GLOG_LEVEL_DEFAULT;
 
     g_option_context_add_main_entries(options, entries, NULL);

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -52,7 +52,7 @@ BASE_CFLAGS = $(BASE_FLAGS) $(CFLAGS)
 FULL_CFLAGS = $(BASE_CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
   $(shell pkg-config --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_LDFLAGS)
-LIBS = $(shell pkg-config --libs $(PKGS))
+LIBS = $(shell pkg-config --libs $(PKGS)) -lpthread
 QUIET_MAKE = make --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =

--- a/unit/common/test_binder.c
+++ b/unit/common/test_binder.c
@@ -689,7 +689,10 @@ test_io_passthough_write_64(
             tx->offsets_size);
 
         G_LOCK(test_binder);
-        tx->handle = test_io_passthough_handle_to_object(binder, tx->handle);
+        if (*cmd != BR_REPLY_64) {
+            tx->handle = test_io_passthough_handle_to_object(binder,
+                tx->handle);
+        }
         for (i = 0; i < tx->offsets_size/sizeof(guint64); i++) {
             guint32* obj_ptr = (guint32*)(data_buffer + data_offsets[i]);
 

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -129,6 +129,11 @@ test_binder_set_passthrough(
     int fd,
     gboolean passthrough);
 
+int
+test_binder_handle(
+    int fd,
+    GBinderLocalObject* obj);
+
 guint
 test_binder_register_object(
     int fd,

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -134,6 +134,12 @@ test_binder_handle(
     int fd,
     GBinderLocalObject* obj);
 
+GBinderLocalObject*
+test_binder_object(
+    int fd,
+    guint handle)
+    G_GNUC_WARN_UNUSED_RESULT; /* Need to unref */
+
 guint
 test_binder_register_object(
     int fd,

--- a/unit/common/test_common.h
+++ b/unit/common/test_common.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -63,6 +63,17 @@ void
 test_quit_later_n(
     GMainLoop* loop,
     guint n);
+
+/*
+ * Makes sure that we own the context for the entire duration of the test.
+ * That prevents many race conditions - all callbacks that are supposed to
+ * be invoked on the main thread, are actually invoked on the main thread
+ * (rather than a random worker thread which happens to acquire the context).
+ */
+void
+test_run_in_context(
+    const TestOpt* opt,
+    GTestFunc func);
 
 #define TEST_TIMEOUT_SEC (20)
 

--- a/unit/unit_bridge/unit_bridge.c
+++ b/unit/unit_bridge/unit_bridge.c
@@ -205,6 +205,7 @@ test_null(
 {
     static const char* ifaces[] = { "foo", "bar", NULL};
 
+    g_assert(!gbinder_bridge_new2(NULL, NULL, NULL, NULL, NULL));
     g_assert(!gbinder_bridge_new(NULL, NULL, NULL, NULL));
     g_assert(!gbinder_bridge_new("foo", NULL, NULL, NULL));
     g_assert(!gbinder_bridge_new("foo", ifaces, NULL, NULL));
@@ -377,7 +378,7 @@ test_basic_run(
 
     /* Both src and dest are required */
     g_assert(!gbinder_bridge_new(name, TEST_IFACES, src, NULL));
-    bridge = gbinder_bridge_new(name, TEST_IFACES, src, dest);
+    bridge = gbinder_bridge_new2(NULL, name, TEST_IFACES, src, dest);
 
     /* Start watching the name */
     id = gbinder_servicemanager_add_registration_handler(src, fqname,

--- a/unit/unit_buffer/unit_buffer.c
+++ b/unit/unit_buffer/unit_buffer.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -14,8 +14,8 @@
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
  *   3. Neither the names of the copyright holders nor the names of its
- *      contributors may be used to endorse or promote products derived from
- *      this software without specific prior written permission.
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -68,12 +68,44 @@ test_null(
     gbinder_buffer_free(buf2);
 
     gbinder_buffer_free(NULL);
+    gbinder_buffer_contents_list_free(NULL);
     g_assert(!gbinder_buffer_driver(NULL));
     g_assert(!gbinder_buffer_objects(NULL));
     g_assert(!gbinder_buffer_io(NULL));
     g_assert(!gbinder_buffer_data(NULL, NULL));
     g_assert(!gbinder_buffer_data(NULL, &size));
+    g_assert(!gbinder_buffer_contents(NULL));
+    g_assert(!gbinder_buffer_contents_list_add(NULL, NULL));
+    g_assert(!gbinder_buffer_contents_list_dup(NULL));
     g_assert(!size);
+    gbinder_driver_unref(driver);
+}
+
+/*==========================================================================*
+ * list
+ *==========================================================================*/
+
+static
+void
+test_list(
+    void)
+{
+    static const guint8 data[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07 };
+    void* ptr = g_memdup(data, sizeof(data));
+    GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderBuffer* buf = gbinder_buffer_new(driver, ptr, sizeof(data), NULL);
+    GBinderBufferContents* contents = gbinder_buffer_contents(buf);
+    GBinderBufferContentsList* list = gbinder_buffer_contents_list_add
+        (NULL, contents);
+    GBinderBufferContentsList* list2 = gbinder_buffer_contents_list_dup(list);
+
+    g_assert(contents);
+    g_assert(list);
+    g_assert(list2);
+
+    gbinder_buffer_free(buf);
+    gbinder_buffer_contents_list_free(list);
+    gbinder_buffer_contents_list_free(list2);
     gbinder_driver_unref(driver);
 }
 
@@ -112,12 +144,14 @@ test_parent(
  *==========================================================================*/
 
 #define TEST_PREFIX "/buffer/"
+#define TEST_(t) TEST_PREFIX t
 
 int main(int argc, char* argv[])
 {
     g_test_init(&argc, &argv, NULL);
-    g_test_add_func(TEST_PREFIX "null", test_null);
-    g_test_add_func(TEST_PREFIX "parent", test_parent);
+    g_test_add_func(TEST_("null"), test_null);
+    g_test_add_func(TEST_("list"), test_list);
+    g_test_add_func(TEST_("parent"), test_parent);
     test_init(&test_opt, argc, argv);
     return g_test_run();
 }

--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -51,12 +51,12 @@ static TestOpt test_opt;
 static
 GBinderClient*
 test_client_new(
-    guint handle,
+    guint h,
     const char* iface)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
-    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, handle);
+    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, h, TRUE);
     GBinderClient* client = gbinder_client_new(obj, iface);
 
     g_assert(client);
@@ -99,7 +99,7 @@ test_basic(
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
-    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0);
+    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0, TRUE);
     const char* iface = "foo";
     GBinderClient* client = gbinder_client_new(obj, iface);
 
@@ -125,7 +125,7 @@ test_interfaces(
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
     GBinderObjectRegistry* reg = gbinder_ipc_object_registry(ipc);
-    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0);
+    GBinderRemoteObject* obj = gbinder_object_registry_get_remote(reg, 0, TRUE);
     static const GBinderClientIfaceInfo ifaces[] = {
         {"33", 33 }, { "11", 11 }, { "22", 22 }
     };
@@ -198,7 +198,7 @@ test_dead(
     gbinder_remote_object_add_death_handler(obj, test_dead_done, loop);
 
     test_binder_br_dead_binder(fd, handle);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_run(&test_opt, loop);
     g_assert(gbinder_remote_object_is_dead(obj));
 
@@ -207,8 +207,9 @@ test_dead(
     g_assert(!gbinder_client_transact(client, 0, 0, NULL, NULL, NULL, NULL));
 
     gbinder_client_unref(client);
-    g_main_loop_unref(loop);
     gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
+    g_main_loop_unref(loop);
 }
 
 /*==========================================================================*

--- a/unit/unit_driver/unit_driver.c
+++ b/unit/unit_driver/unit_driver.c
@@ -76,6 +76,7 @@ test_basic(
     g_assert(gbinder_driver_exit_looper(driver));
     g_assert(!gbinder_driver_request_death_notification(driver, NULL));
     g_assert(!gbinder_driver_clear_death_notification(driver, NULL));
+    g_assert(!gbinder_driver_dead_binder_done(NULL, NULL));
     gbinder_driver_unref(driver);
 
     g_assert(!gbinder_handler_transact(NULL, NULL, NULL, 0, 0, NULL));

--- a/unit/unit_driver/unit_driver.c
+++ b/unit/unit_driver/unit_driver.c
@@ -79,6 +79,7 @@ test_basic(
     gbinder_driver_unref(driver);
 
     g_assert(!gbinder_handler_transact(NULL, NULL, NULL, 0, 0, NULL));
+    g_assert(!gbinder_handler_can_loop(NULL));
 }
 
 /*==========================================================================*

--- a/unit/unit_eventloop/unit_eventloop.c
+++ b/unit/unit_eventloop/unit_eventloop.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2021 Jolla Ltd.
+ * Copyright (C) 2020-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -230,6 +230,8 @@ test_callback(
 
     gbinder_eventloop_set(NULL);
     cb = gbinder_idle_callback_new(test_quit_cb, loop, NULL);
+    g_assert(gbinder_idle_callback_ref(cb) == cb);
+    gbinder_idle_callback_unref(cb);
     gbinder_idle_callback_schedule(cb);
     test_run(&test_opt, loop);
     gbinder_idle_callback_unref(cb);

--- a/unit/unit_local_object/unit_local_object.c
+++ b/unit/unit_local_object/unit_local_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -137,7 +137,7 @@ test_null(
     g_assert(!gbinder_ipc_transact_custom(NULL, NULL, NULL, NULL, NULL));
     gbinder_local_object_handle_increfs(NULL);
     gbinder_local_object_handle_decrefs(NULL);
-    gbinder_local_object_handle_acquire(NULL);
+    gbinder_local_object_handle_acquire(NULL, NULL);
     gbinder_local_object_handle_release(NULL);
 }
 
@@ -179,7 +179,7 @@ test_basic(
         base_interface, -1) == GBINDER_LOCAL_TRANSACTION_NOT_SUPPORTED);
     gbinder_local_object_handle_increfs(foo);
     gbinder_local_object_handle_decrefs(foo);
-    gbinder_local_object_handle_acquire(foo);
+    gbinder_local_object_handle_acquire(foo, NULL);
     gbinder_local_object_handle_release(foo);
     gbinder_local_object_unref(foo);
 
@@ -621,7 +621,7 @@ test_increfs_cb(
 
 static
 void
-test_increfs(
+test_increfs_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
@@ -635,7 +635,7 @@ test_increfs(
     /* ipc is not an object, will be ignored */
     test_binder_br_increfs(fd, ipc);
     test_binder_br_increfs(fd, obj);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_run(&test_opt, loop);
 
     g_assert(obj->weak_refs == 1);
@@ -644,6 +644,14 @@ test_increfs(
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
     g_main_loop_unref(loop);
+}
+
+static
+void
+test_increfs(
+    void)
+{
+    test_run_in_context(&test_opt, test_increfs_run);
 }
 
 /*==========================================================================*
@@ -664,7 +672,7 @@ test_decrefs_cb(
 
 static
 void
-test_decrefs(
+test_decrefs_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
@@ -679,7 +687,7 @@ test_decrefs(
     test_binder_br_decrefs(fd, ipc);
     test_binder_br_increfs(fd, obj);
     test_binder_br_decrefs(fd, obj);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_run(&test_opt, loop);
 
     g_assert(obj->weak_refs == 0);
@@ -688,6 +696,14 @@ test_decrefs(
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
     g_main_loop_unref(loop);
+}
+
+static
+void
+test_decrefs(
+    void)
+{
+    test_run_in_context(&test_opt, test_decrefs_run);
 }
 
 /*==========================================================================*
@@ -707,7 +723,7 @@ test_acquire_cb(
 
 static
 void
-test_acquire(
+test_acquire_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
@@ -721,7 +737,7 @@ test_acquire(
     /* ipc is not an object, will be ignored */
     test_binder_br_acquire(fd, ipc);
     test_binder_br_acquire(fd, obj);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_run(&test_opt, loop);
 
     g_assert(obj->strong_refs == 1);
@@ -730,6 +746,14 @@ test_acquire(
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
     g_main_loop_unref(loop);
+}
+
+static
+void
+test_acquire(
+    void)
+{
+    test_run_in_context(&test_opt, test_acquire_run);
 }
 
 /*==========================================================================*
@@ -750,7 +774,7 @@ test_release_cb(
 
 static
 void
-test_release(
+test_release_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER);
@@ -764,7 +788,7 @@ test_release(
     test_binder_br_release(fd, ipc);
     test_binder_br_acquire(fd, obj);
     test_binder_br_release(fd, obj);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_run(&test_opt, loop);
 
     g_assert(obj->strong_refs == 0);
@@ -773,6 +797,14 @@ test_release(
     gbinder_ipc_unref(ipc);
     gbinder_ipc_exit();
     g_main_loop_unref(loop);
+}
+
+static
+void
+test_release(
+    void)
+{
+    test_run_in_context(&test_opt, test_release_run);
 }
 
 /*==========================================================================*

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -88,7 +88,8 @@ test_null(
     gbinder_local_reply_init_writer(NULL, NULL);
     gbinder_local_reply_init_writer(NULL, &writer);
     g_assert(!gbinder_local_reply_data(NULL));
-    g_assert(!gbinder_local_reply_set_contents(NULL, NULL));
+    g_assert(!gbinder_local_reply_contents(NULL));
+    g_assert(!gbinder_local_reply_set_contents(NULL, NULL, NULL));
 
     gbinder_local_reply_cleanup(NULL, NULL, &count);
     gbinder_local_reply_cleanup(NULL, test_int_inc, &count);
@@ -480,7 +481,7 @@ test_remote_reply(
     /* Copy flat structures (no binder objects) */
     buffer = test_buffer_from_bytes(driver, bytes);
     req2 = gbinder_local_reply_new(io);
-    g_assert(gbinder_local_reply_set_contents(req2, buffer) == req2);
+    g_assert(gbinder_local_reply_set_contents(req2, buffer, NULL) == req2);
     gbinder_buffer_free(buffer);
 
     data2 = gbinder_local_reply_data(req2);

--- a/unit/unit_local_request/unit_local_request.c
+++ b/unit/unit_local_request/unit_local_request.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -94,7 +94,7 @@ test_null(
 
     g_assert(!gbinder_local_request_new(NULL, NULL));
     g_assert(!gbinder_local_request_ref(NULL));
-    g_assert(!gbinder_local_request_new_from_data(NULL));
+    g_assert(!gbinder_local_request_new_from_data(NULL, NULL));
     gbinder_local_request_unref(NULL);
     gbinder_local_request_init_writer(NULL, NULL);
     gbinder_local_request_init_writer(NULL, &writer);
@@ -490,7 +490,7 @@ test_remote_request(
 
     /* Copy flat structures (no binder objects) */
     buffer = test_buffer_from_bytes(driver, bytes);
-    req2 = gbinder_local_request_new_from_data(buffer);
+    req2 = gbinder_local_request_new_from_data(buffer, NULL);
     gbinder_buffer_free(buffer);
 
     data2 = gbinder_local_request_data(req2);
@@ -503,7 +503,7 @@ test_remote_request(
 
     /* Same thing but with non-NULL (albeit empty) array of objects */
     buffer = test_buffer_from_bytes_and_objects(driver, bytes, no_obj);
-    req2 = gbinder_local_request_new_from_data(buffer);
+    req2 = gbinder_local_request_new_from_data(buffer, NULL);
     gbinder_buffer_free(buffer);
 
     data2 = gbinder_local_request_data(req2);
@@ -572,7 +572,7 @@ test_remote_request_obj(
     }
 
     buffer = test_buffer_from_bytes_and_objects(driver, data->bytes, objects);
-    req2 = gbinder_local_request_new_from_data(buffer);
+    req2 = gbinder_local_request_new_from_data(buffer, NULL);
     gbinder_buffer_free(buffer);
 
     test_remote_request_obj_validate_data(gbinder_local_request_data(req2));

--- a/unit/unit_remote_reply/unit_remote_reply.c
+++ b/unit/unit_remote_reply/unit_remote_reply.c
@@ -71,7 +71,8 @@ static
 GBinderRemoteObject*
 reg_dummy_get_remote(
     GBinderObjectRegistry* reg,
-    guint32 handle)
+    guint32 handle,
+    REMOTE_REGISTRY_CREATE create)
 {
     return NULL;
 }

--- a/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
+++ b/unit/unit_servicemanager_aidl/unit_servicemanager_aidl.c
@@ -319,6 +319,7 @@ test_get()
     const char* name = "name";
     GBinderServiceManager* sm;
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GMainContext* context = g_main_loop_get_context(loop);
 
     /* Set up binder simulator */
     test_binder_register_object(fd, obj, AUTO_HANDLE);
@@ -345,11 +346,20 @@ test_get()
     g_assert(gbinder_servicemanager_get_service(sm, name, test_get_cb, loop));
     test_run(&test_opt, loop);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
@@ -392,6 +402,7 @@ test_list()
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* name = "name";
     GBinderServiceManager* sm;
+    GMainContext* context;
     TestList test;
 
     memset(&test, 0, sizeof(test));
@@ -423,11 +434,21 @@ test_list()
     g_assert_cmpuint(gutil_strv_length(test.list), == ,1);
     g_assert_cmpstr(test.list[0], == ,name);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    context = g_main_loop_get_context(test.loop);
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, test.loop);
 
@@ -464,6 +485,7 @@ test_notify()
     const char* name = "name";
     GBinderServiceManager* sm;
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GMainContext* context = g_main_loop_get_context(loop);
     gulong id;
 
     /* Set up binder simulator */
@@ -486,11 +508,20 @@ test_notify()
     test_run(&test_opt, loop);
     gbinder_servicemanager_remove_handler(sm, id);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     servicemanager_aidl_free(svc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
@@ -514,6 +545,7 @@ test_notify2()
     const char* name1 = "name1";
     const char* name2 = "name2";
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GMainContext* context = g_main_loop_get_context(loop);
     gulong id1, id2;
 
     /* Set up binder simulator */
@@ -545,11 +577,20 @@ test_notify2()
     gbinder_servicemanager_remove_handler(sm, id1);
     gbinder_servicemanager_remove_handler(sm, id2);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     servicemanager_aidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);

--- a/unit/unit_servicemanager_aidl2/unit_servicemanager_aidl2.c
+++ b/unit/unit_servicemanager_aidl2/unit_servicemanager_aidl2.c
@@ -180,7 +180,7 @@ servicemanager_aidl2_new(
     self->handle_on_looper_thread = handle_on_looper_thread;
     gbinder_local_object_init_base(obj, ipc, servicemanager_aidl_ifaces,
         servicemanager_aidl2_handler, self);
-    test_binder_set_looper_enabled(fd, TRUE);
+    test_binder_set_looper_enabled(fd, TEST_LOOPER_ENABLE);
     test_binder_register_object(fd, obj, SVCMGR_HANDLE);
     gbinder_ipc_register_local_object(ipc, obj);
     gbinder_ipc_unref(ipc);
@@ -344,7 +344,7 @@ test_context_deinit(
 
 static
 void
-test_get()
+test_get_run()
 {
     TestContext test;
     const char* name = "name";
@@ -375,13 +375,20 @@ test_get()
     test_context_deinit(&test);
 }
 
+static
+void
+test_get()
+{
+    test_run_in_context(&test_opt, test_get_run);
+}
+
 /*==========================================================================*
  * list
  *==========================================================================*/
 
 static
 void
-test_list()
+test_list_run()
 {
     TestContext test;
     const char* name = "name";
@@ -411,6 +418,13 @@ test_list()
     g_strfreev(list);
 
     test_context_deinit(&test);
+}
+
+static
+void
+test_list()
+{
+    test_run_in_context(&test_opt, test_list_run);
 }
 
 /*==========================================================================*

--- a/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
+++ b/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
@@ -169,7 +169,7 @@ test_get_cb(
 
 static
 void
-test_get()
+test_get_run()
 {
     TestConfig config;
     GBinderIpc* ipc;
@@ -178,7 +178,6 @@ test_get()
     int fd;
     GBinderServiceManager* sm;
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
-    GMainContext* context = g_main_loop_get_context(loop);
     const char* name = "android.hidl.base@1.0::IBase/test";
 
     test_config_init(&config, NULL);
@@ -216,24 +215,23 @@ test_get()
     g_assert(gbinder_servicemanager_get_service(sm, name, test_get_cb, loop));
     test_run(&test_opt, loop);
 
-    /*
-     * Synchronize deletion of objects with the threads that may
-     * still be running.
-     */
-    while (!g_main_context_acquire(context)) {
-        GDEBUG("Acquiring the context");
-    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
-    g_main_context_release(context);
 
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, loop);
     test_config_deinit(&config);
     g_main_loop_unref(loop);
+}
+
+static
+void
+test_get()
+{
+    test_run_in_context(&test_opt, test_get_run);
 }
 
 /*==========================================================================*
@@ -263,7 +261,7 @@ test_list_cb(
 
 static
 void
-test_list()
+test_list_run()
 {
     TestList test;
     TestConfig config;
@@ -272,7 +270,6 @@ test_list()
     GBinderLocalObject* obj;
     int fd;
     GBinderServiceManager* sm;
-    GMainContext* context;
     const char* name = "android.hidl.base@1.0::IBase/test";
 
     memset(&test, 0, sizeof(test));
@@ -311,20 +308,11 @@ test_list()
     g_assert_cmpuint(gutil_strv_length(test.list), == ,1);
     g_assert_cmpstr(test.list[0], == ,name);
 
-    /*
-     * Synchronize deletion of objects with the threads that may
-     * still be running.
-     */
-    context = g_main_loop_get_context(test.loop);
-    while (!g_main_context_acquire(context)) {
-        GDEBUG("Acquiring the context");
-    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
-    g_main_context_release(context);
 
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, test.loop);
@@ -332,6 +320,13 @@ test_list()
 
     g_strfreev(test.list);
     g_main_loop_unref(test.loop);
+}
+
+static
+void
+test_list()
+{
+    test_run_in_context(&test_opt, test_list_run);
 }
 
 /*==========================================================================*
@@ -394,7 +389,7 @@ test_notify_cb(
 
 static
 void
-test_notify()
+test_notify_run()
 {
     TestNotify test;
     TestConfig config;
@@ -402,7 +397,6 @@ test_notify()
     GBinderLocalObject* obj;
     int fd;
     GBinderServiceManager* sm;
-    GMainContext* context;
     const char* name = "android.hidl.base@1.0::IBase/test";
     gulong id;
 
@@ -443,25 +437,23 @@ test_notify()
     test_run(&test_opt, test.loop);
     gbinder_servicemanager_remove_handler(sm, id);
 
-    /*
-     * Synchronize deletion of objects with the threads that may
-     * still be running.
-     */
-    context = g_main_loop_get_context(test.loop);
-    while (!g_main_context_acquire(context)) {
-        GDEBUG("Acquiring the context");
-    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(test.smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
-    g_main_context_release(context);
 
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, test.loop);
     test_config_deinit(&config);
     g_main_loop_unref(test.loop);
+}
+
+static
+void
+test_notify()
+{
+    test_run_in_context(&test_opt, test_notify_run);
 }
 
 /*==========================================================================*

--- a/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
+++ b/unit/unit_servicemanager_hidl/unit_servicemanager_hidl.c
@@ -178,6 +178,7 @@ test_get()
     int fd;
     GBinderServiceManager* sm;
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GMainContext* context = g_main_loop_get_context(loop);
     const char* name = "android.hidl.base@1.0::IBase/test";
 
     test_config_init(&config, NULL);
@@ -215,11 +216,20 @@ test_get()
     g_assert(gbinder_servicemanager_get_service(sm, name, test_get_cb, loop));
     test_run(&test_opt, loop);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, loop);
     test_config_deinit(&config);
@@ -262,6 +272,7 @@ test_list()
     GBinderLocalObject* obj;
     int fd;
     GBinderServiceManager* sm;
+    GMainContext* context;
     const char* name = "android.hidl.base@1.0::IBase/test";
 
     memset(&test, 0, sizeof(test));
@@ -300,11 +311,21 @@ test_list()
     g_assert_cmpuint(gutil_strv_length(test.list), == ,1);
     g_assert_cmpstr(test.list[0], == ,name);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    context = g_main_loop_get_context(test.loop);
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, test.loop);
     test_config_deinit(&config);
@@ -381,6 +402,7 @@ test_notify()
     GBinderLocalObject* obj;
     int fd;
     GBinderServiceManager* sm;
+    GMainContext* context;
     const char* name = "android.hidl.base@1.0::IBase/test";
     gulong id;
 
@@ -421,11 +443,21 @@ test_notify()
     test_run(&test_opt, test.loop);
     gbinder_servicemanager_remove_handler(sm, id);
 
+    /*
+     * Synchronize deletion of objects with the threads that may
+     * still be running.
+     */
+    context = g_main_loop_get_context(test.loop);
+    while (!g_main_context_acquire(context)) {
+        GDEBUG("Acquiring the context");
+    }
     test_binder_unregister_objects(fd);
     gbinder_local_object_unref(obj);
     test_servicemanager_hidl_free(test.smsvc);
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
+    g_main_context_release(context);
+
     gbinder_ipc_exit();
     test_binder_exit_wait(&test_opt, test.loop);
     test_config_deinit(&config);

--- a/unit/unit_servicename/unit_servicename.c
+++ b/unit/unit_servicename/unit_servicename.c
@@ -349,6 +349,7 @@ test_present(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 
@@ -479,6 +480,7 @@ test_cancel(
     test_run(&test_opt, loop);
 
     gbinder_ipc_exit();
+    test_binder_exit_wait(&test_opt, loop);
     g_main_loop_unref(loop);
 }
 


### PR DESCRIPTION
`GBinderProxyObject` automatically creates proxies for the remote objects found in the transaction payload. Also added `gbinder_bridge_new2()` function which allows to rename top-level bridged objects.