### PR TITLE
Make more unit tests independent on system config

### DIFF
--- a/unit/unit_ipc/unit_ipc.c
+++ b/unit/unit_ipc/unit_ipc.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2022 Jolla Ltd.
- * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -51,6 +51,7 @@
 #include <sys/types.h>
 
 static TestOpt test_opt;
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-ipc-XXXXXX";
 
 static
 gboolean
@@ -1346,6 +1347,9 @@ test_cancel_on_exit(
 
 int main(int argc, char* argv[])
 {
+    TestConfig test_config;
+    int result;
+
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     g_type_init();
     G_GNUC_END_IGNORE_DEPRECATIONS;
@@ -1375,7 +1379,10 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("drop_remote_refs"), test_drop_remote_refs);
     g_test_add_func(TEST_("cancel_on_exit"), test_cancel_on_exit);
     test_init(&test_opt, argc, argv);
-    return g_test_run();
+    test_config_init(&test_config, TMP_DIR_TEMPLATE);
+    result = g_test_run();
+    test_config_cleanup(&test_config);
+    return result;
 }
 
 /*

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2022 Jolla Ltd.
- * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -46,6 +46,7 @@
 #include <gutil_intarray.h>
 
 static TestOpt test_opt;
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-local-reply-XXXXXX";
 
 static
 void
@@ -538,6 +539,9 @@ test_remote_reply(
 
 int main(int argc, char* argv[])
 {
+    TestConfig test_config;
+    int result;
+
     G_GNUC_BEGIN_IGNORE_DEPRECATIONS;
     g_type_init();
     G_GNUC_END_IGNORE_DEPRECATIONS;
@@ -558,7 +562,10 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_PREFIX "remote_object", test_remote_object);
     g_test_add_func(TEST_PREFIX "remote_reply", test_remote_reply);
     test_init(&test_opt, argc, argv);
-    return g_test_run();
+    test_config_init(&test_config, TMP_DIR_TEMPLATE);
+    result = g_test_run();
+    test_config_cleanup(&test_config);
+    return result;
 }
 
 /*

--- a/unit/unit_local_request/unit_local_request.c
+++ b/unit/unit_local_request/unit_local_request.c
@@ -1,6 +1,6 @@
 /*
+ * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2022 Jolla Ltd.
- * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
  *
  * You may use this file under the terms of BSD license as follows:
  *
@@ -44,6 +44,7 @@
 #include <gutil_intarray.h>
 
 static TestOpt test_opt;
+static const char TMP_DIR_TEMPLATE[] = "gbinder-test-local-request-XXXXXX";
 
 static
 void
@@ -600,6 +601,9 @@ test_remote_request_obj(
 
 int main(int argc, char* argv[])
 {
+    TestConfig test_config;
+    int result;
+
     g_test_init(&argc, &argv, NULL);
     g_test_add_func(TEST_PREFIX "null", test_null);
     g_test_add_func(TEST_PREFIX "cleanup", test_cleanup);
@@ -618,7 +622,10 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_PREFIX "remote_request", test_remote_request);
     g_test_add_func(TEST_PREFIX "remote_request_obj", test_remote_request_obj);
     test_init(&test_opt, argc, argv);
-    return g_test_run();
+    test_config_init(&test_config, TMP_DIR_TEMPLATE);
+    result = g_test_run();
+    test_config_cleanup(&test_config);
+    return result;
 }
 
 /*

--- a/unit/unit_servicemanager/unit_servicemanager.c
+++ b/unit/unit_servicemanager/unit_servicemanager.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2023 Slava Monich <slava@monich.com>
+ * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
  * Copyright (C) 2018-2022 Jolla Ltd.
  *
  * You may use this file under the terms of BSD license as follows:
@@ -449,10 +449,13 @@ test_invalid(
 {
     int status = 0;
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
+    TestConfig config;
     gulong id = 0;
 
+    test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     g_assert(!gbinder_servicemanager_new2(GBINDER_DEFAULT_HWBINDER, "a", NULL));
     sm = gbinder_servicemanager_new(dev);
@@ -484,6 +487,7 @@ test_invalid(
     gbinder_servicemanager_unref(sm);
     gbinder_ipc_unref(ipc);
     test_binder_exit_wait(&test_opt, NULL);
+    test_config_cleanup(&config);
 }
 
 /*==========================================================================*
@@ -496,12 +500,13 @@ test_basic(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     GBinderLocalObject* obj;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     g_assert(sm);
@@ -530,11 +535,12 @@ test_legacy(
 {
     const char* otherdev = "/dev/otherbinder";
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_hwservicemanager_new(dev);
     g_assert(TEST_IS_HWSERVICEMANAGER(sm));
@@ -649,12 +655,14 @@ test_not_present(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestConfig config;
+    int fd;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
 
     /* This makes presence detection PING fail */
     test_binder_br_reply_status(fd, THIS_THREAD, -1);
