### PR TITLE
[build] Support pkg-config cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 STRIP ?= strip
 LD = $(CC)
@@ -135,9 +136,9 @@ DEFINES += -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 \
 INCLUDES += -I$(INCLUDE_DIR)
 BASE_FLAGS = -fPIC
 FULL_CFLAGS = $(BASE_FLAGS) $(CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) \
-  -MMD -MP $(shell pkg-config --cflags $(PKGS))
+  -MMD -MP $(shell $(PKG_CONFIG) --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS) -shared -Wl,-soname,$(LIB_SONAME) \
-  $(shell pkg-config --libs $(PKGS)) -lpthread
+  $(shell $(PKG_CONFIG) --libs $(PKGS)) -lpthread
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =
 COVERAGE_FLAGS = -g

--- a/test/binder-call/Makefile
+++ b/test/binder-call/Makefile
@@ -45,6 +45,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS = -Wall
@@ -52,8 +53,8 @@ DEFINES += -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 \
   -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_MAX_ALLOWED
 INCLUDES = -I$(LIB_DIR)/include -I$(GEN_DIR) -I$(SRC_DIR)
 CFLAGS += -fPIC $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
-  $(shell pkg-config --cflags $(PKGS))
-LDFLAGS += -pie $(shell pkg-config --libs $(PKGS))
+  $(shell $(PKG_CONFIG) --cflags $(PKGS))
+LDFLAGS += -pie $(shell $(PKG_CONFIG) --libs $(PKGS))
 QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =

--- a/test/common/Makefile
+++ b/test/common/Makefile
@@ -43,6 +43,7 @@ RELEASE_BUILD_DIR = $(BUILD_DIR)/release
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS = -Wall
@@ -50,8 +51,8 @@ DEFINES += -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 \
   -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_MAX_ALLOWED
 INCLUDES = -I$(LIB_DIR)/include
 CFLAGS += -fPIC $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
-  $(shell pkg-config --cflags $(PKGS))
-LDFLAGS += -pie $(shell pkg-config --libs $(PKGS))
+  $(shell $(PKG_CONFIG) --cflags $(PKGS))
+LDFLAGS += -pie $(shell $(PKG_CONFIG) --libs $(PKGS))
 QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -66,6 +66,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 # Tools and flags
 #
 
+PKG_CONFIG ?= pkg-config
 CC ?= $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS += -Wall -Wno-deprecated-declarations
@@ -76,9 +77,9 @@ BASE_FLAGS = -fPIC
 BASE_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS)
 BASE_CFLAGS = $(BASE_FLAGS) $(CFLAGS)
 FULL_CFLAGS = $(BASE_CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) -MMD -MP \
-  $(shell pkg-config --cflags $(PKGS))
+  $(shell $(PKG_CONFIG) --cflags $(PKGS))
 FULL_LDFLAGS = $(BASE_LDFLAGS)
-LIBS = $(shell pkg-config --libs $(PKGS)) -lpthread
+LIBS = $(shell $(PKG_CONFIG) --libs $(PKGS)) -lpthread
 QUIET_MAKE = $(MAKE) --no-print-directory
 DEBUG_FLAGS = -g
 RELEASE_FLAGS =


### PR DESCRIPTION
Previously to cross-compile one would need to add a `pkg-config` executable in `$PATH` wrapping all the search paths required; now one can e.g. `make PKG_CONFIG=foreign-arch-target-pkg-config` with the wrapper executable being separate and allowing programs for host to also be built if needed for example.

See also https://github.com/sailfishos/libglibutil/pull/11.