### PR TITLE
Add 'Provides' Tag

### DIFF
--- a/rpm/libgbinder.spec
+++ b/rpm/libgbinder.spec
@@ -32,6 +32,7 @@ C interfaces for Android binder
 
 %package -n %{libname}
 Summary: Runtime library for %{name}
+Provides: %{name} = %{version}
 %else
 %define libname %{name}
 %endif


### PR DESCRIPTION
Adding 'Provides' tag would resolve 'libgbinder' not found error on suse/sle based distributions