### PR TITLE
Drop use of g_main_context_invoke_full

### DIFF
--- a/src/gbinder_eventloop_p.h
+++ b/src/gbinder_eventloop_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2021 Jolla Ltd.
+ * Copyright (C) 2020-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -41,12 +41,14 @@ gbinder_timeout_add(
     guint millis,
     GSourceFunc func,
     gpointer data)
+    G_GNUC_WARN_UNUSED_RESULT
     GBINDER_INTERNAL;
 
 GBinderEventLoopTimeout*
 gbinder_idle_add(
     GSourceFunc func,
     gpointer data)
+    G_GNUC_WARN_UNUSED_RESULT
     GBINDER_INTERNAL;
 
 void
@@ -59,6 +61,7 @@ gbinder_idle_callback_new(
     GBinderEventLoopCallbackFunc func,
     gpointer data,
     GDestroyNotify destroy)
+    G_GNUC_WARN_UNUSED_RESULT
     GBINDER_INTERNAL;
 
 GBinderEventLoopCallback*
@@ -66,6 +69,7 @@ gbinder_idle_callback_schedule_new(
     GBinderEventLoopCallbackFunc func,
     gpointer data,
     GDestroyNotify destroy)
+    G_GNUC_WARN_UNUSED_RESULT
     GBINDER_INTERNAL;
 
 GBinderEventLoopCallback*
@@ -91,6 +95,13 @@ gbinder_idle_callback_cancel(
 void
 gbinder_idle_callback_destroy(
     GBinderEventLoopCallback* cb)
+    GBINDER_INTERNAL;
+
+void
+gbinder_idle_callback_invoke_later(
+    GBinderEventLoopCallbackFunc func,
+    gpointer data,
+    GDestroyNotify destroy)
     GBINDER_INTERNAL;
 
 #endif /* GBINDER_EVENTLOOP_PRIVATE_H */

--- a/unit/coverage/run
+++ b/unit/coverage/run
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 #
 # This script requires lcov, dirname
@@ -65,9 +64,13 @@ for t in $TESTS ; do
     popd
 done
 
+# Sometimes you need this, sometimes that :S
+BASE_DIR="$TOP_DIR"
+#BASE_DIR="$TOP_DIR/src"
+
 FULL_COV="$COV_DIR/full.gcov"
 LIB_COV="$COV_DIR/lib.gcov"
 rm -f "$FULL_COV" "$LIB_COV"
-lcov $LCOV_OPT -c -d "$TOP_DIR/build/coverage" -b "$TOP_DIR/src" -o "$FULL_COV" || exit 1
-lcov $LCOV_OPT -e "$FULL_COV" "$TOP_DIR/src/*" -o "$LIB_COV" || exit 1
+lcov $LCOV_OPT -c -d "$TOP_DIR/build/coverage" -b "$BASE_DIR" -o "$FULL_COV" || exit 1
+lcov $LCOV_OPT -e "$FULL_COV" "$BASE_DIR/*" -o "$LIB_COV" || exit 1
 genhtml $GENHTML_OPT "$LIB_COV" -t "libgbinder" --output-directory "$COV_DIR/report" || exit 1

--- a/unit/unit_eventloop/unit_eventloop.c
+++ b/unit/unit_eventloop/unit_eventloop.c
@@ -48,6 +48,14 @@ test_unreached_proc(
     return G_SOURCE_CONTINUE;
 }
 
+static
+void
+test_quit_cb(
+    gpointer data)
+{
+    g_main_loop_quit((GMainLoop*)data);
+}
+
 /*==========================================================================*
  * Test event loop integration
  *==========================================================================*/
@@ -214,14 +222,6 @@ test_timeout(
 
 static
 void
-test_quit_cb(
-    gpointer data)
-{
-    g_main_loop_quit((GMainLoop*)data);
-}
-
-static
-void
 test_callback(
     void)
 {
@@ -239,6 +239,28 @@ test_callback(
 }
 
 /*==========================================================================*
+ * invoke
+ *==========================================================================*/
+
+static
+void
+test_invoke(
+    void)
+{
+    GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+
+    gbinder_eventloop_set(NULL);
+    gbinder_idle_callback_invoke_later(test_quit_cb, loop, NULL);
+    test_run(&test_opt, loop);
+
+    gbinder_eventloop_set(NULL);
+    gbinder_idle_callback_invoke_later(NULL, loop, test_quit_cb);
+    test_run(&test_opt, loop);
+
+    g_main_loop_unref(loop);
+}
+
+/*==========================================================================*
  * Common
  *==========================================================================*/
 
@@ -251,6 +273,7 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("idle"), test_idle);
     g_test_add_func(TEST_("timeout"), test_timeout);
     g_test_add_func(TEST_("callback"), test_callback);
+    g_test_add_func(TEST_("invoke"), test_invoke);
     test_init(&test_opt, argc, argv);
     return g_test_run();
 }


### PR DESCRIPTION
Replace it with `gbinder_idle_callback_invoke_later()`, which should work nicely with non-GLib event loops.
