### PR TITLE
Explicitly declare function parameters for C23 compatibility

### DIFF
--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -1324,7 +1324,7 @@ gbinder_writer_alloc(
     GBinderWriter* self,
     gsize size,
     gpointer (*alloc)(gsize),
-    void (*dealloc)())
+    void (*dealloc)(gpointer))
 {
     GBinderWriterData* data = gbinder_writer_data(self);
 


### PR DESCRIPTION
In C23, void foo() is equivalent to void foo(void). Therefore, functions must explicitly declare their parameters.

Downstream Bug: https://bugs.gentoo.org/944771
```
cc -c -fPIC  -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_32 -DGLIB_VERSION_MIN_REQUIRED=GLIB_VERSION_MAX_ALLOWED -Wall -Wstrict-aliasing -Wunused-result -Iinclude -MMD -MP -I/usr/lib64/libffi/include -I/usr/include/gutil -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include  -O2 -MT"build/release/gbinder_cleanup.o" -MF"build/release/gbinder_cleanup.d" src/gbinder_cleanup.c -o build/release/gbinder_cleanup.o
src/gbinder_writer.c: In function 'gbinder_writer_alloc':
src/gbinder_writer.c:1334:60: error: passing argument 2 of 'gbinder_cleanup_add' from incompatible pointer type [-Wincompatible-pointer-types]
 1334 |         data->cleanup = gbinder_cleanup_add(data->cleanup, dealloc, ptr);
      |                                                            ^~~~~~~
      |                                                            |
      |                                                            void (*)(void)
In file included from src/gbinder_writer_p.h:38,
                 from src/gbinder_writer.c:33:
src/gbinder_cleanup.h:51:20: note: expected 'GDestroyNotify' {aka 'void (*)(void *)'} but argument is of type 'void (*)(void)'
   51 |     GDestroyNotify destroy,
```