### PR TITLE
Fix return value from binder_ptr_cookie encoder

### DIFF
--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -289,7 +289,7 @@ GBINDER_IO_FN(encode_ptr_cookie)(
     /* We never send these cookies and don't expect them back */
     dest->ptr = (uintptr_t)obj;
     dest->cookie = 0;
-    return sizeof(dest);
+    return sizeof(*dest);
 }
 
 /* Fills binder_transaction_data for BC_TRANSACTION/REPLY */


### PR DESCRIPTION
It was resulting in broken `BC_ACQUIRE_DONE` commands being sent to the driver. That's not nice.