@@ -679,16 +687,17 @@ test_wait(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
     const glong forever = (test_opt.flags & TEST_FLAG_DEBUG) ?
         (TEST_TIMEOUT_SEC * 1000) : -1;
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     gulong id;
-    int count = 0;
+    int fd, count = 0;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
 
     /* This makes presence detection PING fail */
     test_binder_br_reply_status(fd, THIS_THREAD, -1);
@@ -734,14 +743,15 @@ test_wait_long(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     gulong id;
-    int count = 0;
+    int fd, count = 0;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
 
     /* This makes presence detection PING fail */
     test_binder_br_reply_status(fd, THIS_THREAD, -1);
@@ -784,15 +794,16 @@ test_wait_async(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     gulong id[2];
-    int count = 0;
+    int fd, count = 0;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
 
     /* This makes presence detection PING fail */
     test_binder_br_reply_status(fd, THIS_THREAD, -1);
@@ -832,15 +843,17 @@ void
 test_death_run()
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     gulong id[3];
-    int count = 0, reg_count = 0;
+    int fd, count = 0, reg_count = 0;
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
+
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     g_assert(sm);
@@ -909,16 +922,18 @@ test_reanimate(
     void)
 {
     const char* dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
-    const int fd = gbinder_driver_fd(ipc->driver);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     gulong id[3];
-    int count = 0, reg_count = 0;
+    int fd, count = 0, reg_count = 0;
     TestConfig config;
 
     /* Create live service manager */
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
+    fd = gbinder_driver_fd(ipc->driver);
+
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     g_assert(sm);
@@ -965,9 +980,9 @@ test_reuse(
     const char* binder_dev = GBINDER_DEFAULT_BINDER;
     const char* vndbinder_dev = "/dev/vpnbinder";
     const char* hwbinder_dev = GBINDER_DEFAULT_HWBINDER;
-    GBinderIpc* binder_ipc = gbinder_ipc_new(binder_dev, NULL);
-    GBinderIpc* vndbinder_ipc = gbinder_ipc_new(vndbinder_dev, NULL);
-    GBinderIpc* hwbinder_ipc = gbinder_ipc_new(hwbinder_dev, NULL);
+    GBinderIpc* binder_ipc;
+    GBinderIpc* vndbinder_ipc;
+    GBinderIpc* hwbinder_ipc;
     GBinderServiceManager* m1;
     GBinderServiceManager* m2;
     GBinderServiceManager* vnd1;
@@ -977,6 +992,10 @@ test_reuse(
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    binder_ipc = gbinder_ipc_new(binder_dev, NULL);
+    vndbinder_ipc = gbinder_ipc_new(vndbinder_dev, NULL);
+    hwbinder_ipc = gbinder_ipc_new(hwbinder_dev, NULL);
+
     test_setup_ping(binder_ipc);
     test_setup_ping(vndbinder_ipc);
     test_setup_ping(hwbinder_ipc);
@@ -1023,7 +1042,7 @@ test_notify_type(
     GType t,
     const char* dev)
 {
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
     const char* name = "foo";
@@ -1032,6 +1051,7 @@ test_notify_type(
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new_with_type(t, NULL, NULL);
     test = TEST_SERVICEMANAGER2(sm, t);
@@ -1094,8 +1114,8 @@ test_list(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
     char** list;
@@ -1103,6 +1123,7 @@ test_list(
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     test = TEST_SERVICEMANAGER(sm);
@@ -1146,8 +1167,8 @@ test_get(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
     int status = -1;
@@ -1156,6 +1177,7 @@ test_get(
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     test = TEST_SERVICEMANAGER(sm);
@@ -1211,8 +1233,8 @@ test_add(
     void)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
-    GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     GMainLoop* loop = g_main_loop_new(NULL, FALSE);
+    GBinderIpc* ipc;
     GBinderServiceManager* sm;
     TestHwServiceManager* test;
     GBinderLocalObject* obj;
@@ -1220,6 +1242,7 @@ test_add(
     TestConfig config;
 
     test_config_init(&config, TMP_DIR_TEMPLATE);
+    ipc = gbinder_ipc_new(dev, NULL);
     test_setup_ping(ipc);
     sm = gbinder_servicemanager_new(dev);
     test = TEST_SERVICEMANAGER(sm);


### PR DESCRIPTION
System gbinder config shouldn't break unit tests. But some of them apparently still did (issue #129)