### PR TITLE
Make protocol selectable at runtime

### DIFF
--- a/include/gbinder_servicemanager.h
+++ b/include/gbinder_servicemanager.h
@@ -79,6 +79,12 @@ gbinder_servicemanager_new(
     const char* dev);
 
 GBinderServiceManager*
+gbinder_servicemanager_new2(
+    const char* dev,
+    const char* sm_protocol,
+    const char* rpc_protocol); /* Since 1.1.20 */
+
+GBinderServiceManager*
 gbinder_defaultservicemanager_new(
     const char* dev)
     G_DEPRECATED_FOR(gbinder_servicemanager_new);

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -1840,14 +1840,18 @@ const GBinderIpcSyncApi gbinder_ipc_sync_main = {
  *==========================================================================*/
 
 GBinderIpc*
-gbinder_ipc_new(
-    const char* dev)
+gbinder_ipc_new_for_protocol(
+    const char* dev,
+    const char* protocol_name)
 {
     GBinderIpc* self = NULL;
     const GBinderRpcProtocol* protocol;
 
     if (!dev || !dev[0]) dev = GBINDER_DEFAULT_BINDER;
-    protocol = gbinder_rpc_protocol_for_device(dev); /* Never returns NULL */
+    if (protocol_name)
+        protocol = gbinder_rpc_protocol_by_name(protocol_name);
+    if (!protocol_name || !protocol)
+        protocol = gbinder_rpc_protocol_for_device(dev); /* Never returns NULL */
 
     /* Lock */
     pthread_mutex_lock(&gbinder_ipc_mutex);
@@ -1880,6 +1884,13 @@ gbinder_ipc_new(
     pthread_mutex_unlock(&gbinder_ipc_mutex);
     /* Unlock */
     return self;
+}
+
+GBinderIpc*
+gbinder_ipc_new(
+    const char* dev)
+{
+    return gbinder_ipc_new_for_protocol(dev, NULL /* pick from config, or default */);
 }
 
 GBinderIpc*

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -104,6 +104,12 @@ gbinder_ipc_new(
     GBINDER_INTERNAL;
 
 GBinderIpc*
+gbinder_ipc_new_for_protocol(
+    const char* dev,
+    const char* protocol_name)
+    GBINDER_INTERNAL;
+
+GBinderIpc*
 gbinder_ipc_ref(
     GBinderIpc* ipc)
     GBINDER_INTERNAL;

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -379,6 +379,13 @@ gbinder_rpc_protocol_for_device(
     return gbinder_rpc_protocol_default;
 }
 
+const GBinderRpcProtocol*
+gbinder_rpc_protocol_by_name(
+    const char* protocol_name)
+{
+    return gbinder_rpc_protocol_find(protocol_name);
+}
+
 /*
  * Local Variables:
  * mode: C

--- a/src/gbinder_rpc_protocol.h
+++ b/src/gbinder_rpc_protocol.h
@@ -49,6 +49,11 @@ struct gbinder_rpc_protocol {
         char** iface);
 };
 
+const GBinderRpcProtocol*
+gbinder_rpc_protocol_by_name(
+    const char* protocol_name)
+    GBINDER_INTERNAL;
+
 /* Returns one of the above based on the device name */
 const GBinderRpcProtocol*
 gbinder_rpc_protocol_for_device(

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -90,7 +90,8 @@ GType gbinder_servicemanager_get_type(void) GBINDER_INTERNAL;
 GBinderServiceManager*
 gbinder_servicemanager_new_with_type(
     GType type,
-    const char* dev)
+    const char* dev,
+    const char* rpc_protocol)
     GBINDER_INTERNAL;
 
 void

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -409,7 +409,7 @@ test_null(
     void)
 {
     g_assert(!gbinder_servicemanager_new(NULL));
-    g_assert(!gbinder_servicemanager_new_with_type(0, NULL));
+    g_assert(!gbinder_servicemanager_new_with_type(0, NULL, NULL));
     g_assert(!gbinder_servicemanager_new_local_object(NULL, NULL, NULL, NULL));
     g_assert(!gbinder_servicemanager_ref(NULL));
     g_assert(!gbinder_servicemanager_device(NULL));
@@ -449,7 +449,7 @@ test_invalid(
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     g_assert(!gbinder_servicemanager_new_with_type(GBINDER_TYPE_LOCAL_OBJECT,
-        NULL));
+        NULL, NULL));
     g_assert(TEST_IS_HWSERVICEMANAGER(sm));
     g_assert(!gbinder_servicemanager_list(sm, NULL, NULL));
     g_assert(!gbinder_servicemanager_get_service(sm, "foo", NULL, NULL));
@@ -995,7 +995,7 @@ test_notify_type(
     gulong id1, id2;
 
     test_setup_ping(ipc);
-    sm = gbinder_servicemanager_new_with_type(t, NULL);
+    sm = gbinder_servicemanager_new_with_type(t, NULL, NULL);
     test = TEST_SERVICEMANAGER2(sm, t);
     id1 = gbinder_servicemanager_add_registration_handler(sm, name,
         test_registration_func_inc, &count);


### PR DESCRIPTION
In waydroid we spawn binder services from the host to interact with the android container.
Having the binder protocol as a system configuration makes it impossible to upgrade the android version without also updating the host configuration. We don't want these necessarily coupled.

Make the protocol selectable as a string so we can dynamically choose how to talk to the android container based on its android version.