### PR TITLE
All binder objects need stability field in Android 11

### DIFF
--- a/src/gbinder_buffer.c
+++ b/src/gbinder_buffer.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -249,6 +249,15 @@ gbinder_buffer_io(
     GBinderDriver* driver = gbinder_buffer_driver(buf);
 
     return driver ? gbinder_driver_io(driver) : NULL;
+}
+
+const GBinderRpcProtocol*
+gbinder_buffer_protocol(
+    GBinderBuffer* buf)
+{
+    GBinderDriver* driver = gbinder_buffer_driver(buf);
+
+    return driver ? gbinder_driver_protocol(driver) : NULL;
 }
 
 void**

--- a/src/gbinder_buffer_p.h
+++ b/src/gbinder_buffer_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -70,6 +70,11 @@ gbinder_buffer_data(
 
 const GBinderIo*
 gbinder_buffer_io(
+    GBinderBuffer* buf)
+    GBINDER_INTERNAL;
+
+const GBinderRpcProtocol*
+gbinder_buffer_protocol(
     GBinderBuffer* buf)
     GBINDER_INTERNAL;
 

--- a/src/gbinder_client.c
+++ b/src/gbinder_client.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -282,7 +282,8 @@ gbinder_client_new2(
             priv->ranges = g_new0(GBinderClientIfaceRange, 1);
             priv->ranges[0].last_code = UINT_MAX;
             priv->ranges[0].basic_req = gbinder_local_request_new
-                (gbinder_driver_io(driver), NULL);
+                (gbinder_driver_io(driver), gbinder_driver_protocol(driver),
+                    NULL);
         }
         return self;
     }
