### PR TITLE
Include definition of _IOC_SIZE

### DIFF
--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -61,6 +61,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>
+#include <linux/ioctl.h>
 
 /* BINDER_VM_SIZE copied from native/libs/binder/ProcessState.cpp */
 #define BINDER_VM_SIZE ((1024*1024) - sysconf(_SC_PAGE_SIZE)*2)


### PR DESCRIPTION
On some musl-based systems, the compilation fails because `_IOC_SIZE` is not defined. By including `linux/ioctl.h` the definition should get pulled in on these systems as well.