### PR TITLE
[gbinder] Byte array padding

### DIFF
--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -770,7 +770,8 @@ gbinder_reader_read_byte_array(
             *len = (gsize)*ptr;
             p->ptr += sizeof(*ptr);
             data = p->ptr;
-            p->ptr += *len;
+            gsize pad = G_ALIGN4(*len);
+            p->ptr += pad;
         }
     }
     return data;

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -1209,13 +1209,18 @@ gbinder_writer_append_byte_array(
             len = 0;
         }
 
-        g_byte_array_set_size(buf, buf->len + sizeof(len) + len);
-        ptr = buf->data + (buf->len - sizeof(len) - len);
+        gint32 padded_len = G_ALIGN4(len);
+        g_byte_array_set_size(buf, buf->len + sizeof(len) + padded_len);
+        ptr = buf->data + (buf->len - sizeof(len) - padded_len);
 
         if (len > 0) {
             *((gint32*)ptr) = len;
             ptr += sizeof(len);
             memcpy(ptr, byte_array, len);
+            /* FF padding */
+            if (padded_len > len) {
+                memset(ptr, 0xFF, padded_len - len);
+            }
         } else {
             *((gint32*)ptr) = -1;
         }


### PR DESCRIPTION
Android aligns byte array reads and writes to 4 bytes and pads with 0xFF. Not accounting for this causes misalignment issues on further reading.

See Parcel::writeInplace()