### PR TITLE
Fix gbinder_driver_reply_data return value

### DIFF
--- a/src/gbinder_driver.c
+++ b/src/gbinder_driver.c
@@ -506,7 +506,7 @@ gbinder_driver_reply_data(
     write.ptr = (uintptr_t)buf;
     write.size = len;
     write.consumed = 0;
-    status = gbinder_driver_write(self, &write) >= 0;
+    status = gbinder_driver_write(self, &write);
 
     g_free(offsets_buf);
     return status >= 0;


### PR DESCRIPTION
Previously this always returned 1. Drop the first comparison so status can be negative and errors will return 0.

This was found as a result of static code analysis. However the wrong return value doesn't cause any bug as it is not used anywhere in the code.