### PR TITLE
[gbinder] Added writer and reader for parcelables

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -143,6 +143,11 @@ gbinder_reader_read_buffer(
     G_GNUC_WARN_UNUSED_RESULT;
 
 const void*
+gbinder_reader_read_parcelable(
+    GBinderReader* reader,
+    gsize* size); /* Since 1.1.XX */
+
+const void*
 gbinder_reader_read_hidl_struct1(
     GBinderReader* reader,
     gsize size); /* Since 1.0.9 */

--- a/include/gbinder_writer.h
+++ b/include/gbinder_writer.h
@@ -149,6 +149,12 @@ gbinder_writer_append_buffer_object(
     gsize len);
 
 void
+gbinder_writer_append_parcelable(
+    GBinderWriter* writer,
+    const void* buf,
+    gsize len); /* Since 1.1.XX */
+
+void
 gbinder_writer_append_hidl_vec(
     GBinderWriter* writer,
     const void* base,

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -754,6 +754,43 @@ gbinder_writer_data_append_buffer_object(
     return index;
 }
 
+/*
+ * This is supposed to be used to write aidl parcelables, and is not
+ * guaranteed to work on any other kind of parcelable.
+ */
+void
+gbinder_writer_append_parcelable(
+    GBinderWriter* self,
+    const void* buf,
+    gsize len) /* Since 1.1.XX */
+{
+    GBinderWriterData* data = gbinder_writer_data(self);
+
+    if (G_LIKELY(data)) {
+        gbinder_writer_data_append_parcelable(data, buf, len);
+    }
+}
+
+void
+gbinder_writer_data_append_parcelable(
+    GBinderWriterData* data,
+    const void* ptr,
+    gsize size)
+{
+    if (!ptr) {
+        /* Null */
+        gbinder_writer_data_append_int32(data, 0);
+        return;
+    }
+
+    /* Non-null */
+    gbinder_writer_data_append_int32(data, 1);
+    /* Write the parcelable size, taking in account the size of this integer as well */
+    gbinder_writer_data_append_int32(data, size + sizeof(gint32));
+    /* Append the parcelable data */
+    g_byte_array_append(data->bytes, ptr, size);
+}
+
 void
 gbinder_writer_append_hidl_string(
     GBinderWriter* self,

--- a/src/gbinder_writer_p.h
+++ b/src/gbinder_writer_p.h
@@ -131,6 +131,13 @@ gbinder_writer_data_append_buffer_object(
     GBINDER_INTERNAL;
 
 void
+gbinder_writer_data_append_parcelable(
+    GBinderWriterData* data,
+    const void* ptr,
+    gsize size)
+    GBINDER_INTERNAL;
+
+void
 gbinder_writer_data_append_hidl_vec(
     GBinderWriterData* data,
     const void* base,


### PR DESCRIPTION
Parcelables allow to serialize arbitrary objects inside an AIDL parcel.

The structure is pretty simple, and is as follows:

* (int32) Control integer that signals whether there is content (1), or not (0)
* (int32) Integer holding the payload size, including itself
* The actual payload

This pull request adds both a writer and a reader for parcelables, along with matching unit tests.

Useful to talk with AIDL HALs on Android 11+.