### PR TITLE
Add readers and writers for int8 and int16

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -66,6 +66,26 @@ gbinder_reader_read_bool(
     gboolean* value);
 
 gboolean
+gbinder_reader_read_int8(
+    GBinderReader* reader,
+    gint8* value); /* Since 1.1.15 */
+
+gboolean
+gbinder_reader_read_uint8(
+    GBinderReader* reader,
+    guint8* value); /* Since 1.1.15 */
+
+gboolean
+gbinder_reader_read_int16(
+    GBinderReader* reader,
+    gint16* value); /* Since 1.1.15 */
+
+gboolean
+gbinder_reader_read_uint16(
+    GBinderReader* reader,
+    guint16* value); /* Since 1.1.15 */
+
+gboolean
 gbinder_reader_read_int32(
     GBinderReader* reader,
     gint32* value);

--- a/include/gbinder_writer.h
+++ b/include/gbinder_writer.h
@@ -56,6 +56,16 @@ struct gbinder_parent {
 };
 
 void
+gbinder_writer_append_int8(
+    GBinderWriter* writer,
+    guint8 value); /* Since 1.1.15 */
+
+void
+gbinder_writer_append_int16(
+    GBinderWriter* writer,
+    guint16 value); /* Since 1.1.15 */
+
+void
 gbinder_writer_append_int32(
     GBinderWriter* writer,
     guint32 value);

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -139,6 +139,62 @@ gbinder_reader_read_bool(
 }
 
 gboolean
+gbinder_reader_read_int8(
+    GBinderReader* reader,
+    gint8* value) /* Since 1.1.15 */
+{
+    return gbinder_reader_read_uint8(reader, (guint8*)value);
+}
+
+gboolean
+gbinder_reader_read_uint8(
+    GBinderReader* reader,
+    guint8* value) /* Since 1.1.15 */
+{
+    /* Primitive values are supposed to be padded to 4-byte boundary */
+    if (value) {
+        guint32 padded;
+
+        if (gbinder_reader_read_uint32(reader, &padded)) {
+            *value = (guint8)padded;
+            return TRUE;
+        } else {
+            return FALSE;
+        }
+    } else {
+        return gbinder_reader_read_uint32(reader, NULL);
+    }
+}
+
+gboolean
+gbinder_reader_read_int16(
+    GBinderReader* reader,
+    gint16* value) /* Since 1.1.15 */
+{
+    return gbinder_reader_read_uint16(reader, (guint16*)value);
+}
+
+gboolean
+gbinder_reader_read_uint16(
+    GBinderReader* reader,
+    guint16* value) /* Since 1.1.15 */
+{
+    /* Primitive values are supposed to be padded to 4-byte boundary */
+    if (value) {
+        guint32 padded;
+
+        if (gbinder_reader_read_uint32(reader, &padded)) {
+            *value = (guint16)padded;
+            return TRUE;
+        } else {
+            return FALSE;
+        }
+    } else {
+        return gbinder_reader_read_uint32(reader, NULL);
+    }
+}
+
+gboolean
 gbinder_reader_read_int32(
     GBinderReader* reader,
     gint32* value)

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -213,12 +213,34 @@ gbinder_writer_data_append_bool(
     GBinderWriterData* data,
     gboolean value)
 {
-    guint8 padded[4];
+    /* Primitive values are padded to 4-byte boundary */
+    gbinder_writer_data_append_int32(data, value != FALSE);
+}
 
-    /* Boolean values are padded to 4-byte boundary */
-    padded[0] = (value != FALSE);
-    padded[1] = padded[2] = padded[3] = 0;
-    g_byte_array_append(data->bytes, padded, sizeof(padded));
+void
+gbinder_writer_append_int8(
+    GBinderWriter* self,
+    guint8 value) /* Since 1.1.15 */
+{
+    GBinderWriterData* data = gbinder_writer_data(self);
+
+    if (G_LIKELY(data)) {
+        /* Primitive values are padded to 4-byte boundary */
+        gbinder_writer_data_append_int32(data, value);
+    }
+}
+
+void
+gbinder_writer_append_int16(
+    GBinderWriter* self,
+    guint16 value) /* Since 1.1.15 */
+{
+    GBinderWriterData* data = gbinder_writer_data(self);
+
+    if (G_LIKELY(data)) {
+        /* Primitive values are padded to 4-byte boundary */
+        gbinder_writer_data_append_int32(data, value);
+    }
 }
 
 void

