### PR TITLE
[gbinder] fix sending NULL binder object

### DIFF
--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -175,12 +175,10 @@ GBINDER_IO_FN(encode_local_object)(
     struct flat_binder_object* dest = out;
 
     memset(dest, 0, sizeof(*dest));
+    dest->hdr.type = BINDER_TYPE_BINDER;
     if (obj) {
-        dest->hdr.type = BINDER_TYPE_BINDER;
         dest->flags = 0x7f | FLAT_BINDER_FLAG_ACCEPTS_FDS;
         dest->binder = (uintptr_t)obj;
-    } else {
-        dest->hdr.type = BINDER_TYPE_HANDLE;
     }
     if (protocol->finish_flatten_binder) {
         protocol->finish_flatten_binder(dest + 1, obj);

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -1176,8 +1176,11 @@ gbinder_writer_data_append_local_object(
     n = data->io->encode_local_object(buf->data + offset, obj, data->protocol);
     /* Fix the data size */
     g_byte_array_set_size(buf, offset + n);
-    /* Record the offset */
-    gbinder_writer_data_record_offset(data, offset);
+
+    if (obj) {
+        /* Record the offset */
+        gbinder_writer_data_record_offset(data, offset);
+    }
 }
 
 void
@@ -1308,8 +1311,11 @@ gbinder_writer_data_append_remote_object(
     n = data->io->encode_remote_object(buf->data + offset, obj);
     /* Fix the data size */
     g_byte_array_set_size(buf, offset + n);
-    /* Record the offset */
-    gbinder_writer_data_record_offset(data, offset);
+
+    if (obj) {
+        /* Record the offset */
+        gbinder_writer_data_record_offset(data, offset);
+    }
 }
 
 static

--- a/unit/unit_local_reply/unit_local_reply.c
+++ b/unit/unit_local_reply/unit_local_reply.c
@@ -454,10 +454,7 @@ test_local_object(
     reply = test_local_reply_new();
     gbinder_local_reply_append_local_object(reply, NULL);
     data = gbinder_local_reply_data(reply);
-    offsets = gbinder_output_data_offsets(data);
-    g_assert(offsets);
-    g_assert_cmpuint(offsets->count, == ,1);
-    g_assert_cmpuint(offsets->data[0], == ,0);
+    g_assert(!gbinder_output_data_offsets(data));
     g_assert_cmpuint(gbinder_output_data_buffers_size(data), == ,0);
     g_assert_cmpuint(data->bytes->len, == ,BINDER_OBJECT_SIZE_32);
     gbinder_local_reply_unref(reply);
@@ -475,14 +472,10 @@ test_remote_object(
 {
     GBinderLocalReply* reply = test_local_reply_new();
     GBinderOutputData* data;
-    GUtilIntArray* offsets;
 
     gbinder_local_reply_append_remote_object(reply, NULL);
     data = gbinder_local_reply_data(reply);
-    offsets = gbinder_output_data_offsets(data);
-    g_assert(offsets);
-    g_assert(offsets->count == 1);
-    g_assert(offsets->data[0] == 0);
+    g_assert(!gbinder_output_data_offsets(data));
     g_assert(!gbinder_output_data_buffers_size(data));
     g_assert(data->bytes->len == BINDER_OBJECT_SIZE_32);
     gbinder_local_reply_unref(reply);

--- a/unit/unit_writer/unit_writer.c
+++ b/unit/unit_writer/unit_writer.c
@@ -1359,10 +1359,7 @@ test_local_object(
     gbinder_local_request_init_writer(req, &writer);
     gbinder_writer_append_local_object(&writer, NULL);
     data = gbinder_local_request_data(req);
-    offsets = gbinder_output_data_offsets(data);
-    g_assert(offsets);
-    g_assert_cmpuint(offsets->count, == ,1);
-    g_assert_cmpuint(offsets->data[0], == ,0);
+    g_assert(!gbinder_output_data_offsets(data));
     g_assert_cmpuint(gbinder_output_data_buffers_size(data), == ,0);
     g_assert_cmpuint(data->bytes->len, == ,test->objsize);
     gbinder_local_request_unref(req);
@@ -1380,7 +1377,6 @@ test_remote_object(
 {
     GBinderLocalRequest* req = test_local_request_new_64();
     GBinderOutputData* data;
-    GUtilIntArray* offsets;
     GBinderWriter writer;
     TestContext test;
 
@@ -1388,10 +1384,7 @@ test_remote_object(
     gbinder_local_request_init_writer(req, &writer);
     gbinder_writer_append_remote_object(&writer, NULL);
     data = gbinder_local_request_data(req);
-    offsets = gbinder_output_data_offsets(data);
-    g_assert(offsets);
-    g_assert(offsets->count == 1);
-    g_assert(offsets->data[0] == 0);
+    g_assert(!gbinder_output_data_offsets(data));
     g_assert(!gbinder_output_data_buffers_size(data));
     g_assert(data->bytes->len == BINDER_OBJECT_SIZE_64);
     gbinder_local_request_unref(req);


### PR DESCRIPTION
* Use BINDER_TYPE_BINDER for NULL local object. 3 reasons:
  - This is what encode_remote_object() does. I see no reason a NULL local object should be encoded differently than a NULL remote object.
  - This is what Parcel.cpp does when flattening a NULL binder [1]. This is contrary to what is said in PR #99 [2]; I'm not sure why PR #99 said it uses BINDER_TYPE_HANDLE.
  - More importantly, BINDER_TYPE_HANDLE number 0 does NOT represent a NULL binder. According to the comment at [3], handle number 0 actually represent the context manager. So, by sending BINDER_TYPE_HANDLE number 0, we're sending context manager, not a NULL binder.

[1]\: https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-14.0.0_r1/libs/binder/Parcel.cpp#277
[2]\: https://github.com/mer-hybris/libgbinder/pull/99
[3]\: https://android.googlesource.com/platform/frameworks/native/+/refs/tags/android-14.0.0_r1/libs/binder/ProcessState.cpp#336

* Writer: don't write object offset for NULL binder object
Writing offset will trigger the kernel-side code to transform the flat
binder object into the handle form, which (in my understanding) is not
a valid operation for a NULL binder object. Meanwhile, the receiving
side will create a corresponding Binder object from such handle,
tripping the stability check as it will no longer accept UNDECLARED.

  OTOH, if the offset is not written, then the receiving side will receive
the flat binder object as-is, with type BINDER and pointer NULL, which
will be interpreted as NULL binder. This is also what Android's
Parcel.cpp does [4][5].

  IMO, this is sort of a hack. Binder kernel driver should handle the NULL
binder internally, and not relying on the sender doing the correct
thing. Meanwhile, the receiver should always reject a flat binder object
of type BINDER. But that's how Android work, so... 🤷

[4]\: https://github.com/LineageOS/android_frameworks_native/blob/lineage-19.1/libs/binder/Parcel.cpp#L1327-L1332
[5]\: https://github.com/LineageOS/android_frameworks_native/blob/lineage-19.1/libs/binder/Parcel.cpp#L2023-L2029