@@ -373,9 +374,10 @@ gbinder_client_new_request(
 {
     if (G_LIKELY(self)) {
         GBinderClientPriv* priv = gbinder_client_cast(self);
-        const GBinderIo* io = gbinder_driver_io(self->remote->ipc->driver);
+        GBinderDriver* driver = self->remote->ipc->driver;
 
-        return gbinder_local_request_new(io, priv->ranges->rpc_header);
+        return gbinder_local_request_new(gbinder_driver_io(driver),
+            gbinder_driver_protocol(driver), priv->ranges->rpc_header);
     }
     return NULL;
 }
@@ -387,13 +389,14 @@ gbinder_client_new_request2(
 {
     if (G_LIKELY(self)) {
         GBinderClientPriv* priv = gbinder_client_cast(self);
-        const GBinderClientIfaceRange* r = gbinder_client_find_range
+        const GBinderClientIfaceRange* range = gbinder_client_find_range
             (priv, code);
 
-        if (r) {
-            const GBinderIo* io = gbinder_driver_io(self->remote->ipc->driver);
+        if (range) {
+            GBinderDriver* driver = self->remote->ipc->driver;
 
-            return gbinder_local_request_new(io, r->rpc_header);
+            return gbinder_local_request_new(gbinder_driver_io(driver),
+                gbinder_driver_protocol(driver), range->rpc_header);
         }
     }
     return NULL;

--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -1324,8 +1324,9 @@ GBinderLocalRequest*
 gbinder_driver_local_request_new_ping(
     GBinderDriver* self)
 {
-    GBinderLocalRequest* req = gbinder_local_request_new(self->io, NULL);
     GBinderWriter writer;
+    GBinderLocalRequest* req = gbinder_local_request_new(self->io,
+        self->protocol, NULL);
 
     gbinder_local_request_init_writer(req, &writer);
     self->protocol->write_ping(&writer);

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -126,7 +126,7 @@ struct gbinder_io {
     } br;
 
     /* Size of the object and its extra data */
-    gsize (*object_size)(const void* obj);
+    gsize (*object_size)(const void* obj, const GBinderRpcProtocol* protocol);
     gsize (*object_data_size)(const void* obj);
 
     /* Writes pointer to the buffer. The destination buffer must have
@@ -142,8 +142,9 @@ struct gbinder_io {
     guint (*encode_cookie)(void* out, guint64 cookie);
 
     /* Encode flat_buffer_object */
-#define GBINDER_MAX_BINDER_OBJECT_SIZE (24)
-    guint (*encode_local_object)(void* out, GBinderLocalObject* obj);
+#define GBINDER_MAX_BINDER_OBJECT_SIZE (28)
+    guint (*encode_local_object)(void* out, GBinderLocalObject* obj,
+        const GBinderRpcProtocol* protocol);
     guint (*encode_remote_object)(void* out, GBinderRemoteObject* obj);
     guint (*encode_fd_object)(void* out, int fd);
     guint (*encode_fda_object)(void* out, const GBinderFds *fds,
@@ -189,9 +190,11 @@ struct gbinder_io {
     void (*decode_transaction_data)(const void* data, GBinderIoTxData* tx);
     void* (*decode_ptr_cookie)(const void* data);
     guint (*decode_cookie)(const void* data, guint64* cookie);
-    guint (*decode_binder_handle)(const void* obj, guint32* handle);
+    guint (*decode_binder_handle)(const void* obj, guint32* handle,
+        const GBinderRpcProtocol* protocol);
     guint (*decode_binder_object)(const void* data, gsize size,
-        GBinderObjectRegistry* reg, GBinderRemoteObject** obj);
+        GBinderObjectRegistry* reg, GBinderRemoteObject** obj,
+        const GBinderRpcProtocol* protocol);
     guint (*decode_buffer_object)(GBinderBuffer* buf, gsize offset,
         GBinderIoBufferObject* out);
     guint (*decode_fd_object)(const void* data, gsize size, int* fd);

--- a/src/gbinder_local_object.c
+++ b/src/gbinder_local_object.c
@@ -90,6 +90,15 @@ static const char hidl_base_interface[] = "android.hidl.base@1.0::IBase";
  *==========================================================================*/
 
 static
+GBinderLocalReply*
+gbinder_local_object_create_reply(
+    GBinderLocalObject* self)
+{
+    return gbinder_local_reply_new(gbinder_local_object_io(self),
+        gbinder_local_object_protocol(self));
+}
+
+static
 GBINDER_LOCAL_TRANSACTION_SUPPORT
 gbinder_local_object_default_can_handle_transaction(
     GBinderLocalObject* self,
@@ -139,8 +148,7 @@ gbinder_local_object_ping_transaction(
     GBinderRemoteRequest* req,
     int* status)
 {
-    const GBinderIo* io = gbinder_local_object_io(self);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalReply* reply = gbinder_local_object_create_reply(self);
 
     GVERBOSE("  PING_TRANSACTION");
     gbinder_local_reply_append_int32(reply, GBINDER_STATUS_OK);
@@ -155,9 +163,8 @@ gbinder_local_object_interface_transaction(
     GBinderRemoteRequest* req,
     int* status)
 {
-    const GBinderIo* io = gbinder_local_object_io(self);
     GBinderLocalObjectPriv* priv = self->priv;
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalReply* reply = gbinder_local_object_create_reply(self);
 
     GVERBOSE("  INTERFACE_TRANSACTION");
     gbinder_local_reply_append_string16(reply, priv->ifaces[0]);
@@ -173,8 +180,7 @@ gbinder_local_object_hidl_ping_transaction(
     int* status)
 {
     /*android.hidl.base@1.0::IBase interfaceDescriptor() */
-    const GBinderIo* io = gbinder_local_object_io(self);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalReply* reply = gbinder_local_object_create_reply(self);
 
     GVERBOSE("  HIDL_PING_TRANSACTION \"%s\"",
         gbinder_remote_request_interface(req));
@@ -191,9 +197,8 @@ gbinder_local_object_hidl_get_descriptor_transaction(
     int* status)
 {
     /*android.hidl.base@1.0::IBase interfaceDescriptor() */
-    const GBinderIo* io = gbinder_local_object_io(self);
     GBinderLocalObjectPriv* priv = self->priv;
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalReply* reply = gbinder_local_object_create_reply(self);
     GBinderWriter writer;
 
     GVERBOSE("  HIDL_GET_DESCRIPTOR_TRANSACTION \"%s\"",
@@ -213,8 +218,7 @@ gbinder_local_object_hidl_descriptor_chain_transaction(
     int* status)
 {
     /*android.hidl.base@1.0::IBase interfaceChain() */
-    const GBinderIo* io = gbinder_local_object_io(self);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalReply* reply = gbinder_local_object_create_reply(self);
     GBinderWriter writer;
 
     GVERBOSE("  HIDL_DESCRIPTOR_CHAIN_TRANSACTION \"%s\"",
@@ -480,7 +484,7 @@ gbinder_local_object_new_reply(
     GBinderLocalObject* self)
 {
     if (G_LIKELY(self)) {
-        return gbinder_local_reply_new(gbinder_local_object_io(self));
+        return gbinder_local_object_create_reply(self);
     }
     return NULL;
 }

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -92,6 +92,8 @@ GType gbinder_local_object_get_type(void) GBINDER_INTERNAL;
 
 #define gbinder_local_object_dev(obj) (gbinder_driver_dev((obj)->ipc->driver))
 #define gbinder_local_object_io(obj) (gbinder_driver_io((obj)->ipc->driver))
+#define gbinder_local_object_protocol(obj) \
+    (gbinder_driver_protocol((obj)->ipc->driver))
 
 GBinderLocalObject*
 gbinder_local_object_new_with_type(

--- a/src/gbinder_local_reply.c
+++ b/src/gbinder_local_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -72,10 +72,12 @@ gbinder_local_reply_output_buffers_size(
 
 GBinderLocalReply*
 gbinder_local_reply_new(
-    const GBinderIo* io)
+    const GBinderIo* io,
+    const GBinderRpcProtocol* protocol)
 {
     GASSERT(io);
-    if (io) {
+    GASSERT(protocol);
+    if (io && protocol) {
         GBinderLocalReply* self = g_slice_new0(GBinderLocalReply);
         GBinderWriterData* data = &self->data;
         GBinderOutputData* out = &self->out;
@@ -87,6 +89,7 @@ gbinder_local_reply_new(
 
         g_atomic_int_set(&self->refcount, 1);
         data->io = io;
+        data->protocol = protocol;
         out->bytes = data->bytes = g_byte_array_new();
         out->f = &local_reply_output_fn;
         return self;

--- a/src/gbinder_local_reply_p.h
+++ b/src/gbinder_local_reply_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -39,7 +39,8 @@
 
 GBinderLocalReply*
 gbinder_local_reply_new(
-    const GBinderIo* io)
+    const GBinderIo* io,
+    const GBinderRpcProtocol* protocol)
     GBINDER_INTERNAL;
 
 GBinderOutputData*

--- a/src/gbinder_local_request_p.h
+++ b/src/gbinder_local_request_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -40,6 +40,7 @@
 GBinderLocalRequest*
 gbinder_local_request_new(
     const GBinderIo* io,
+    const GBinderRpcProtocol* protocol,
     GBytes* init)
     GBINDER_INTERNAL;
 

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -352,7 +352,8 @@ gbinder_reader_read_nullable_object(
     if (gbinder_reader_can_read_object(p)) {
         const GBinderReaderData* data = p->data;
         const guint eaten = data->reg->io->decode_binder_object(p->ptr,
-            gbinder_reader_bytes_remaining(reader), data->reg, out);
+            gbinder_reader_bytes_remaining(reader), data->reg, out,
+            gbinder_buffer_protocol(data->buffer));
 
         if (eaten) {
             p->ptr += eaten;

--- a/src/gbinder_remote_reply.c
+++ b/src/gbinder_remote_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -131,8 +131,9 @@ gbinder_remote_reply_convert_to_local(
         GBinderObjectRegistry* reg = d->reg;
 
         if (reg) {
-            return gbinder_local_reply_set_contents
-                (gbinder_local_reply_new(reg->io), d->buffer, convert);
+            return gbinder_local_reply_set_contents(gbinder_local_reply_new
+                (reg->io, gbinder_buffer_protocol(d->buffer)),
+                    d->buffer, convert);
         }
     }
     return NULL;

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -212,12 +212,23 @@ gbinder_rpc_protocol_aidl3_read_rpc_header(
     return *iface;
 }
 
+static
+void
+gbinder_rpc_protocol_aidl3_finish_flatten_binder(
+    void* out,
+    GBinderLocalObject* obj)
+{
+    *(guint32*)out = GBINDER_STABILITY_SYSTEM;
+}
+
 static const GBinderRpcProtocol gbinder_rpc_protocol_aidl3 = {
     .name = "aidl3",
     .ping_tx = GBINDER_PING_TRANSACTION,
     .write_ping = gbinder_rpc_protocol_aidl_write_ping, /* no payload */
     .write_rpc_header = gbinder_rpc_protocol_aidl3_write_rpc_header,
-    .read_rpc_header = gbinder_rpc_protocol_aidl3_read_rpc_header
+    .read_rpc_header = gbinder_rpc_protocol_aidl3_read_rpc_header,
+    .flat_binder_object_extra = 4,
+    .finish_flatten_binder = gbinder_rpc_protocol_aidl3_finish_flatten_binder
 };
 
 /*==========================================================================*

--- a/src/gbinder_rpc_protocol.h
+++ b/src/gbinder_rpc_protocol.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2020 Jolla Ltd.
- * Copyright (C) 2018-2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -47,6 +47,17 @@ struct gbinder_rpc_protocol {
     void (*write_rpc_header)(GBinderWriter* writer, const char* iface);
     const char* (*read_rpc_header)(GBinderReader* reader, guint32 txcode,
         char** iface);
+
+    /*
+     * For the sake of simplicity, let's assume that the trailer has a
+     * fixed size and that size is the same on both 32 and 64 bit platforms.
+     * Also note that finish_unflatten_binder() is only invoked for the
+     * remote objects that are not NULL, otherwise flat_binder_object_extra
+     * bytes are just skipped.
+     */
+    gsize flat_binder_object_extra;
+    void (*finish_flatten_binder)(void* out, GBinderLocalObject* obj);
+    void (*finish_unflatten_binder)(const void* in, GBinderRemoteObject* obj);
 };
 
 const GBinderRpcProtocol*

--- a/src/gbinder_servicemanager_aidl.h
+++ b/src/gbinder_servicemanager_aidl.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2022 Jolla Ltd.
+ * Copyright (C) 2020-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -51,10 +51,6 @@ typedef struct gbinder_servicemanager_aidl_class {
 
 #define GBINDER_TYPE_SERVICEMANAGER_AIDL \
     gbinder_servicemanager_aidl_get_type()
-#define GBINDER_SERVICEMANAGER_AIDL_CLASS(klass) \
-    G_TYPE_CHECK_CLASS_CAST((klass), GBINDER_TYPE_SERVICEMANAGER_AIDL, \
-    GBinderServiceManagerAidlClass)
-
 #define GBINDER_SERVICEMANAGER_AIDL_GET_CLASS(obj) \
     G_TYPE_INSTANCE_GET_CLASS((obj), GBINDER_TYPE_SERVICEMANAGER_AIDL, \
     GBinderServiceManagerAidlClass)
@@ -64,13 +60,6 @@ enum gbinder_servicemanager_aidl_calls {
     CHECK_SERVICE_TRANSACTION,
     ADD_SERVICE_TRANSACTION,
     LIST_SERVICES_TRANSACTION
-};
-
-enum gbinder_stability_level {
-    UNDECLARED = 0,
-    VENDOR = 0b000011,
-    SYSTEM = 0b001100,
-    VINTF = 0b111111
 };
 
 #define DUMP_FLAG_PRIORITY_DEFAULT (0x08)

--- a/src/gbinder_servicemanager_aidl2.c
+++ b/src/gbinder_servicemanager_aidl2.c
@@ -45,8 +45,6 @@ G_DEFINE_TYPE(GBinderServiceManagerAidl2,
     GBINDER_TYPE_SERVICEMANAGER_AIDL)
 
 #define PARENT_CLASS gbinder_servicemanager_aidl2_parent_class
-#define DUMP_FLAG_PRIORITY_DEFAULT (0x08)
-#define DUMP_FLAG_PRIORITY_ALL     (0x0f)
 
 static
 GBinderLocalRequest*

--- a/src/gbinder_servicemanager_aidl3.c
+++ b/src/gbinder_servicemanager_aidl3.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2021 Jolla Ltd.
- * Copyright (C) 2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2021-2022 Jolla Ltd.
+ * Copyright (C) 2021-2022 Slava Monich <slava.monich@jolla.com>
  * Copyright (C) 2021 Gary Wang <gary.wang@canonical.com>
  * Copyright (C) 2021 Madhushan Nishantha <jlmadushan@gmail.com>
  *
@@ -68,7 +68,7 @@ gbinder_servicemanager_aidl3_get_service(
         CHECK_SERVICE_TRANSACTION, req, status, api);
 
     gbinder_remote_reply_init_reader(reply, &reader);
-    gbinder_reader_read_int32(&reader, NULL /* stability */);
+    gbinder_reader_read_int32(&reader, NULL /* status? */);
     obj = gbinder_reader_read_object(&reader);
 
     gbinder_remote_reply_unref(reply);
@@ -129,11 +129,6 @@ gbinder_servicemanager_aidl3_add_service_req(
 
     gbinder_local_request_append_string16(req, name);
     gbinder_local_request_append_local_object(req, obj);
-    /*
-     * Starting from Android 11, to add a service, Android framework requires
-     * an additional field `stability` when reading a strong binder.
-     */
-    gbinder_local_request_append_int32(req, SYSTEM);
     gbinder_local_request_append_int32(req, 0);
     gbinder_local_request_append_int32(req, DUMP_FLAG_PRIORITY_DEFAULT);
     return req;

--- a/src/gbinder_servicemanager_aidl4.c
+++ b/src/gbinder_servicemanager_aidl4.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2020 Jolla Ltd.
- * Copyright (C) 2020 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2020-2022 Jolla Ltd.
+ * Copyright (C) 2020-2022 Slava Monich <slava.monich@jolla.com>
  * Copyright (C) 2021 Gary Wang <gary.wang@canonical.com>
  * Copyright (C) 2021 Madhushan Nishantha <jlmadushan@gmail.com>
  *
@@ -35,7 +35,6 @@
 #include "gbinder_servicemanager_aidl_p.h"
 #include "gbinder_client_p.h"
 #include "gbinder_reader_p.h"
-#include "binder.h"
 
 #include <gbinder_local_request.h>
 #include <gbinder_remote_reply.h>
@@ -64,18 +63,24 @@ gbinder_servicemanager_aidl4_add_service_req(
 
     gbinder_local_request_append_string16(req, name);
     gbinder_local_request_append_local_object(req, obj);
+
     /*
      * When reading nullable strong binder, from Android 12, the format of
      * the `stability` field passed on the wire was changed and evolved to
-     * `struct Category`, which consists of the following members with 4 bytes long.
+     * `struct Category`, which consists of the following members with 4 bytes
+     * long.
      *
      * struct Category {
      *   uint8_t version;
      *   uint8_t reserved[2];
      *   Level level;        <- bitmask of Stability::Level
      * }
+     *
+     * Hmmm, is that ^ really true?
      */
-    gbinder_local_request_append_int32(req, B_PACK_CHARS(SYSTEM, 0, 0, BINDER_WIRE_FORMAT_VERSION));
+    gbinder_local_request_append_int32(req,
+        GBINDER_FOURCC(GBINDER_STABILITY_SYSTEM, 0, 0,
+            BINDER_WIRE_FORMAT_VERSION));
     gbinder_local_request_append_int32(req, 0);
     gbinder_local_request_append_int32(req, DUMP_FLAG_PRIORITY_DEFAULT);
 

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -76,6 +76,13 @@ typedef struct gbinder_ipc_sync_api GBinderIpcSyncApi;
 
 /* As a special case, ServiceManager's handle is zero */
 #define GBINDER_SERVICEMANAGER_HANDLE (0)
+
+typedef enum gbinder_stability_level {
+    GBINDER_STABILITY_UNDECLARED = 0,
+    GBINDER_STABILITY_VENDOR = 0x03,
+    GBINDER_STABILITY_SYSTEM = 0x0c,
+    GBINDER_STABILITY_VINTF = 0x3f
+} GBINDER_STABILITY_LEVEL;
 
 #endif /* GBINDER_TYPES_PRIVATE_H */
 

--- a/src/gbinder_writer_p.h
+++ b/src/gbinder_writer_p.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -39,6 +39,7 @@
 
 typedef struct gbinder_writer_data {
     const GBinderIo* io;
+    const GBinderRpcProtocol* protocol;
     GByteArray* bytes;
     GUtilIntArray* offsets;
     gsize buffers_size;

--- a/unit/common/test_binder.c
+++ b/unit/common/test_binder.c
@@ -69,11 +69,6 @@ static GMainLoop* test_binder_exit_loop = NULL;
 #define BINDER_SET_MAX_THREADS _IOW('b', 5, guint32)
 #define BINDER_BUFFER_FLAG_HAS_PARENT 0x01
 
-#define B_TYPE_LARGE 0x85
-#define BINDER_TYPE_BINDER  GBINDER_FOURCC('s', 'b', '*', B_TYPE_LARGE)
-#define BINDER_TYPE_HANDLE  GBINDER_FOURCC('s', 'h', '*', B_TYPE_LARGE)
-#define BINDER_TYPE_PTR     GBINDER_FOURCC('p', 't', '*', B_TYPE_LARGE)
-
 #define TF_ONE_WAY     0x01
 #define TF_ROOT_OBJECT 0x04
 #define TF_STATUS_CODE 0x08

--- a/unit/common/test_binder.h
+++ b/unit/common/test_binder.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -34,6 +34,16 @@
 #define TEST_BINDER_H
 
 #include "test_common.h"
+
+#define B_TYPE_LARGE 0x85
+#define BINDER_TYPE_BINDER  GBINDER_FOURCC('s', 'b', '*', B_TYPE_LARGE)
+#define BINDER_TYPE_HANDLE  GBINDER_FOURCC('s', 'h', '*', B_TYPE_LARGE)
+#define BINDER_TYPE_PTR     GBINDER_FOURCC('p', 't', '*', B_TYPE_LARGE)
+
+#define BUFFER_OBJECT_SIZE_32 (24)
+#define BUFFER_OBJECT_SIZE_64 (40)
+#define BINDER_OBJECT_SIZE_32 (16)
+#define BINDER_OBJECT_SIZE_64 (24)
 
 typedef struct test_binder TestBinder;
 

--- a/unit/unit_client/unit_client.c
+++ b/unit/unit_client/unit_client.c
@@ -277,7 +277,8 @@ test_sync_reply_tx(
     GBinderDriver* driver = gbinder_client_ipc(client)->driver;
     int fd = gbinder_driver_fd(driver);
     const GBinderIo* io = gbinder_driver_io(driver);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    const GBinderRpcProtocol* protocol = gbinder_driver_protocol(driver);
+    GBinderLocalReply* reply = gbinder_local_reply_new(io, protocol);
     GBinderRemoteReply* tx_reply;
     GBinderOutputData* data;
     const guint32 handle = 0;
@@ -380,7 +381,8 @@ test_reply_tx(
     GBinderDriver* driver = gbinder_client_ipc(client)->driver;
     int fd = gbinder_driver_fd(driver);
     const GBinderIo* io = gbinder_driver_io(driver);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    const GBinderRpcProtocol* protocol = gbinder_driver_protocol(driver);
+    GBinderLocalReply* reply = gbinder_local_reply_new(io, protocol);
     GBinderOutputData* data;
     const guint32 handle = 0;
     const guint32 code = 1;

--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -70,6 +70,24 @@ test_quit_when_destroyed(
     test_quit_later((GMainLoop*)loop);
 }
 
+static
+GBinderLocalRequest*
+test_local_request_new(
+    GBinderIpc* ipc)
+{
+    return gbinder_local_request_new(gbinder_driver_io(ipc->driver),
+        gbinder_driver_protocol(ipc->driver), NULL);
+}
+
+static
+GBinderLocalReply*
+test_local_reply_new(
+    GBinderIpc* ipc)
+{
+    return gbinder_local_reply_new(gbinder_driver_io(ipc->driver),
+        gbinder_driver_protocol(ipc->driver));
+}
+
 /*==========================================================================*
  * null
  *==========================================================================*/
@@ -212,9 +230,8 @@ test_async_oneway(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
@@ -239,9 +256,8 @@ test_sync_oneway(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
 
     test_binder_br_transaction_complete(fd);
     g_assert_cmpint(gbinder_ipc_sync_main.sync_oneway(ipc, 0, 1, req), == ,0);
@@ -261,12 +277,11 @@ test_sync_reply_ok_status(
     int* status)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
-    const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
+    GBinderLocalReply* reply = test_local_reply_new(ipc);
     GBinderRemoteReply* tx_reply;
     GBinderOutputData* data;
+    const int fd = gbinder_driver_fd(ipc->driver);
     const guint32 handle = 0;
     const guint32 code = 1;
     const char* result_in = "foo";
@@ -318,9 +333,8 @@ test_sync_reply_error(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     const guint32 handle = 0;
     const guint32 code = 1;
     const gint expected_status = (-EINVAL);
@@ -387,13 +401,12 @@ test_transact_ok(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
-    const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
+    GBinderLocalReply* reply = test_local_reply_new(ipc);
     GBinderOutputData* data;
     const guint32 handle = 0;
     const guint32 code = 1;
+    const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
@@ -446,9 +459,8 @@ test_transact_dead(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
@@ -494,9 +506,8 @@ test_transact_failed(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
@@ -544,9 +555,8 @@ test_transact_status(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     const int fd = gbinder_driver_fd(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     gulong id;
 
@@ -798,7 +808,6 @@ test_transact_2way_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
@@ -809,9 +818,9 @@ test_transact_2way_run(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_2way_incoming_proc, &incoming_call);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
-    GBinderLocalRequest* incoming_req = gbinder_local_request_new(io, NULL);
-    GBinderLocalReply* reply = gbinder_local_reply_new(io);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
+    GBinderLocalRequest* incoming_req = test_local_request_new(ipc);
+    GBinderLocalReply* reply = test_local_reply_new(ipc);
     GBinderWriter writer;
 
     /* Prepare reply */
@@ -944,7 +953,6 @@ test_transact_incoming_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
@@ -952,8 +960,8 @@ test_transact_incoming_run(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_incoming_proc, loop);
-    GBinderLocalRequest* ping = gbinder_local_request_new(io, NULL);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
+    GBinderLocalRequest* ping = test_local_request_new(ipc);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     GBinderWriter writer;
 
     gbinder_local_request_init_writer(ping, &writer);
@@ -1025,7 +1033,6 @@ test_transact_status_reply_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
@@ -1033,7 +1040,7 @@ test_transact_status_reply_run(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_status_reply_proc, loop);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     GBinderOutputData* data;
     GBinderWriter writer;
 
@@ -1142,7 +1149,6 @@ test_transact_async_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
@@ -1150,7 +1156,7 @@ test_transact_async_run(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_async_proc, loop);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     GBinderOutputData* data;
     GBinderWriter writer;
 
@@ -1225,7 +1231,6 @@ test_transact_async_sync_run(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
     const int fd = gbinder_driver_fd(ipc->driver);
     const char* dev = gbinder_driver_dev(ipc->driver);
     const GBinderRpcProtocol* prot = gbinder_rpc_protocol_for_device(dev);
@@ -1233,7 +1238,7 @@ test_transact_async_sync_run(
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     GBinderLocalObject* obj = gbinder_local_object_new
         (ipc, ifaces, test_transact_async_sync_proc, loop);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     GBinderOutputData* data;
     GBinderWriter writer;
 
@@ -1340,8 +1345,7 @@ test_cancel_on_exit(
     void)
 {
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, NULL);
-    const GBinderIo* io = gbinder_driver_io(ipc->driver);
-    GBinderLocalRequest* req = gbinder_local_request_new(io, NULL);
+    GBinderLocalRequest* req = test_local_request_new(ipc);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
     int fd = gbinder_driver_fd(ipc->driver);
 

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -36,6 +36,7 @@
 #include "gbinder_local_object.h"
 #include "gbinder_local_reply_p.h"
 #include "gbinder_output_data.h"
+#include "gbinder_rpc_protocol.h"
 #include "gbinder_buffer_p.h"
 #include "gbinder_driver.h"
 #include "gbinder_writer.h"
@@ -45,11 +46,6 @@
 #include <gutil_intarray.h>
 
 static TestOpt test_opt;
-
-#define BUFFER_OBJECT_SIZE_32 (24)
-#define BUFFER_OBJECT_SIZE_64 (GBINDER_MAX_BUFFER_OBJECT_SIZE)
-#define BINDER_OBJECT_SIZE_32 (16)
-#define BINDER_OBJECT_SIZE_64 (GBINDER_MAX_BINDER_OBJECT_SIZE)
 
 static
 void
@@ -70,6 +66,14 @@ test_buffer_from_bytes(
     return gbinder_buffer_new(driver, bytes->data, bytes->len, NULL);
 }
 
+static
+GBinderLocalReply*
+test_local_reply_new()
+{
+    return gbinder_local_reply_new(&gbinder_io_32,
+        gbinder_rpc_protocol_for_device(NULL));
+}
+
 /*==========================================================================*
  * null
  *==========================================================================*/
@@ -82,7 +86,10 @@ test_null(
     GBinderWriter writer;
     int count = 0;
 
-    g_assert(!gbinder_local_reply_new(NULL));
+    g_assert(!gbinder_local_reply_new(NULL, NULL));
+    g_assert(!gbinder_local_reply_new(&gbinder_io_32, NULL));
+    g_assert(!gbinder_local_reply_new(NULL,
+        gbinder_rpc_protocol_for_device(NULL)));
     g_assert(!gbinder_local_reply_ref(NULL));
     gbinder_local_reply_unref(NULL);
     gbinder_local_reply_init_writer(NULL, NULL);
@@ -118,7 +125,7 @@ void
 test_cleanup(
     void)
 {
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     int count = 0;
 
     gbinder_local_reply_cleanup(reply, NULL, &count);
@@ -141,7 +148,7 @@ test_bool(
 {
     static const guint8 output_true[] = { 0x01, 0x00, 0x00, 0x00 };
     static const guint8 output_false[] = { 0x00, 0x00, 0x00, 0x00 };
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_bool(reply, FALSE);
@@ -152,7 +159,7 @@ test_bool(
     g_assert(!memcmp(data->bytes->data, output_false, data->bytes->len));
     gbinder_local_reply_unref(reply);
 
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_append_bool(reply, TRUE);
     data = gbinder_local_reply_data(reply);
     g_assert(!gbinder_output_data_offsets(data));
@@ -161,7 +168,7 @@ test_bool(
     g_assert(!memcmp(data->bytes->data, output_true, data->bytes->len));
     gbinder_local_reply_unref(reply);
 
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_append_bool(reply, 42);
     data = gbinder_local_reply_data(reply);
     g_assert(!gbinder_output_data_offsets(data));
@@ -181,7 +188,7 @@ test_fd(
     void)
 {
     const gint32 fd = 1;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
     GUtilIntArray* offsets;
 
@@ -206,7 +213,7 @@ test_int32(
     void)
 {
     const guint32 value = 1234567;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
     GBinderWriter writer;
 
@@ -221,7 +228,7 @@ test_int32(
     gbinder_local_reply_unref(reply);
 
     /* Same with writer */
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_init_writer(reply, &writer);
     gbinder_writer_append_int32(&writer, value);
     data = gbinder_local_reply_data(reply);
@@ -242,7 +249,7 @@ test_int64(
     void)
 {
     const guint64 value = 123456789;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_int64(reply, value);
@@ -264,7 +271,7 @@ test_float(
     void)
 {
     const gfloat value = 123456789;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_float(reply, value);
@@ -286,7 +293,7 @@ test_double(
     void)
 {
     const gdouble value = 123456789;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_double(reply, value);
@@ -310,7 +317,7 @@ test_string8(
     /* The size of the string gets aligned at 4-byte boundary */
     static const char input[] = "test";
     static const guint8 output[] = { 't', 'e', 's', 't', 0, 0, 0, 0 };
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_string8(reply, input);
@@ -322,7 +329,7 @@ test_string8(
     gbinder_local_reply_unref(reply);
 
     /* NULL string doesn't get encoded at all (should it be?) */
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_append_string8(reply, NULL);
     data = gbinder_local_reply_data(reply);
     g_assert(!gbinder_output_data_offsets(data));
@@ -346,7 +353,7 @@ test_string16(
         TEST_INT16_BYTES('x'), 0x00, 0x00
     };
     const gint32 null_output = -1;
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
 
     gbinder_local_reply_append_string16(reply, input);
@@ -358,7 +365,7 @@ test_string16(
     gbinder_local_reply_unref(reply);
 
     /* NULL string gets encoded as -1 */
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_append_string16(reply, NULL);
     data = gbinder_local_reply_data(reply);
     g_assert(!gbinder_output_data_offsets(data));
@@ -377,7 +384,7 @@ void
 test_hidl_string(
     void)
 {
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
     GUtilIntArray* offsets;
 
@@ -400,7 +407,7 @@ void
 test_hidl_string_vec(
     void)
 {
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
     GUtilIntArray* offsets;
 
@@ -436,22 +443,22 @@ test_local_object(
     data = gbinder_local_reply_data(reply);
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets);
-    g_assert(offsets->count == 1);
-    g_assert(offsets->data[0] == 0);
-    g_assert(!gbinder_output_data_buffers_size(data));
-    g_assert(data->bytes->len == BINDER_OBJECT_SIZE_64);
+    g_assert_cmpuint(offsets->count, == ,1);
+    g_assert_cmpuint(offsets->data[0], == ,0);
+    g_assert_cmpuint(gbinder_output_data_buffers_size(data), == ,0);
+    g_assert_cmpuint(data->bytes->len, == ,BINDER_OBJECT_SIZE_64);
     gbinder_local_reply_unref(reply);
 
     /* Append NULL object (with 32-bit I/O module) */
-    reply = gbinder_local_reply_new(&gbinder_io_32);
+    reply = test_local_reply_new();
     gbinder_local_reply_append_local_object(reply, NULL);
     data = gbinder_local_reply_data(reply);
     offsets = gbinder_output_data_offsets(data);
     g_assert(offsets);
-    g_assert(offsets->count == 1);
-    g_assert(offsets->data[0] == 0);
-    g_assert(!gbinder_output_data_buffers_size(data));
-    g_assert(data->bytes->len == BINDER_OBJECT_SIZE_32);
+    g_assert_cmpuint(offsets->count, == ,1);
+    g_assert_cmpuint(offsets->data[0], == ,0);
+    g_assert_cmpuint(gbinder_output_data_buffers_size(data), == ,0);
+    g_assert_cmpuint(data->bytes->len, == ,BINDER_OBJECT_SIZE_32);
     gbinder_local_reply_unref(reply);
     gbinder_ipc_unref(ipc);
 }
@@ -465,7 +472,7 @@ void
 test_remote_object(
     void)
 {
-    GBinderLocalReply* reply = gbinder_local_reply_new(&gbinder_io_32);
+    GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
     GUtilIntArray* offsets;
 
@@ -494,7 +501,8 @@ test_remote_reply(
     static const guint8 output[] = { 't', 'e', 's', 't', 0, 0, 0, 0 };
     GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
     const GBinderIo* io = gbinder_driver_io(driver);
-    GBinderLocalReply* req = gbinder_local_reply_new(io);
+    GBinderLocalReply* req = gbinder_local_reply_new(io,
+        gbinder_rpc_protocol_for_device(NULL));
     GBinderLocalReply* req2;
     GBinderOutputData* data2;
     const GByteArray* bytes;
@@ -506,7 +514,7 @@ test_remote_reply(
 
     /* Copy flat structures (no binder objects) */
     buffer = test_buffer_from_bytes(driver, bytes);
-    req2 = gbinder_local_reply_new(io);
+    req2 = gbinder_local_reply_new(io, gbinder_rpc_protocol_for_device(NULL));
     g_assert(gbinder_local_reply_set_contents(req2, buffer, NULL) == req2);
     gbinder_buffer_free(buffer);
 

--- a/unit/unit_protocol/unit_protocol.c
+++ b/unit/unit_protocol/unit_protocol.c
@@ -393,7 +393,8 @@ test_write_header(
     test_config_init2(&config, test->dev, test->prot);
 
     prot = gbinder_rpc_protocol_for_device(test->dev);
-    req = gbinder_local_request_new(&gbinder_io_32, NULL);
+    req = gbinder_local_request_new(&gbinder_io_32,
+        gbinder_rpc_protocol_for_device(NULL), NULL);
     gbinder_local_request_init_writer(req, &writer);
     prot->write_rpc_header(&writer, test->iface);
     data = gbinder_local_request_data(req);

--- a/unit/unit_remote_reply/unit_remote_reply.c
+++ b/unit/unit_remote_reply/unit_remote_reply.c
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2018-2021 Jolla Ltd.
- * Copyright (C) 2018-2021 Slava Monich <slava.monich@jolla.com>
+ * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -31,6 +31,7 @@
  */
 
 #include "test_common.h"
+#include "test_binder.h"
 
 #include "gbinder_buffer_p.h"
 #include "gbinder_driver.h"
@@ -43,9 +44,6 @@
 #include <gutil_intarray.h>
 
 static TestOpt test_opt;
-
-#define BINDER_TYPE_BINDER GBINDER_FOURCC('s', 'b', '*', 0x85)
-#define BINDER_OBJECT_SIZE_64 (GBINDER_MAX_BINDER_OBJECT_SIZE)
 
 /*==========================================================================*
  * Dummy GBinderObjectRegistry functions

--- a/unit/unit_remote_request/unit_remote_request.c
+++ b/unit/unit_remote_request/unit_remote_request.c
@@ -31,6 +31,7 @@
  */
 
 #include "test_common.h"
+#include "test_binder.h"
 
 #include "gbinder_buffer_p.h"
 #include "gbinder_config.h"
@@ -58,9 +59,6 @@ static TestOpt test_opt;
     TEST_INT16_BYTES('o'), 0x00, 0x00
 #define HIDL_RPC_HEADER \
     'f', 'o', 'o', 0x00
-
-#define BINDER_TYPE_BINDER GBINDER_FOURCC('s', 'b', '*', 0x85)
-#define BINDER_OBJECT_SIZE_64 (GBINDER_MAX_BINDER_OBJECT_SIZE)
 
 /*==========================================================================*
  * null

--- a/unit/unit_servicemanager_aidl3/unit_servicemanager_aidl3.c
+++ b/unit/unit_servicemanager_aidl3/unit_servicemanager_aidl3.c
@@ -51,13 +51,6 @@ static TestOpt test_opt;
 static const char TMP_DIR_TEMPLATE[] =
     "gbinder-test-servicemanager_aidl3-XXXXXX";
 
-enum gbinder_stability_level {
-    UNDECLARED = 0,
-    VENDOR = 0b000011,
-    SYSTEM = 0b001100,
-    VINTF = 0b111111
-};
-
 GType
 gbinder_servicemanager_hidl_get_type()
 {
@@ -109,7 +102,6 @@ servicemanager_aidl3_handler(
     GBinderReader reader;
     GBinderRemoteObject* remote_obj;
     guint32 allow_isolated, dumpsys_priority;
-    gint32 stability;
     char* str;
 
     g_assert(!flags);
@@ -122,18 +114,18 @@ servicemanager_aidl3_handler(
         gbinder_remote_request_init_reader(req, &reader);
         str = gbinder_reader_read_string16(&reader);
         if (str) {
-            reply = gbinder_local_object_new_reply(obj);
-            remote_obj = g_hash_table_lookup(self->objects, str);
-            if (remote_obj) {
-                GBinderWriter writer;
+            GBinderWriter writer;
 
+            remote_obj = g_hash_table_lookup(self->objects, str);
+            reply = gbinder_local_object_new_reply(obj);
+
+            gbinder_local_reply_init_writer(reply, &writer);
+            gbinder_writer_append_int32(&writer, GBINDER_STATUS_OK);
+            gbinder_writer_append_remote_object(&writer, remote_obj);
+            if (remote_obj) {
                 GDEBUG("Found name '%s' => %p", str, remote_obj);
-                gbinder_local_reply_init_writer(reply, &writer);
-                gbinder_writer_append_int32(&writer, UNDECLARED);
-                gbinder_writer_append_remote_object(&writer, remote_obj);
             } else {
                 GDEBUG("Name '%s' not found", str);
-                gbinder_local_reply_append_int32(reply, GBINDER_STATUS_OK);
             }
             g_free(str);
         }
@@ -142,8 +134,7 @@ servicemanager_aidl3_handler(
         gbinder_remote_request_init_reader(req, &reader);
         str = gbinder_reader_read_string16(&reader);
         remote_obj = gbinder_reader_read_object(&reader);
-        gbinder_reader_read_int32(&reader, &stability);
-        if (str && remote_obj && stability == 0b001100 &&
+        if (str && remote_obj &&
             gbinder_reader_read_uint32(&reader, &allow_isolated) &&
             gbinder_reader_read_uint32(&reader, &dumpsys_priority)) {
             GDEBUG("Adding '%s'", str);


### PR DESCRIPTION
According to [Parcel::finishFlattenBinder()](https://android.googlesource.com/platform/frameworks/native/+/refs/heads/android11-release/libs/binder/Parcel.cpp#167)