### PR TITLE
Fix potential string length overflow

### DIFF
--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -665,7 +665,7 @@ gbinder_reader_read_nullable_string8(
                 *out_len = 0;
             }
             return TRUE;
-        } else if (len >= 0) {
+        } else if (len >= 0 && len < INT32_MAX) {
             const guint32 padded_len = G_ALIGN4(len + 1);
             const char* str = (char*)(p->ptr + 4);
 
@@ -724,8 +724,8 @@ gbinder_reader_read_nullable_string16_utf16(
                 *out_len = 0;
             }
             return TRUE;
-        } else if (len >= 0) {
-            const guint32 padded_len = G_ALIGN4((len + 1)*2);
+        } else if (len >= 0 && len < INT32_MAX) {
+            const gsize padded_len = G_ALIGN4((((gsize)len) + 1) * 2);
 
             if ((p->ptr + padded_len + 4) <= p->end) {
                 const gunichar2* utf16 = (gunichar2*)(p->ptr + 4);

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -572,6 +572,10 @@ static const guint8 test_string8_in_invalid [] = {
     TEST_INT32_BYTES(-2)
 };
 
+static const guint8 test_string8_in_too_long [] = {
+    TEST_INT32_BYTES(INT32_MAX)
+};
+
 static const guint8 test_string8_in_short1 [] = {
     0x00
 };
@@ -595,6 +599,8 @@ static const guint8 test_string8_in_basic2 [] = {
 static const TestStringData test_string8_tests [] = {
     { "invalid", TEST_ARRAY_AND_SIZE(test_string8_in_invalid), NULL,
         sizeof(test_string8_in_invalid) },
+    { "too_long", TEST_ARRAY_AND_SIZE(test_string8_in_too_long), NULL,
+        sizeof(test_string8_in_too_long) },
     { "short1", TEST_ARRAY_AND_SIZE(test_string8_in_short1), NULL,
         sizeof(test_string8_in_short1) },
     { "short2", TEST_ARRAY_AND_SIZE(test_string8_in_short2), NULL,
@@ -685,6 +691,10 @@ static const guint8 test_string16_in_invalid [] = {
     TEST_INT32_BYTES(-2)
 };
 
+static const guint8 test_string16_in_too_long [] = {
+    TEST_INT32_BYTES(INT32_MAX)
+};
+
 static const guint8 test_string16_in_short [] = {
     TEST_INT32_BYTES(3),
     TEST_INT16_BYTES('f'), TEST_INT16_BYTES('o'),
@@ -712,6 +722,8 @@ static const guint8 test_string16_in_basic2 [] = {
 static const TestStringData test_string16_tests [] = {
     { "invalid", TEST_ARRAY_AND_SIZE(test_string16_in_invalid), NULL,
         sizeof(test_string16_in_invalid) },
+    { "too_long", TEST_ARRAY_AND_SIZE(test_string16_in_too_long), NULL,
+        sizeof(test_string16_in_too_long) },
     { "short", TEST_ARRAY_AND_SIZE(test_string16_in_short), NULL,
         sizeof(test_string16_in_short) },
     { "noterm", TEST_ARRAY_AND_SIZE(test_string16_in_noterm), NULL,


### PR DESCRIPTION
If `len` equals `INT32_MAX`, `len + 1` becomes negative.

A similar check is done by Android in [Parcel::readString8Inplace](https://android.googlesource.com/platform/frameworks/native/+/main/libs/binder/Parcel.cpp#2264) and [Parcel::readString16Inplace](https://android.googlesource.com/platform/frameworks/native/+/main/libs/binder/Parcel.cpp#2309)