### PR TITLE
gbinder_writer_append_struct_vec

### DIFF
--- a/include/gbinder_writer.h
+++ b/include/gbinder_writer.h
@@ -138,6 +138,13 @@ gbinder_writer_append_struct(
     const GBinderParent* parent); /* Since 1.1.27 */
 
 void
+gbinder_writer_append_struct_vec(
+    GBinderWriter* writer,
+    const void* ptr,
+    guint count,
+    const GBinderWriterType* type); /* Since 1.1.29 */
+
+void
 gbinder_writer_field_hidl_vec_write_buf(
     GBinderWriter* writer,
     const void* ptr,

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -800,6 +800,39 @@ gbinder_writer_append_struct(
     }
 }
 
+/*
+ * Appends top-level vec<type>. Allocates GBinderHidlVec for that, but
+ * unlike gbinder_writer_append_hidl_vec(), doesn't copy the contents
+ * of the vector.
+ */
+void
+gbinder_writer_append_struct_vec(
+    GBinderWriter* writer,
+    const void* ptr,
+    guint count,
+    const GBinderWriterType* type) /* Since 1.1.29 */
+{
+    GBinderHidlVec* vec = gbinder_writer_new0(writer, GBinderHidlVec);
+    GBinderWriterField vec_f[2];
+    GBinderWriterType vec_t;
+
+    memset(vec_f, 0, sizeof(vec_f));
+    vec_f->name = "hidl_vec.data.ptr";
+    vec_f->type = type;
+    vec_f->write_buf = gbinder_writer_field_hidl_vec_write_buf;
+
+    memset(&vec_t, 0, sizeof(vec_t));
+    vec_t.name = "hidl_vec";
+    vec_t.size = sizeof(GBinderHidlVec);
+    vec_t.fields = vec_f;
+
+    vec->owns_buffer = TRUE;
+    vec->data.ptr = ptr;
+    vec->count = count;
+
+    gbinder_writer_append_struct(writer, vec, &vec_t, NULL);
+}
+
 void
 gbinder_writer_field_hidl_vec_write_buf(
     GBinderWriter* writer,

--- a/unit/unit_writer/unit_writer.c
+++ b/unit/unit_writer/unit_writer.c
@@ -1112,6 +1112,18 @@ test_struct(
     g_assert_cmpuint(offsets->data[0], == ,0);
     gbinder_local_request_unref(req);
 
+    /* Write vec<TestStruct> in a different way */
+    req = test_local_request_new();
+    gbinder_local_request_init_writer(req, &writer);
+    gbinder_writer_append_struct_vec(&writer, &test_struct, 1, &test_struct_t);
+
+    data = gbinder_local_request_data(req);
+    offsets = gbinder_output_data_offsets(data);
+    g_assert(offsets);
+    g_assert_cmpuint(offsets->count, == ,5);
+    g_assert_cmpuint(offsets->data[0], == ,0);
+    gbinder_local_request_unref(req);
+
     /* Corner cases */
     req = test_local_request_new();
     gbinder_local_request_init_writer(req, &writer);


### PR DESCRIPTION
Appends top-level `vec<type>`. Allocates `GBinderHidlVec` for that, but unlike `gbinder_writer_append_hidl_vec()`, doesn't copy the contents of the vector.