--- a/unit/common/test_common.h
+++ b/unit/common/test_common.h
@@ -80,6 +80,10 @@ test_run_in_context(
 /* Helper macros */
 
 #if G_BYTE_ORDER == G_LITTLE_ENDIAN
+#  define TEST_INT8_BYTES_4(v) \
+    (guint8)(v), 0, 0, 0
+#  define TEST_INT16_BYTES_4(v) \
+    (guint8)(v), (guint8)((v) >> 8), 0, 0
 #  define TEST_INT16_BYTES(v) \
     (guint8)(v), (guint8)((v) >> 8)
 #  define TEST_INT32_BYTES(v) \
@@ -91,6 +95,10 @@ test_run_in_context(
     (guint8)(((guint64)(v)) >> 32), (guint8)(((guint64)(v)) >> 40), \
     (guint8)(((guint64)(v)) >> 48), (guint8)(((guint64)(v)) >> 56)
 #elif G_BYTE_ORDER == G_BIG_ENDIAN
+#  define TEST_INT8_BYTES_4(v) \
+    0, 0, 0, (guint8)(v)
+#  define TEST_INT16_BYTES_4(v) \
+    0, 0, (guint8)((v) >> 8), (guint8)(v)
 #  define TEST_INT16_BYTES(v) \
     (guint8)((v) >> 8), (guint8)(v)
 #  define TEST_INT32_BYTES(v) \

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -108,6 +108,8 @@ test_empty(
     g_assert(!gbinder_reader_bytes_remaining(&reader));
     g_assert(!gbinder_reader_read_byte(&reader, NULL));
     g_assert(!gbinder_reader_read_bool(&reader, NULL));
+    g_assert(!gbinder_reader_read_int8(&reader, NULL));
+    g_assert(!gbinder_reader_read_int16(&reader, NULL));
     g_assert(!gbinder_reader_read_int32(&reader, NULL));
     g_assert(!gbinder_reader_read_uint32(&reader, NULL));
     g_assert(!gbinder_reader_read_int64(&reader, NULL));
@@ -176,8 +178,8 @@ void
 test_bool(
     void)
 {
-    const guint8 in_true[4] = { 0x01, 0xff, 0xff, 0xff };
-    const guint8 in_false[4] = { 0x00, 0xff, 0xff, 0xff };
+    const guint8 in_true[] = { TEST_INT8_BYTES_4(TRUE) };
+    const guint8 in_false[] = { TEST_INT8_BYTES_4(FALSE) };
     gboolean out = FALSE;
     GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
     GBinderReader reader;
@@ -211,6 +213,108 @@ test_bool(
     g_assert(gbinder_reader_read_bool(&reader, &out));
     g_assert(gbinder_reader_at_end(&reader));
     g_assert(out == FALSE);
+
+    gbinder_buffer_free(data.buffer);
+    gbinder_driver_unref(driver);
+}
+
+/*==========================================================================*
+ * int8
+ *==========================================================================*/
+
+static
+void
+test_int8(
+    void)
+{
+    const guint8 in = 42;
+    const guint8 in4[] = { TEST_INT8_BYTES_4(42) };
+    guint8 out1 = 0;
+    gint8 out2 = 0;
+    GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderReader reader;
+    GBinderReaderData data;
+
+    g_assert(driver);
+    memset(&data, 0, sizeof(data));
+
+    /* Not enough data */
+    data.buffer = gbinder_buffer_new(driver, g_memdup(&in, sizeof(in)),
+        sizeof(in), NULL);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in));
+    g_assert(!gbinder_reader_read_uint8(&reader, &out1));
+    g_assert(!gbinder_reader_at_end(&reader));
+    gbinder_buffer_free(data.buffer);
+
+    /* Enough data */
+    data.buffer = gbinder_buffer_new(driver, g_memdup(in4, sizeof(in4)),
+        sizeof(in4), NULL);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_uint8(&reader, &out1));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpuint(in, == ,out1);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_int8(&reader, &out2));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpint(in, == ,out2);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_int8(&reader, NULL));
+    g_assert(gbinder_reader_at_end(&reader));
+
+    gbinder_buffer_free(data.buffer);
+    gbinder_driver_unref(driver);
+}
+
+/*==========================================================================*
+ * int16
+ *==========================================================================*/
+
+static
+void
+test_int16(
+    void)
+{
+    const guint16 in = 42;
+    const guint8 in4[] = { TEST_INT16_BYTES_4(42) };
+    guint16 out1 = 0;
+    gint16 out2 = 0;
+    GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
+    GBinderReader reader;
+    GBinderReaderData data;
+
+    g_assert(driver);
+    memset(&data, 0, sizeof(data));
+
+    /* Not enough data */
+    data.buffer = gbinder_buffer_new(driver, g_memdup(&in, sizeof(in)),
+        sizeof(in), NULL);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in));
+    g_assert(!gbinder_reader_read_uint16(&reader, &out1));
+    g_assert(!gbinder_reader_at_end(&reader));
+    gbinder_buffer_free(data.buffer);
+
+    /* Enough data */
+    data.buffer = gbinder_buffer_new(driver, g_memdup(in4, sizeof(in4)),
+        sizeof(in4), NULL);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_uint16(&reader, &out1));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpuint(in, == ,out1);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_int16(&reader, &out2));
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_cmpint(in, == ,out2);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(in4));
+    g_assert(gbinder_reader_read_int16(&reader, NULL));
+    g_assert(gbinder_reader_at_end(&reader));
 
     gbinder_buffer_free(data.buffer);
     gbinder_driver_unref(driver);
