### PR TITLE
Allow to modify GBinderLocalRequest

### DIFF
--- a/include/gbinder_local_request.h
+++ b/include/gbinder_local_request.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018 Jolla Ltd.
- * Copyright (C) 2018 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -13,9 +13,9 @@
  *   2. Redistributions in binary form must reproduce the above copyright
  *      notice, this list of conditions and the following disclaimer in the
  *      documentation and/or other materials provided with the distribution.
- *   3. Neither the name of Jolla Ltd nor the names of its contributors may
- *      be used to endorse or promote products derived from this software
- *      without specific prior written permission.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -111,6 +111,16 @@ GBinderLocalRequest*
 gbinder_local_request_append_remote_object(
     GBinderLocalRequest* request,
     GBinderRemoteObject* obj);
+
+gsize
+gbinder_local_request_size(
+    GBinderLocalRequest* request); /* Since 1.1.14 */
+
+guint32
+gbinder_local_request_replace_int32(
+    GBinderLocalRequest* request,
+    gsize offset,
+    guint32 value); /* Since 1.1.14 */
 
 G_END_DECLS
 

--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2021 Jolla Ltd.
+ * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -111,6 +111,10 @@ gbinder_servicemanager_ref(
 void
 gbinder_servicemanager_unref(
     GBinderServiceManager* sm);
+
+const char*
+gbinder_servicemanager_device(
+    GBinderServiceManager* sm); /* Since 1.1.14 */
 
 gboolean
 gbinder_servicemanager_is_present(

--- a/src/gbinder_local_request.c
+++ b/src/gbinder_local_request.c
@@ -338,6 +338,34 @@ gbinder_local_request_append_remote_object(
     return self;
 }
 
+gsize
+gbinder_local_request_size(
+    GBinderLocalRequest* self) /* Since 1.1.14 */
+{
+    return G_LIKELY(self) ? self->data.bytes->len : 0;
+}
+
+guint32
+gbinder_local_request_replace_int32(
+    GBinderLocalRequest* self,
+    gsize offset,
+    guint32 value) /* Since 1.1.14 */
+{
+    guint32 result = 0;
+
+    if (G_LIKELY(self)) {
+        GByteArray* buf = self->data.bytes;
+
+        if (offset + sizeof(value) <= buf->len) {
+            guint32* ptr = (guint32*)(buf->data + offset);
+
+            result = *ptr;
+            *ptr = value;
+        }
+    }
+    return result;
+}
+
 /*
  * Local Variables:
  * mode: C

--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -698,6 +698,13 @@ gbinder_servicemanager_unref(
     }
 }
 
+const char*
+gbinder_servicemanager_device(
+    GBinderServiceManager* self) /* Since 1.1.14 */
+{
+    return G_LIKELY(self) ? self->dev : NULL;
+}
+
 gboolean
 gbinder_servicemanager_is_present(
     GBinderServiceManager* self) /* Since 1.0.25 */

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -403,6 +403,7 @@ test_null(
     g_assert(!gbinder_servicemanager_new_with_type(0, NULL));
     g_assert(!gbinder_servicemanager_new_local_object(NULL, NULL, NULL, NULL));
     g_assert(!gbinder_servicemanager_ref(NULL));
+    g_assert(!gbinder_servicemanager_device(NULL));
     g_assert(!gbinder_servicemanager_is_present(NULL));
     g_assert(!gbinder_servicemanager_wait(NULL, 0));
     g_assert(!gbinder_servicemanager_list(NULL, NULL, NULL));
@@ -487,6 +488,7 @@ test_basic(
     obj = gbinder_servicemanager_new_local_object(sm, "foo.bar",
         test_transact_func, NULL);
     g_assert(obj);
+    g_assert_cmpstr(gbinder_servicemanager_device(sm), == ,dev);
     gbinder_local_object_unref(obj);
 
     g_assert(gbinder_servicemanager_ref(sm) == sm);


### PR DESCRIPTION
This adds two new functions:

- gbinder_local_request_size()
- gbinder_local_request_replace_int32()

which only allows to re-write a single int32 which is all I need at the moment. More re-writing API may be added in the future if they become needed.

Use this API carefully.