### PR TITLE
Tweak the spec file

### DIFF
--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -44,7 +44,6 @@ make -C test/binder-ping KEEP_SYMBOLS=1 release
 make -C test/binder-call KEEP_SYMBOLS=1 release
 
 %install
-rm -rf %{buildroot}
 make LIBDIR=%{_libdir} DESTDIR=%{buildroot} install-dev
 make -C test/binder-bridge DESTDIR=%{buildroot} install
 make -C test/binder-list DESTDIR=%{buildroot} install
@@ -67,6 +66,7 @@ make -C unit test
 
 %files devel
 %defattr(-,root,root,-)
+%dir %{_includedir}/gbinder
 %{_libdir}/pkgconfig/*.pc
 %{_libdir}/%{name}.so
 %{_includedir}/gbinder/*.h


### PR DESCRIPTION
1. Some packaging guides suggest not to do `rm -rf %{buildroot}`
2. Own the directory containing the header files, not just the files