@@ -2199,6 +2303,8 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("empty"), test_empty);
     g_test_add_func(TEST_("byte"), test_byte);
     g_test_add_func(TEST_("bool"), test_bool);
+    g_test_add_func(TEST_("int8"), test_int8);
+    g_test_add_func(TEST_("int16"), test_int16);
     g_test_add_func(TEST_("int32"), test_int32);
     g_test_add_func(TEST_("int64"), test_int64);
     g_test_add_func(TEST_("float"), test_float);

--- a/unit/unit_writer/unit_writer.c
+++ b/unit/unit_writer/unit_writer.c
@@ -64,6 +64,10 @@ test_null(
     gsize size = 1;
 
     gbinder_local_request_init_writer(NULL, &writer);
+    gbinder_writer_append_int8(NULL, 0);
+    gbinder_writer_append_int8(&writer, 0);
+    gbinder_writer_append_int16(NULL, 0);
+    gbinder_writer_append_int16(&writer, 0);
     gbinder_writer_append_int32(NULL, 0);
     gbinder_writer_append_int32(&writer, 0);
     gbinder_writer_append_int64(NULL, 0);
@@ -162,6 +166,60 @@ test_cleanup(
     gbinder_writer_add_cleanup(&writer, test_cleanup_fn, &cleanup_count);
     gbinder_local_request_unref(req);
     g_assert_cmpint(cleanup_count, == ,2);
+}
+
+/*==========================================================================*
+ * int8
+ *==========================================================================*/
+
+static
+void
+test_int8(
+    void)
+{
+    const char encoded[] = {
+        TEST_INT8_BYTES_4(0x80)
+    };
+    GBinderLocalRequest* req = gbinder_local_request_new(&gbinder_io_32, NULL);
+    GBinderOutputData* data;
+    GBinderWriter writer;
+
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_int8(&writer, 0x80);
+
+    data = gbinder_local_request_data(req);
+    g_assert(!gbinder_output_data_offsets(data));
+    g_assert(!gbinder_output_data_buffers_size(data));
+    g_assert_cmpuint(data->bytes->len, == ,sizeof(encoded));
+    g_assert(!memcmp(data->bytes->data, encoded, data->bytes->len));
+    gbinder_local_request_unref(req);
+}
+
+/*==========================================================================*
+ * int16
+ *==========================================================================*/
+
+static
+void
+test_int16(
+    void)
+{
+    const char encoded[] = {
+        TEST_INT16_BYTES_4(0x80ff)
+    };
+    GBinderLocalRequest* req = gbinder_local_request_new(&gbinder_io_32, NULL);
+    GBinderOutputData* data;
+    GBinderWriter writer;
+
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_int16(&writer, 0x80ff);
+
+    data = gbinder_local_request_data(req);
+    g_assert(!gbinder_output_data_offsets(data));
+    g_assert(!gbinder_output_data_buffers_size(data));
+    g_assert_cmpuint(data->bytes->len, == ,sizeof(encoded));
+    g_assert(!memcmp(data->bytes->data, encoded, data->bytes->len));
+    gbinder_local_request_unref(req);
 }
 
 /*==========================================================================*
@@ -283,9 +341,9 @@ test_bool(
     void)
 {
     const char encoded[] = {
-        0x00, 0x00, 0x00, 0x00,
-        0x01, 0x00, 0x00, 0x00,
-        0x01, 0x00, 0x00, 0x00
+        TEST_INT8_BYTES_4(0),
+        TEST_INT8_BYTES_4(1),
+        TEST_INT8_BYTES_4(1)
     };
     GBinderLocalRequest* req = gbinder_local_request_new(&gbinder_io_32, NULL);
     GBinderOutputData* data;
@@ -1063,6 +1121,8 @@ int main(int argc, char* argv[])
     g_test_init(&argc, &argv, NULL);
     g_test_add_func(TEST_("null"), test_null);
     g_test_add_func(TEST_("cleanup"), test_cleanup);
+    g_test_add_func(TEST_("int8"), test_int8);
+    g_test_add_func(TEST_("int16"), test_int16);
     g_test_add_func(TEST_("int32"), test_int32);
     g_test_add_func(TEST_("int64"), test_int64);
     g_test_add_func(TEST_("float"), test_float);


### PR DESCRIPTION
Those have to be padded to 4-byte boundary. It's easy to forget.