### PR TITLE
Make sure stale object pointers don't hang around

### DIFF
--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -149,7 +149,7 @@ gbinder_ipc_register_local_object(
 
 GBinderRemoteObject*
 gbinder_ipc_get_service_manager(
-    GBinderIpc* self)
+    GBinderIpc* ipc)
     GBINDER_INTERNAL
     G_GNUC_WARN_UNUSED_RESULT;
 
@@ -196,21 +196,27 @@ gbinder_ipc_cancel(
 /* Internal for GBinderLocalObject */
 void
 gbinder_ipc_local_object_disposed(
-    GBinderIpc* self,
+    GBinderIpc* ipc,
+    GBinderLocalObject* obj)
+    GBINDER_INTERNAL;
+
+void
+gbinder_ipc_invalidate_local_object(
+    GBinderIpc* ipc,
     GBinderLocalObject* obj)
     GBINDER_INTERNAL;
 
 /* Internal for GBinderRemoteObject */
 void
 gbinder_ipc_remote_object_disposed(
-    GBinderIpc* self,
+    GBinderIpc* ipc,
     GBinderRemoteObject* obj)
     GBINDER_INTERNAL;
 
 /* Needed by unit tests */
 gboolean
 gbinder_ipc_set_max_threads(
-    GBinderIpc* self,
+    GBinderIpc* ipc,
     gint max_threads)
     GBINDER_INTERNAL;
 

--- a/src/gbinder_local_object.c
+++ b/src/gbinder_local_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -644,6 +644,7 @@ gbinder_local_object_finalize(
     GBinderLocalObjectPriv* priv = self->priv;
 
     GASSERT(!self->strong_refs);
+    gbinder_ipc_invalidate_local_object(self->ipc, self);
     gbinder_ipc_unref(self->ipc);
     g_strfreev(priv->ifaces);
     G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021 Jolla Ltd.
- * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2021-2022 Jolla Ltd.
+ * Copyright (C) 2021-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -416,10 +416,8 @@ gbinder_proxy_object_release(
     GBinderProxyObjectPriv* priv = self->priv;
 
     if (priv->remote_death_id && object->strong_refs == 1) {
-        GBinderRemoteObject* remote = self->remote;
-
         /* Last strong ref, release the attached remote object */
-        gbinder_driver_release(remote->ipc->driver, remote->handle);
+        gbinder_remote_object_commit_suicide(self->remote);
     }
     GBINDER_LOCAL_OBJECT_CLASS(PARENT_CLASS)->release(object);
 }

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -149,6 +149,7 @@ gbinder_remote_object_commit_suicide(
         GBinderRemoteObjectPriv* priv = self->priv;
 
         self->dead = TRUE;
+        gbinder_driver_clear_death_notification(driver, self);
         if (priv->acquired) {
             priv->acquired = FALSE;
             /* Release the dead node */

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -294,6 +294,7 @@ gbinder_remote_object_finalize(
     GBinderIpc* ipc = self->ipc;
     GBinderDriver* driver = ipc->driver;
 
+    gbinder_ipc_invalidate_remote_handle(ipc, self->handle);
     if (!self->dead) {
         gbinder_driver_clear_death_notification(driver, self);
     }


### PR DESCRIPTION
When an object is being finalized, other thread may re-reference the object right before it gets removed from the table (making ref_count greater than 1) and then quickly release that reference before g_object_unref() re-checks the refcount.

If that happens, the object may remain in the table by time when its finalize() callback is called. That applies both to local and remote objects.

We still have to invalidate the handle in dispose() callback because it's the last point when GObject can be legitimately re-referenced and brought back to life.