### PR TITLE
[gbinder] Make stability field of local object configurable. JB#61912

### DIFF
--- a/include/gbinder_local_object.h
+++ b/include/gbinder_local_object.h
@@ -61,6 +61,11 @@ GBinderLocalReply*
 gbinder_local_object_new_reply(
     GBinderLocalObject* obj);
 
+void
+gbinder_local_object_set_stability(
+    GBinderLocalObject* self,
+    GBINDER_STABILITY_LEVEL stability); /* Since 1.0.40 */
+
 G_END_DECLS
 
 #endif /* GBINDER_LOCAL_OBJECT_H */

--- a/include/gbinder_types.h
+++ b/include/gbinder_types.h
@@ -173,6 +173,13 @@ typedef enum gbinder_status {
     GBINDER_STATUS_DEAD_OBJECT
 } GBINDER_STATUS;
 
+typedef enum gbinder_stability_level {
+    GBINDER_STABILITY_UNDECLARED = 0,
+    GBINDER_STABILITY_VENDOR = 0x03,
+    GBINDER_STABILITY_SYSTEM = 0x0c,
+    GBINDER_STABILITY_VINTF = 0x3f
+} GBINDER_STABILITY_LEVEL;
+
 #define GBINDER_FOURCC(c1,c2,c3,c4) \
     (((c1) << 24) | ((c2) << 16) | ((c3) << 8) | (c4))
 

--- a/src/gbinder_local_object.c
+++ b/src/gbinder_local_object.c
@@ -442,6 +442,7 @@ gbinder_local_object_init_base(
 
     self->ipc = gbinder_ipc_ref(ipc);
     self->ifaces = (const char**)priv->ifaces;
+    self->stability = GBINDER_STABILITY_SYSTEM;
     priv->txproc = txproc;
     priv->user_data = user_data;
 }
@@ -609,6 +610,16 @@ gbinder_local_object_handle_release(
     GBinderLocalObject* self)
 {
     gbinder_local_object_handle_later(self, gbinder_local_object_release_proc);
+}
+
+void
+gbinder_local_object_set_stability(
+    GBinderLocalObject* self,
+    GBINDER_STABILITY_LEVEL stability)
+{
+    if (G_LIKELY(self)) {
+        self->stability = stability;
+    }
 }
 
 /*==========================================================================*

--- a/src/gbinder_local_object_p.h
+++ b/src/gbinder_local_object_p.h
@@ -59,6 +59,7 @@ struct gbinder_local_object {
     const char* const* ifaces;
     gint weak_refs;
     gint strong_refs;
+    GBINDER_STABILITY_LEVEL stability;
 };
 
 typedef enum gbinder_local_transaction_support {

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -35,6 +35,7 @@
 #include "gbinder_writer.h"
 #include "gbinder_config.h"
 #include "gbinder_log.h"
+#include "gbinder_local_object_p.h"
 
 #define STRICT_MODE_PENALTY_GATHER (0x40 << 16)
 #define BINDER_RPC_FLAGS (STRICT_MODE_PENALTY_GATHER)
@@ -218,7 +219,11 @@ gbinder_rpc_protocol_aidl3_finish_flatten_binder(
     void* out,
     GBinderLocalObject* obj)
 {
-    *(guint32*)out = GBINDER_STABILITY_SYSTEM;
+    if (G_LIKELY(obj)) {
+        *(guint32*)out = obj->stability;
+    } else {
+        *(guint32*)out = GBINDER_STABILITY_UNDECLARED;
+    }
 }
 
 static const GBinderRpcProtocol gbinder_rpc_protocol_aidl3 = {

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -77,13 +77,6 @@ typedef struct gbinder_ipc_sync_api GBinderIpcSyncApi;
 /* As a special case, ServiceManager's handle is zero */
 #define GBINDER_SERVICEMANAGER_HANDLE (0)
 
-typedef enum gbinder_stability_level {
-    GBINDER_STABILITY_UNDECLARED = 0,
-    GBINDER_STABILITY_VENDOR = 0x03,
-    GBINDER_STABILITY_SYSTEM = 0x0c,
-    GBINDER_STABILITY_VINTF = 0x3f
-} GBINDER_STABILITY_LEVEL;
-
 #endif /* GBINDER_TYPES_PRIVATE_H */
 
 /*


### PR DESCRIPTION
AIDL HALs require stability field value to be set to VINTF as opposed to the default SYSTEM, so expose a way to let the caller set the value to used by finish_flatten_binder per local object.