### PR TITLE
[build] Use MAKE var instead of explicitly calling make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ RELEASE_DEPS = libglibutil_release
 .PHONY: libglibutil_debug libglibutil_release
 
 libglibutil_debug:
-	make -C $(LIBGLIBUTIL_PATH) debug
+	$(MAKE) -C $(LIBGLIBUTIL_PATH) debug
 
 libglibutil_release:
-	make -C $(LIBGLIBUTIL_PATH) release
+	$(MAKE) -C $(LIBGLIBUTIL_PATH) release
 
 endif
 
@@ -237,8 +237,8 @@ print_release_path:
 	@echo $(RELEASE_BUILD_DIR)
 
 clean:
-	make -C test clean
-	make -C unit clean
+	$(MAKE) -C test clean
+	$(MAKE) -C unit clean
 	rm -fr test/coverage/results test/coverage/*.gcov
 	rm -f *~ $(SRC_DIR)/*~ $(INCLUDE_DIR)/*~
 	rm -fr $(BUILD_DIR) RPMS installroot
@@ -248,7 +248,7 @@ clean:
 	rm -f debian/libgbinder.install debian/libgbinder-dev.install
 
 test:
-	make -C unit test
+	$(MAKE) -C unit test
 
 $(BUILD_DIR):
 	mkdir -p $@

--- a/test/binder-call/Makefile
+++ b/test/binder-call/Makefile
@@ -54,7 +54,7 @@ INCLUDES = -I$(LIB_DIR)/include -I$(GEN_DIR) -I$(SRC_DIR)
 CFLAGS += -fPIC $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
   $(shell pkg-config --cflags $(PKGS))
 LDFLAGS += -pie $(shell pkg-config --libs $(PKGS))
-QUIET_MAKE = make --no-print-directory
+QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =
 
@@ -120,7 +120,7 @@ clean:
 	rm -fr $(BUILD_DIR)
 
 cleaner: clean
-	@make -C $(LIB_DIR) clean
+	@$(MAKE) -C $(LIB_DIR) clean
 
 $(DEBUG_BUILD_DIR):
 	mkdir -p $@

--- a/test/common/Makefile
+++ b/test/common/Makefile
@@ -52,7 +52,7 @@ INCLUDES = -I$(LIB_DIR)/include
 CFLAGS += -fPIC $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
   $(shell pkg-config --cflags $(PKGS))
 LDFLAGS += -pie $(shell pkg-config --libs $(PKGS))
-QUIET_MAKE = make --no-print-directory
+QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =
 
@@ -110,7 +110,7 @@ clean:
 	rm -fr $(BUILD_DIR)
 
 cleaner: clean
-	@make -C $(LIB_DIR) clean
+	@$(MAKE) -C $(LIB_DIR) clean
 
 $(DEBUG_BUILD_DIR):
 	mkdir -p $@

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -37,10 +37,10 @@ RELEASE_DEPS = libglibutil_release
 .PHONY: libglibutil_debug libglibutil_release
 
 libglibutil_debug:
-	make -C $(LIBGLIBUTIL_PATH) debug
+	$(MAKE) -C $(LIBGLIBUTIL_PATH) debug
 
 libglibutil_release:
-	make -C $(LIBGLIBUTIL_PATH) release
+	$(MAKE) -C $(LIBGLIBUTIL_PATH) release
 
 endif
 
@@ -79,7 +79,7 @@ FULL_CFLAGS = $(BASE_CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
   $(shell pkg-config --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_LDFLAGS)
 LIBS = $(shell pkg-config --libs $(PKGS)) -lpthread
-QUIET_MAKE = make --no-print-directory
+QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =
 COVERAGE_FLAGS = -g
@@ -158,7 +158,7 @@ unitclean:
 clean: unitclean
 
 cleaner: unitclean
-	@make -C $(LIB_DIR) clean
+	@$(MAKE) -C $(LIB_DIR) clean
 
 test_banner:
 	@echo "===========" $(EXE) "=========== "


### PR DESCRIPTION
There are multiple `make` implementations and nothing guarantees that the `make` executable is `gmake`, which is what [this Makefile](https://github.com/mer-hybris/libgbinder/blob/master/Makefile) requires.

As a practical example https://chimera-linux.org/ uses [`bmake`](https://pkgs.chimera-linux.org/packages?name=cmd%3Amake) as the default `make` while also having [`gmake`](https://pkgs.chimera-linux.org/packages?name=cmd%3Agmake) easily available for projects needing it.

My packaging of this project where this is used: https://github.com/JamiKettunen/cports/commit/f73c628
See also: https://github.com/sailfishos/libglibutil/pull/5

I've left `unit/coverage/run` untouched as it appears to not be run during the distro packaging process.