### PR TITLE
AIDL proxying fixes

### DIFF
--- a/src/gbinder_io.c
+++ b/src/gbinder_io.c
@@ -181,7 +181,8 @@ GBINDER_IO_FN(encode_local_object)(
         dest->binder = (uintptr_t)obj;
     }
     if (protocol->finish_flatten_binder) {
-        protocol->finish_flatten_binder(dest + 1, obj);
+        protocol->finish_flatten_binder(dest + 1, obj ?
+            obj->stability : GBINDER_STABILITY_UNDECLARED);
     } else if (protocol->flat_binder_object_extra) {
         memset(dest + 1, 0, protocol->flat_binder_object_extra);
     }
@@ -192,7 +193,8 @@ static
 guint
 GBINDER_IO_FN(encode_remote_object)(
     void* out,
-    GBinderRemoteObject* obj)
+    GBinderRemoteObject* obj,
+    const GBinderRpcProtocol* protocol)
 {
     struct flat_binder_object* dest = out;
 
@@ -204,7 +206,13 @@ GBINDER_IO_FN(encode_remote_object)(
     } else {
         dest->hdr.type = BINDER_TYPE_BINDER;
     }
-    return sizeof(*dest);
+    if (protocol->finish_flatten_binder) {
+        protocol->finish_flatten_binder(dest + 1, obj ?
+            obj->stability : GBINDER_STABILITY_UNDECLARED);
+    } else if (protocol->flat_binder_object_extra) {
+        memset(dest + 1, 0, protocol->flat_binder_object_extra);
+    }
+    return sizeof(*dest) + protocol->flat_binder_object_extra;
 }
 
 static
@@ -533,7 +541,12 @@ GBINDER_IO_FN(decode_binder_object)(
 {
     const struct flat_binder_object* obj = data;
 
-    if (size >= sizeof(*obj)) {
+    if (size >= sizeof(struct binder_object_header)) {
+        const gsize objsize = GBINDER_IO_FN(object_size)(obj, protocol);
+
+        if (!objsize || objsize > size) {
+            return 0;
+        }
         switch (obj->hdr.type) {
         case BINDER_TYPE_HANDLE:
             if (out) {
@@ -543,14 +556,14 @@ GBINDER_IO_FN(decode_binder_object)(
                     protocol->finish_unflatten_binder(obj + 1, *out);
                 }
             }
-            return sizeof(*obj) + protocol->flat_binder_object_extra;
+            return objsize;
         case BINDER_TYPE_BINDER:
             if (!obj->binder) {
                 /* That's a NULL reference */
                 if (out) {
                     *out = NULL;
                 }
-                return sizeof(*obj) + protocol->flat_binder_object_extra;
+                return objsize;
             }
             /* fallthrough */
         default:

--- a/src/gbinder_io.h
+++ b/src/gbinder_io.h
@@ -145,7 +145,8 @@ struct gbinder_io {
 #define GBINDER_MAX_BINDER_OBJECT_SIZE (28)
     guint (*encode_local_object)(void* out, GBinderLocalObject* obj,
         const GBinderRpcProtocol* protocol);
-    guint (*encode_remote_object)(void* out, GBinderRemoteObject* obj);
+    guint (*encode_remote_object)(void* out, GBinderRemoteObject* obj,
+        const GBinderRpcProtocol* protocol);
     guint (*encode_fd_object)(void* out, int fd);
     guint (*encode_fda_object)(void* out, const GBinderFds *fds,
         const GBinderParent* parent);

--- a/src/gbinder_ipc.c
+++ b/src/gbinder_ipc.c
@@ -1792,9 +1792,8 @@ const GBinderIpcSyncApi gbinder_ipc_sync_worker = {
  * GBinderIpcSyncApi for the main thread
  *==========================================================================*/
 
-static
 GBinderRemoteReply*
-gbinder_ipc_transact_sync_reply(
+gbinder_ipc_transact_sync_reply_main(
     GBinderIpc* self,
     guint32 handle,
     guint32 code,
@@ -1820,9 +1819,8 @@ gbinder_ipc_transact_sync_reply(
     return NULL;
 }
 
-static
 int
-gbinder_ipc_transact_sync_oneway(
+gbinder_ipc_transact_sync_oneway_main(
     GBinderIpc* self,
     guint32 handle,
     guint32 code,
@@ -1839,8 +1837,8 @@ gbinder_ipc_transact_sync_oneway(
 }
 
 const GBinderIpcSyncApi gbinder_ipc_sync_main = {
-    .sync_reply = gbinder_ipc_transact_sync_reply,
-    .sync_oneway = gbinder_ipc_transact_sync_oneway
+    .sync_reply = gbinder_ipc_transact_sync_reply_main,
+    .sync_oneway = gbinder_ipc_transact_sync_oneway_main
 };
 
 /*==========================================================================*

--- a/src/gbinder_ipc.h
+++ b/src/gbinder_ipc.h
@@ -172,6 +172,23 @@ gbinder_ipc_ping_sync(
     const GBinderIpcSyncApi* api)
     GBINDER_INTERNAL;
 
+GBinderRemoteReply*
+gbinder_ipc_transact_sync_reply_main(
+    GBinderIpc* ipc,
+    guint32 handle,
+    guint32 code,
+    GBinderLocalRequest* req,
+    int* status)
+    GBINDER_INTERNAL;
+
+int
+gbinder_ipc_transact_sync_oneway_main(
+    GBinderIpc* ipc,
+    guint32 handle,
+    guint32 code,
+    GBinderLocalRequest* req)
+    GBINDER_INTERNAL;
+
 gulong
 gbinder_ipc_transact(
     GBinderIpc* ipc,

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -40,6 +40,7 @@
 #include "gbinder_object_converter.h"
 #include "gbinder_object_registry.h"
 #include "gbinder_driver.h"
+#include "gbinder_eventloop_p.h"
 #include "gbinder_ipc.h"
 #include "gbinder_log.h"
 
@@ -156,6 +157,23 @@ gbinder_proxy_object_converter_init(
 
 static
 void
+gbinder_proxy_object_handle_dead_reply(
+    gpointer user_data)
+{
+    gbinder_remote_object_commit_suicide(user_data);
+}
+
+static
+void
+gbinder_proxy_object_handle_dead_reply_later(
+    GBinderRemoteObject* remote)
+{
+    gbinder_idle_callback_invoke_later(gbinder_proxy_object_handle_dead_reply,
+        gbinder_remote_object_ref(remote), g_object_unref);
+}
+
+static
+void
 gbinder_proxy_tx_dequeue(
     GBinderProxyTx* tx)
 {
@@ -246,37 +264,113 @@ gbinder_proxy_object_handle_transaction(
     GBinderProxyObject* self = THIS(object);
     GBinderProxyObjectPriv* priv = self->priv;
     GBinderRemoteObject* remote = self->remote;
+    GBinderProxyTx* tx;
+    GBinderLocalRequest* fwd;
+    GBinderProxyObjectConverter convert;
 
-    if (!priv->dropped && !remote->dead) {
-        GBinderLocalRequest* fwd;
-        GBinderProxyTx* tx = g_slice_new0(GBinderProxyTx);
-        GBinderProxyObjectConverter convert;
+    /*
+     * Direct synchronous transactions don't have req->tx to block
+     * and complete asynchronously. Forward them synchronously and
+     * return the reply directly.
+     */
+    if (!req->tx) {
+        GBinderRemoteReply* reply;
+        GBinderLocalReply* fwd_reply = NULL;
+        GBinderProxyObjectConverter convert_reply;
+        gboolean has_reply = FALSE;
+        const gboolean oneway = !!(flags & GBINDER_TX_FLAG_ONEWAY);
+        int tx_status;
 
-        g_object_ref(tx->proxy = self);
-        tx->req = gbinder_remote_request_ref(req);
-        tx->next = priv->tx;
-        priv->tx = tx;
+        if (priv->dropped || remote->dead) {
+            GVERBOSE_("dropped: %d dead:%d", priv->dropped, remote->dead);
+            *status = (-EBADMSG);
+            return NULL;
+        }
 
-        /* Mark the incoming request as pending */
-        gbinder_remote_request_block(req);
-
-        /*
-         * For auto-created proxy objects, this object's GBinderIpc will
-         * become a remote, and the remote's GBinderIpc will become local
-         * because they work in the opposite direction.
-         */
         gbinder_proxy_object_converter_init(&convert, self, object->ipc,
             remote->ipc);
-
-        /* Forward the transaction */
         fwd = gbinder_remote_request_convert_to_local(req, &convert.pub);
-        tx->id = gbinder_ipc_transact(remote->ipc, remote->handle, code, flags,
-            fwd, gbinder_proxy_tx_reply, gbinder_proxy_tx_destroy, tx);
+        if (!fwd) {
+            GWARN("Failed to convert transaction 0x%08x for forwarding", code);
+            *status = -ENOMEM;
+            return NULL;
+        }
+
+        if (oneway) {
+            reply = NULL;
+            tx_status = gbinder_ipc_sync_worker.sync_oneway(remote->ipc,
+                remote->handle, code, fwd);
+        } else {
+            reply = gbinder_ipc_sync_worker.sync_reply(remote->ipc,
+                remote->handle, code, fwd, &tx_status);
+        }
         gbinder_local_request_unref(fwd);
-        *status = GBINDER_STATUS_OK;
-    } else {
+
+        if (reply) {
+            has_reply = TRUE;
+            if (gbinder_remote_reply_is_empty(reply)) {
+                fwd_reply = gbinder_local_object_new_reply(object);
+            } else {
+                gbinder_proxy_object_converter_init(&convert_reply, self,
+                    remote->ipc, self->parent.ipc);
+                fwd_reply = gbinder_remote_reply_convert_to_local(reply,
+                    &convert_reply.pub);
+            }
+            gbinder_remote_reply_unref(reply);
+        }
+        if (tx_status == GBINDER_STATUS_DEAD_OBJECT) {
+            gbinder_proxy_object_handle_dead_reply_later(remote);
+        }
+        *status = (has_reply && !fwd_reply) ? -ENOMEM : tx_status;
+        return fwd_reply;
+    }
+
+    if (priv->dropped || remote->dead) {
         GVERBOSE_("dropped: %d dead:%d", priv->dropped, remote->dead);
         *status = (-EBADMSG);
+        return NULL;
+    }
+    tx = g_slice_new0(GBinderProxyTx);
+    g_object_ref(tx->proxy = self);
+    tx->req = gbinder_remote_request_ref(req);
+    tx->next = priv->tx;
+    priv->tx = tx;
+
+    /* Mark the incoming request as pending */
+    gbinder_remote_request_block(req);
+
+    /*
+     * For auto-created proxy objects, this object's GBinderIpc will
+     * become a remote, and the remote's GBinderIpc will become local
+     * because they work in the opposite direction.
+     */
+    gbinder_proxy_object_converter_init(&convert, self, object->ipc,
+        remote->ipc);
+
+    /* Forward the transaction */
+    fwd = gbinder_remote_request_convert_to_local(req, &convert.pub);
+    if (fwd) {
+        tx->id = gbinder_ipc_transact(remote->ipc, remote->handle,
+            code, flags, fwd, gbinder_proxy_tx_reply,
+            gbinder_proxy_tx_destroy, tx);
+        gbinder_local_request_unref(fwd);
+        if (tx->id) {
+            *status = GBINDER_STATUS_OK;
+        } else {
+            GWARN("Failed to enqueue forwarded transaction 0x%08x", code);
+            gbinder_proxy_tx_dequeue(tx);
+            gbinder_remote_request_complete(req, NULL, -EFAULT);
+            gbinder_remote_request_unref(tx->req);
+            gutil_slice_free(tx);
+            *status = -EFAULT;
+        }
+    } else {
+        GWARN("Failed to convert transaction 0x%08x for forwarding", code);
+        gbinder_proxy_tx_dequeue(tx);
+        gbinder_remote_request_complete(req, NULL, -ENOMEM);
+        gbinder_remote_request_unref(tx->req);
+        gutil_slice_free(tx);
+        *status = -ENOMEM;
     }
     return NULL;
 }
@@ -407,6 +501,7 @@ gbinder_proxy_object_class_init(
     object_class->finalize = gbinder_proxy_object_finalize;
     klass->can_handle_transaction = gbinder_proxy_object_can_handle_transaction;
     klass->handle_transaction = gbinder_proxy_object_handle_transaction;
+    klass->handle_looper_transaction = gbinder_proxy_object_handle_transaction;
     klass->acquire = gbinder_proxy_object_acquire;
     klass->drop = gbinder_proxy_object_drop;
 }

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -287,6 +287,12 @@ gbinder_proxy_object_handle_transaction(
     GBinderLocalRequest* fwd;
     GBinderProxyObjectConverter convert;
 
+    if (priv->dropped || remote->dead) {
+        GVERBOSE_("dropped: %d dead:%d", priv->dropped, remote->dead);
+        *status = (-EBADMSG);
+        return NULL;
+    }
+
     /*
      * Direct synchronous transactions don't have req->tx to block
      * and complete asynchronously. Forward them synchronously and
@@ -300,12 +306,6 @@ gbinder_proxy_object_handle_transaction(
         const gboolean oneway = !!(flags & GBINDER_TX_FLAG_ONEWAY);
         int tx_status;
 
-        if (priv->dropped || remote->dead) {
-            GVERBOSE_("dropped: %d dead:%d", priv->dropped, remote->dead);
-            *status = (-EBADMSG);
-            return NULL;
-        }
-
         gbinder_proxy_object_converter_init(&convert, self, object->ipc,
             remote->ipc);
         fwd = gbinder_remote_request_convert_to_local(req, &convert.pub);
@@ -317,10 +317,10 @@ gbinder_proxy_object_handle_transaction(
 
         if (oneway) {
             reply = NULL;
-            tx_status = gbinder_ipc_sync_worker.sync_oneway(remote->ipc,
+            tx_status = gbinder_ipc_transact_sync_oneway_main(remote->ipc,
                 remote->handle, code, fwd);
         } else {
-            reply = gbinder_ipc_sync_worker.sync_reply(remote->ipc,
+            reply = gbinder_ipc_transact_sync_reply_main(remote->ipc,
                 remote->handle, code, fwd, &tx_status);
         }
         gbinder_local_request_unref(fwd);
@@ -344,11 +344,6 @@ gbinder_proxy_object_handle_transaction(
         return fwd_reply;
     }
 
-    if (priv->dropped || remote->dead) {
-        GVERBOSE_("dropped: %d dead:%d", priv->dropped, remote->dead);
-        *status = (-EBADMSG);
-        return NULL;
-    }
     tx = g_slice_new0(GBinderProxyTx);
     g_object_ref(tx->proxy = self);
     tx->req = gbinder_remote_request_ref(req);

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -437,6 +437,7 @@ gbinder_proxy_object_new(
         if (object) {
             GBinderProxyObject* self = THIS(object);
 
+            object->stability = remote->stability;
             GDEBUG("Proxy %p %s => %u %s created", self, gbinder_ipc_name(src),
                 remote->handle, gbinder_ipc_name(remote->ipc));
             self->remote = gbinder_remote_object_ref(remote);

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -112,8 +112,13 @@ gbinder_proxy_object_set_min_stability(
     GBinderLocalObject* local,
     GBINDER_STABILITY_LEVEL stability)
 {
-    if (local && local->stability < stability) {
-        local->stability = stability;
+    if (local && (local->stability & stability) != stability) {
+        if (local->stability && stability &&
+            stability != GBINDER_STABILITY_VINTF) {
+            local->stability = GBINDER_STABILITY_VINTF;
+        } else {
+            local->stability = stability;
+        }
     }
 }
 

--- a/src/gbinder_proxy_object.c
+++ b/src/gbinder_proxy_object.c
@@ -81,6 +81,7 @@ typedef struct gbinder_proxy_object_converter {
     GBinderObjectConverter pub;
     GBinderIpc* remote;
     GBinderIpc* local;
+    GBINDER_STABILITY_LEVEL stability;
 } GBinderProxyObjectConverter;
 
 GBINDER_INLINE_FUNC
@@ -106,6 +107,17 @@ gbinder_proxy_object_converter_check(
 }
 
 static
+void
+gbinder_proxy_object_set_min_stability(
+    GBinderLocalObject* local,
+    GBINDER_STABILITY_LEVEL stability)
+{
+    if (local && local->stability < stability) {
+        local->stability = stability;
+    }
+}
+
+static
 GBinderLocalObject*
 gbinder_proxy_object_converter_handle_to_local(
     GBinderObjectConverter* pub,
@@ -122,6 +134,7 @@ gbinder_proxy_object_converter_handle_to_local(
         /* GBinderProxyObject will reference GBinderRemoteObject */
         local = &gbinder_proxy_object_new(c->local, remote)->parent;
     }
+    gbinder_proxy_object_set_min_stability(local, c->stability);
 
     /* Release the reference returned by gbinder_object_registry_get_remote */
     gbinder_remote_object_unref(remote);
@@ -146,6 +159,7 @@ gbinder_proxy_object_converter_init(
     memset(convert, 0, sizeof(*convert));
     convert->remote = remote;
     convert->local = local;
+    convert->stability = proxy->parent.stability;
     pub->f = &gbinder_converter_fn;
     pub->io = gbinder_ipc_io(dest);
     pub->protocol = gbinder_ipc_protocol(dest);

--- a/src/gbinder_remote_object.c
+++ b/src/gbinder_remote_object.c
@@ -176,6 +176,7 @@ gbinder_remote_object_new(
 
         self->ipc = gbinder_ipc_ref(ipc);
         self->handle = handle;
+        self->stability = GBINDER_STABILITY_SYSTEM;
         switch (create) {
         case REMOTE_OBJECT_CREATE_DEAD:
             self->dead = TRUE;

--- a/src/gbinder_remote_object_p.h
+++ b/src/gbinder_remote_object_p.h
@@ -45,6 +45,7 @@ struct gbinder_remote_object {
     GBinderRemoteObjectPriv* priv;
     GBinderIpc* ipc;
     guint32 handle;
+    GBINDER_STABILITY_LEVEL stability;
     gboolean dead;
 };
 

--- a/src/gbinder_remote_request.c
+++ b/src/gbinder_remote_request.c
@@ -99,18 +99,22 @@ gbinder_remote_request_convert_to_local(
 {
     GBinderRemoteRequestPriv* self = gbinder_remote_request_cast(req);
 
-    if (G_LIKELY(self)) {
+    if (G_LIKELY(self) && G_LIKELY(convert)) {
         GBinderReaderData* data = &self->data;
+        GBinderBuffer* buffer = data->buffer;
 
-        if (!convert || convert->protocol == self->protocol) {
+        if (!buffer) {
+            return gbinder_local_request_new(convert->io, convert->protocol,
+                NULL);
+        } else if (convert->protocol == self->protocol) {
             /* The same protocol, the same format of RPC header */
-            return gbinder_local_request_new_from_data(data->buffer, convert);
+            return gbinder_local_request_new_from_data(buffer, convert);
         } else {
             /* Need to translate to another format */
             GBinderLocalRequest* local = gbinder_local_request_new_iface
                 (convert->io, convert->protocol, self->iface);
 
-            gbinder_local_request_append_contents(local, data->buffer,
+            gbinder_local_request_append_contents(local, buffer,
                 self->header_size, convert);
             return local;
         }

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -327,13 +327,9 @@ static
 void
 gbinder_rpc_protocol_aidl3_finish_flatten_binder(
     void* out,
-    GBinderLocalObject* obj)
+    GBINDER_STABILITY_LEVEL stability)
 {
-    if (G_LIKELY(obj)) {
-        *(guint32*)out = obj->stability;
-    } else {
-        *(guint32*)out = GBINDER_STABILITY_UNDECLARED;
-    }
+    *(guint32*)out = stability;
 }
 
 static
@@ -378,12 +374,12 @@ static
 void
 gbinder_rpc_protocol_aidl4_finish_flatten_binder(
     void* out,
-    GBinderLocalObject* obj)
+    GBINDER_STABILITY_LEVEL stability)
 {
     struct stability_category cat = {
         .binder_wire_format_version = BINDER_WIRE_FORMAT_VERSION_AIDL4,
         .reserved = { 0, 0, },
-        .stability_level = obj ? obj->stability : GBINDER_STABILITY_UNDECLARED,
+        .stability_level = stability,
     };
 
     memcpy(out, &cat, sizeof(cat));

--- a/src/gbinder_rpc_protocol.c
+++ b/src/gbinder_rpc_protocol.c
@@ -38,6 +38,7 @@
 #include "gbinder_config.h"
 #include "gbinder_log.h"
 #include "gbinder_local_object_p.h"
+#include "gbinder_remote_object_p.h"
 
 #include <gutil_misc.h>
 
@@ -335,6 +336,18 @@ gbinder_rpc_protocol_aidl3_finish_flatten_binder(
     }
 }
 
+static
+void
+gbinder_rpc_protocol_aidl3_finish_unflatten_binder(
+    const void* in,
+    GBinderRemoteObject* obj)
+{
+    guint32 stability;
+
+    memcpy(&stability, in, sizeof(stability));
+    obj->stability = stability;
+}
+
 static const GBinderRpcProtocol gbinder_rpc_protocol_aidl3 = {
     .name = "aidl3",
     .ping_tx = GBINDER_PING_TRANSACTION,
@@ -343,6 +356,8 @@ static const GBinderRpcProtocol gbinder_rpc_protocol_aidl3 = {
     .read_rpc_header = gbinder_rpc_protocol_aidl3_read_rpc_header,
     .flat_binder_object_extra = 4,
     .finish_flatten_binder = gbinder_rpc_protocol_aidl3_finish_flatten_binder,
+    .finish_unflatten_binder =
+        gbinder_rpc_protocol_aidl3_finish_unflatten_binder,
     .write_fmq_descriptor = gbinder_rpc_protocol_aidl_write_fmq_descriptor,
 };
 
@@ -374,6 +389,18 @@ gbinder_rpc_protocol_aidl4_finish_flatten_binder(
     memcpy(out, &cat, sizeof(cat));
 }
 
+static
+void
+gbinder_rpc_protocol_aidl4_finish_unflatten_binder(
+    const void* in,
+    GBinderRemoteObject* obj)
+{
+    struct stability_category cat;
+
+    memcpy(&cat, in, sizeof(cat));
+    obj->stability = cat.stability_level;
+}
+
 static const GBinderRpcProtocol gbinder_rpc_protocol_aidl4 = {
     .name = "aidl4",
     .ping_tx = GBINDER_PING_TRANSACTION,
@@ -382,6 +409,8 @@ static const GBinderRpcProtocol gbinder_rpc_protocol_aidl4 = {
     .read_rpc_header = gbinder_rpc_protocol_aidl3_read_rpc_header,
     .flat_binder_object_extra = 4,
     .finish_flatten_binder = gbinder_rpc_protocol_aidl4_finish_flatten_binder,
+    .finish_unflatten_binder =
+        gbinder_rpc_protocol_aidl4_finish_unflatten_binder,
     .write_fmq_descriptor = gbinder_rpc_protocol_aidl_write_fmq_descriptor,
 };
 

--- a/src/gbinder_rpc_protocol.h
+++ b/src/gbinder_rpc_protocol.h
@@ -57,7 +57,8 @@ struct gbinder_rpc_protocol {
      * bytes are just skipped.
      */
     gsize flat_binder_object_extra;
-    void (*finish_flatten_binder)(void* out, GBinderLocalObject* obj);
+    void (*finish_flatten_binder)(void* out,
+        GBINDER_STABILITY_LEVEL stability);
     void (*finish_unflatten_binder)(const void* in, GBinderRemoteObject* obj);
     void (*write_fmq_descriptor)(GBinderWriter* writer, const GBinderFmq* queue);
 };

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -116,11 +116,20 @@ gbinder_writer_data_append_contents(
             }
             while (*objects) {
                 const guint8* obj = *objects++;
-                gsize objsize, offset = obj - bufdata;
+                gsize objsize, src_objsize, offset = obj - bufdata;
                 GBinderLocalObject* local;
                 guint32 handle;
 
                 GASSERT(offset >= off && offset < bufsize);
+                if (offset >= bufsize) {
+                    GWARN("Invalid object offset %u", (guint)offset);
+                    return;
+                }
+                src_objsize = io->object_size(obj, proto);
+                if (src_objsize > bufsize - offset) {
+                    GWARN("Invalid object at offset %u", (guint)offset);
+                    return;
+                }
                 if (offset > off) {
                     /* Copy serialized data preceeding this object */
                     g_byte_array_append(dest, bufdata + off, offset - off);
@@ -130,9 +139,10 @@ gbinder_writer_data_append_contents(
                 gutil_int_array_append(data->offsets, dest->len);
 
                 /* Convert remote object into local if necessary */
-                if (convert && io->decode_binder_handle(obj, &handle, proto) &&
-                    (local = gbinder_object_converter_handle_to_local
-                    (convert, handle))) {
+                if (src_objsize && convert && io->decode_binder_handle(obj,
+                    &handle, proto) && (local =
+                    gbinder_object_converter_handle_to_local(convert,
+                    handle))) {
                     const guint pos = dest->len;
 
                     g_byte_array_set_size(dest, pos +
@@ -145,13 +155,17 @@ gbinder_writer_data_append_contents(
                     data->cleanup = gbinder_cleanup_add(data->cleanup,
                         (GDestroyNotify) gbinder_local_object_unref, local);
                 } else {
-                    objsize = io->object_size(obj, proto);
-                    g_byte_array_append(dest, obj, objsize);
+                    objsize = src_objsize;
+                    if (src_objsize) {
+                        g_byte_array_append(dest, obj, src_objsize);
+                    }
                 }
 
                 /* Size of each buffer has to be 8-byte aligned */
-                data->buffers_size += G_ALIGN8(io->object_data_size(obj));
-                off += objsize;
+                if (src_objsize) {
+                    data->buffers_size += G_ALIGN8(io->object_data_size(obj));
+                }
+                off += src_objsize;
             }
         }
         if (off < bufsize) {
@@ -1319,7 +1333,7 @@ gbinder_writer_data_append_remote_object(
     /* Preallocate enough space */
     g_byte_array_set_size(buf, offset + GBINDER_MAX_BINDER_OBJECT_SIZE);
     /* Write the object */
-    n = data->io->encode_remote_object(buf->data + offset, obj);
+    n = data->io->encode_remote_object(buf->data + offset, obj, data->protocol);
     /* Fix the data size */
     g_byte_array_set_size(buf, offset + n);
 

--- a/unit/unit_proxy_object/unit_proxy_object.c
+++ b/unit/unit_proxy_object/unit_proxy_object.c
@@ -37,6 +37,7 @@
 #include "gbinder_config.h"
 #include "gbinder_driver.h"
 #include "gbinder_proxy_object.h"
+#include "gbinder_client_p.h"
 #include "gbinder_remote_object_p.h"
 #include "gbinder_remote_request.h"
 #include "gbinder_remote_reply.h"
@@ -803,6 +804,247 @@ test_obj(
 }
 
 /*==========================================================================*
+ * nested_sync
+ *==========================================================================*/
+
+typedef struct test_nested_sync_data {
+    GMainLoop* loop;
+    GThread* thread;
+    GBinderLocalObject* obj;
+    GBinderLocalObject* connection;
+    GBinderRemoteObject* accessor;
+    GBinderRemoteRequest* req;
+    gboolean register_handled;
+    gboolean connect_handled;
+    gboolean register_finished;
+} TestNestedSync;
+
+static
+GBinderLocalReply*
+test_nested_accessor_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    TestNestedSync* test = user_data;
+    GBinderReader reader;
+    GBinderRemoteObject* observer;
+
+    GDEBUG("Nested accessor request handled");
+    g_assert(!test->connect_handled);
+    test->connect_handled = TRUE;
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE2));
+    g_assert(code == TX_CODE2);
+
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert((observer = gbinder_reader_read_object(&reader)));
+    g_assert(gbinder_reader_at_end(&reader));
+    gbinder_remote_object_unref(observer);
+
+    test->connection = gbinder_local_object_new(obj->ipc, TEST_IFACES2,
+        NULL, NULL);
+    g_assert(test->connection);
+
+    *status = GBINDER_STATUS_OK;
+    return gbinder_local_reply_append_int32
+        (gbinder_local_reply_append_local_object
+            (gbinder_local_object_new_reply(obj), test->connection),
+            TX_RESULT2);
+}
+
+static
+gpointer
+test_nested_register_thread(
+    gpointer user_data)
+{
+    TestNestedSync* test = user_data;
+    GBinderReader reader;
+    GBinderRemoteObject* connection;
+    GBinderLocalObject* observer;
+    GBinderClient* client;
+    GBinderLocalRequest* req2;
+    GBinderRemoteReply* reply2;
+    GBinderLocalReply* complete;
+    gint32 result = 0;
+    int status2 = -1;
+
+    observer = gbinder_local_object_new(test->obj->ipc, TEST_IFACES2,
+        NULL, NULL);
+    g_assert(observer);
+
+    client = gbinder_client_new(test->accessor, TEST_IFACE2);
+    req2 = gbinder_client_new_request(client);
+    gbinder_local_request_append_local_object(req2, observer);
+    reply2 = gbinder_client_transact_sync_reply2(client, TX_CODE2, req2,
+        &status2, &gbinder_ipc_sync_worker);
+    g_assert_cmpint(status2, == ,GBINDER_STATUS_OK);
+    g_assert(reply2);
+
+    gbinder_remote_reply_init_reader(reply2, &reader);
+    g_assert((connection = gbinder_reader_read_object(&reader)));
+    g_assert(gbinder_reader_read_int32(&reader, &result));
+    g_assert_cmpint(result, == ,TX_RESULT2);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    gbinder_remote_object_unref(connection);
+    gbinder_remote_reply_unref(reply2);
+    gbinder_local_request_unref(req2);
+    gbinder_client_unref(client);
+    gbinder_local_object_drop(observer);
+
+    complete = gbinder_local_reply_append_int32
+        (gbinder_local_object_new_reply(test->obj), TX_RESULT1);
+    gbinder_remote_request_complete(test->req, complete, GBINDER_STATUS_OK);
+    gbinder_local_reply_unref(complete);
+    return NULL;
+}
+
+static
+GBinderLocalReply*
+test_nested_register_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    TestNestedSync* test = user_data;
+    GBinderReader reader;
+
+    GDEBUG("Nested register request handled");
+    g_assert(!test->register_handled);
+    test->register_handled = TRUE;
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE));
+    g_assert(code == TX_CODE);
+
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert((test->accessor = gbinder_reader_read_object(&reader)));
+    g_assert_cmpint(test->accessor->stability, == ,GBINDER_STABILITY_VINTF);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    gbinder_remote_request_block(req);
+    test->obj = gbinder_local_object_ref(obj);
+    test->req = gbinder_remote_request_ref(req);
+    test->thread = g_thread_new("nested-register",
+        test_nested_register_thread, test);
+
+    *status = GBINDER_STATUS_OK;
+    return NULL;
+}
+
+static
+void
+test_nested_register_reply(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* data)
+{
+    TestNestedSync* test = data;
+    GBinderReader reader;
+    gint32 result = 0;
+
+    GDEBUG("Nested register reply received");
+    g_assert_cmpint(status, == ,GBINDER_STATUS_OK);
+    g_assert(reply);
+
+    gbinder_remote_reply_init_reader(reply, &reader);
+    g_assert(gbinder_reader_read_int32(&reader, &result));
+    g_assert_cmpint(result, == ,TX_RESULT1);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    test->register_finished = TRUE;
+    g_main_loop_quit(test->loop);
+}
+
+static
+void
+test_nested_sync_run(
+    void)
+{
+    TestNestedSync test;
+    GBinderLocalObject* obj;
+    GBinderLocalObject* accessor;
+    GBinderProxyObject* proxy;
+    GBinderRemoteObject* remote_obj;
+    GBinderRemoteObject* proxy_remote;
+    GBinderClient* client;
+    GBinderLocalRequest* req;
+    GBinderIpc* ipc_obj;
+    GBinderIpc* ipc_proxy;
+    int fd_obj, fd_proxy;
+
+    memset(&test, 0, sizeof(test));
+    test.loop = g_main_loop_new(NULL, FALSE);
+
+    ipc_proxy = gbinder_ipc_new(DEV, "aidl3");
+    ipc_obj = gbinder_ipc_new(DEV2, "aidl3");
+    fd_proxy = gbinder_driver_fd(ipc_proxy->driver);
+    fd_obj = gbinder_driver_fd(ipc_obj->driver);
+
+    obj = gbinder_local_object_new(ipc_obj, TEST_IFACES,
+        test_nested_register_cb, &test);
+    remote_obj = gbinder_remote_object_new(ipc_obj,
+        test_binder_register_object(fd_obj, obj, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+    remote_obj->stability = GBINDER_STABILITY_VINTF;
+
+    g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    g_assert_cmpint(proxy->parent.stability, == ,GBINDER_STABILITY_VINTF);
+    proxy_remote = gbinder_remote_object_new(ipc_proxy,
+        test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+    client = gbinder_client_new(proxy_remote, TEST_IFACE);
+
+    accessor = gbinder_local_object_new(ipc_proxy, TEST_IFACES2,
+        test_nested_accessor_cb, &test);
+    req = gbinder_client_new_request(client);
+    gbinder_local_request_append_local_object(req, accessor);
+    g_assert(gbinder_client_transact(client, TX_CODE, 0, req,
+        test_nested_register_reply, NULL, &test));
+    gbinder_local_request_unref(req);
+
+    test_run(&test_opt, test.loop);
+
+    g_assert(test.register_handled);
+    g_assert(test.connect_handled);
+    g_assert(test.register_finished);
+
+    g_thread_join(test.thread);
+    test_binder_unregister_objects(fd_obj);
+    test_binder_unregister_objects(fd_proxy);
+
+    gbinder_local_object_drop(obj);
+    gbinder_local_object_drop(accessor);
+    gbinder_local_object_unref(test.obj);
+    gbinder_local_object_drop(test.connection);
+    gbinder_remote_object_unref(test.accessor);
+    gbinder_remote_request_unref(test.req);
+    gbinder_local_object_drop(&proxy->parent);
+    gbinder_remote_object_unref(proxy_remote);
+    gbinder_remote_object_unref(remote_obj);
+    gbinder_client_unref(client);
+    gbinder_ipc_unref(ipc_obj);
+    gbinder_ipc_unref(ipc_proxy);
+    test_binder_exit_wait(&test_opt, test.loop);
+    g_main_loop_unref(test.loop);
+}
+
+static
+void
+test_nested_sync(
+    void)
+{
+    test_run_in_context(&test_opt, test_nested_sync_run);
+}
+
+/*==========================================================================*
  * Common
  *==========================================================================*/
 
@@ -824,6 +1066,7 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("interface"), test_interface);
     g_test_add_func(TEST_("param"), test_param);
     g_test_add_func(TEST_("obj"), test_obj);
+    g_test_add_func(TEST_("nested_sync"), test_nested_sync);
 
     test_init(&test_opt, argc, argv);
     test_config_init(&test_config, TMP_DIR_TEMPLATE);

--- a/unit/unit_proxy_object/unit_proxy_object.c
+++ b/unit/unit_proxy_object/unit_proxy_object.c
@@ -163,9 +163,11 @@ test_basic_run(
     remote_obj = gbinder_remote_object_new(ipc_obj,
         test_binder_register_object(fd_obj, obj, AUTO_HANDLE),
         REMOTE_OBJECT_CREATE_ALIVE);
+    remote_obj->stability = GBINDER_STABILITY_VINTF;
 
     g_assert(!gbinder_proxy_object_new(NULL, remote_obj));
     g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    g_assert_cmpint(proxy->parent.stability, == ,GBINDER_STABILITY_VINTF);
     client = gbinder_client_new(proxy->remote, TEST_IFACE);
 
     /* Perform a transaction via proxy */

--- a/unit/unit_proxy_object/unit_proxy_object.c
+++ b/unit/unit_proxy_object/unit_proxy_object.c
@@ -131,6 +131,8 @@ test_basic_reply(
     GBinderReader reader;
 
     GDEBUG("Reply received");
+    g_assert_cmpint(status, == ,GBINDER_STATUS_OK);
+    g_assert(reply);
 
     /* No parameters are expected */
     gbinder_remote_reply_init_reader(reply, &reader);
@@ -191,6 +193,203 @@ test_basic(
     void)
 {
     test_run_in_context(&test_opt, test_basic_run);
+}
+
+/*==========================================================================*
+ * empty_reply
+ *==========================================================================*/
+
+typedef struct test_empty_reply {
+    GMainLoop* loop;
+    GThread* main_thread;
+    gboolean handled;
+} TestEmptyReply;
+
+static
+GBinderLocalReply*
+test_empty_reply_cb(
+    GBinderLocalObject* obj,
+    GBinderRemoteRequest* req,
+    guint code,
+    guint flags,
+    int* status,
+    void* user_data)
+{
+    TestEmptyReply* test = user_data;
+    GBinderReader reader;
+
+    g_assert(test->main_thread == g_thread_self());
+    g_assert(!flags);
+    g_assert(!g_strcmp0(gbinder_remote_request_interface(req), TEST_IFACE));
+    g_assert(code == TX_CODE);
+
+    gbinder_remote_request_init_reader(req, &reader);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    *status = GBINDER_STATUS_OK;
+    test->handled = TRUE;
+    return gbinder_local_object_new_reply(obj);
+}
+
+static
+void
+test_empty_reply_done(
+    GBinderClient* client,
+    GBinderRemoteReply* reply,
+    int status,
+    void* user_data)
+{
+    TestEmptyReply* test = user_data;
+    GBinderReader reader;
+
+    g_assert_cmpint(status, == ,GBINDER_STATUS_OK);
+    g_assert(reply);
+    gbinder_remote_reply_init_reader(reply, &reader);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    g_main_loop_quit(test->loop);
+}
+
+static
+void
+test_empty_reply_run(
+    void)
+{
+    GBinderLocalObject* obj;
+    GBinderProxyObject* proxy;
+    GBinderRemoteObject* remote_obj;
+    GBinderRemoteObject* proxy_remote;
+    GBinderClient* client;
+    GBinderIpc* ipc_obj;
+    GBinderIpc* ipc_proxy;
+    TestEmptyReply test;
+    int fd_obj, fd_proxy;
+
+    memset(&test, 0, sizeof(test));
+    test.loop = g_main_loop_new(NULL, FALSE);
+    test.main_thread = g_thread_self();
+
+    ipc_proxy = gbinder_ipc_new(DEV, NULL);
+    ipc_obj = gbinder_ipc_new(DEV2, NULL);
+    fd_proxy = gbinder_driver_fd(ipc_proxy->driver);
+    fd_obj = gbinder_driver_fd(ipc_obj->driver);
+    obj = gbinder_local_object_new(ipc_obj, TEST_IFACES,
+        test_empty_reply_cb, &test);
+    remote_obj = gbinder_remote_object_new(ipc_obj,
+        test_binder_register_object(fd_obj, obj, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+
+    g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    proxy_remote = gbinder_remote_object_new(ipc_proxy,
+        test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+    client = gbinder_client_new(proxy_remote, TEST_IFACE);
+
+    g_assert(gbinder_client_transact(client, TX_CODE, 0, NULL,
+        test_empty_reply_done, NULL, &test));
+
+    test_run(&test_opt, test.loop);
+    g_assert(test.handled);
+
+    test_binder_unregister_objects(fd_obj);
+    test_binder_unregister_objects(fd_proxy);
+    gbinder_local_object_drop(obj);
+    gbinder_local_object_drop(&proxy->parent);
+    gbinder_remote_object_unref(proxy_remote);
+    gbinder_remote_object_unref(remote_obj);
+    gbinder_client_unref(client);
+    gbinder_ipc_unref(ipc_obj);
+    gbinder_ipc_unref(ipc_proxy);
+    test_binder_exit_wait(&test_opt, test.loop);
+    g_main_loop_unref(test.loop);
+}
+
+static
+void
+test_empty_reply(
+    void)
+{
+    test_run_in_context(&test_opt, test_empty_reply_run);
+}
+
+/*==========================================================================*
+ * interface
+ *==========================================================================*/
+
+static
+void
+test_interface_run(
+    void)
+{
+    GBinderLocalObject* obj;
+    GBinderProxyObject* proxy;
+    GBinderRemoteObject* remote_obj;
+    GBinderRemoteObject* proxy_remote;
+    GBinderRemoteReply* reply;
+    GBinderLocalRequest* req;
+    GBinderIpc* ipc_obj;
+    GBinderIpc* ipc_proxy;
+    char* iface;
+    gint32 result;
+    int fd_obj, fd_proxy, status = INT_MAX;
+
+    ipc_proxy = gbinder_ipc_new(DEV, "aidl");
+    ipc_obj = gbinder_ipc_new(DEV2, "aidl");
+    fd_proxy = gbinder_driver_fd(ipc_proxy->driver);
+    fd_obj = gbinder_driver_fd(ipc_obj->driver);
+    obj = gbinder_local_object_new(ipc_obj, TEST_IFACES, NULL, NULL);
+    remote_obj = gbinder_remote_object_new(ipc_obj,
+        test_binder_register_object(fd_obj, obj, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+
+    g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
+    proxy_remote = gbinder_remote_object_new(ipc_proxy,
+        test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
+        REMOTE_OBJECT_CREATE_ALIVE);
+
+    /*
+     * INTERFACE_TRANSACTION has no request payload. The proxy has to turn
+     * such bufferless incoming request into an empty local request.
+     */
+    req = gbinder_driver_local_request_new(ipc_proxy->driver, NULL);
+    reply = gbinder_ipc_sync_main.sync_reply(ipc_proxy, proxy_remote->handle,
+        GBINDER_INTERFACE_TRANSACTION, req, &status);
+    g_assert(reply);
+    g_assert_cmpint(status, == ,GBINDER_STATUS_OK);
+    iface = gbinder_remote_reply_read_string16(reply);
+    g_assert_cmpstr(iface, == ,TEST_IFACE);
+
+    g_free(iface);
+    gbinder_remote_reply_unref(reply);
+    gbinder_local_request_unref(req);
+
+    req = gbinder_driver_local_request_new(ipc_proxy->driver, NULL);
+    reply = gbinder_ipc_sync_main.sync_reply(ipc_proxy, proxy_remote->handle,
+        GBINDER_PING_TRANSACTION, req, &status);
+    g_assert(reply);
+    g_assert_cmpint(status, == ,GBINDER_STATUS_OK);
+    g_assert(gbinder_remote_reply_read_int32(reply, &result));
+    g_assert_cmpint(result, == ,GBINDER_STATUS_OK);
+
+    gbinder_remote_reply_unref(reply);
+    gbinder_local_request_unref(req);
+    test_binder_unregister_objects(fd_obj);
+    test_binder_unregister_objects(fd_proxy);
+    gbinder_local_object_drop(obj);
+    gbinder_local_object_drop(&proxy->parent);
+    gbinder_remote_object_unref(proxy_remote);
+    gbinder_remote_object_unref(remote_obj);
+    gbinder_ipc_unref(ipc_obj);
+    gbinder_ipc_unref(ipc_proxy);
+    test_binder_exit_wait(&test_opt, NULL);
+}
+
+static
+void
+test_interface(
+    void)
+{
+    test_run_in_context(&test_opt, test_interface_run);
 }
 
 /*==========================================================================*
@@ -619,6 +818,8 @@ int main(int argc, char* argv[])
     g_test_init(&argc, &argv, NULL);
     g_test_add_func(TEST_("null"), test_null);
     g_test_add_func(TEST_("basic"), test_basic);
+    g_test_add_func(TEST_("empty_reply"), test_empty_reply);
+    g_test_add_func(TEST_("interface"), test_interface);
     g_test_add_func(TEST_("param"), test_param);
     g_test_add_func(TEST_("obj"), test_obj);
 

--- a/unit/unit_proxy_object/unit_proxy_object.c
+++ b/unit/unit_proxy_object/unit_proxy_object.c
@@ -925,6 +925,7 @@ test_nested_register_cb(
 
     gbinder_remote_request_init_reader(req, &reader);
     g_assert((test->accessor = gbinder_reader_read_object(&reader)));
+    /* Default system stability plus outer vendor stability requires VINTF. */
     g_assert_cmpint(test->accessor->stability, == ,GBINDER_STABILITY_VINTF);
     g_assert(gbinder_reader_at_end(&reader));
 
@@ -993,10 +994,10 @@ test_nested_sync_run(
     remote_obj = gbinder_remote_object_new(ipc_obj,
         test_binder_register_object(fd_obj, obj, AUTO_HANDLE),
         REMOTE_OBJECT_CREATE_ALIVE);
-    remote_obj->stability = GBINDER_STABILITY_VINTF;
+    remote_obj->stability = GBINDER_STABILITY_VENDOR;
 
     g_assert((proxy = gbinder_proxy_object_new(ipc_proxy, remote_obj)));
-    g_assert_cmpint(proxy->parent.stability, == ,GBINDER_STABILITY_VINTF);
+    g_assert_cmpint(proxy->parent.stability, == ,GBINDER_STABILITY_VENDOR);
     proxy_remote = gbinder_remote_object_new(ipc_proxy,
         test_binder_register_object(fd_proxy, &proxy->parent, AUTO_HANDLE),
         REMOTE_OBJECT_CREATE_ALIVE);

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -2367,6 +2367,38 @@ test_object_invalid(
     test_binder_exit_wait(&test_opt, NULL);
 }
 
+static
+void
+test_object_truncated_aidl(
+    void)
+{
+    /* AIDL3 requires a 4-byte stability trailer after flat_binder_object. */
+    static const guint8 input[] = { TEST_BINDER_OBJECT_64(1) };
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_BINDER, "aidl3");
+    GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
+        g_memdup(input, sizeof(input)), sizeof(input), NULL);
+    GBinderRemoteObject* obj = NULL;
+    GBinderReaderData data;
+    GBinderReader reader;
+
+    g_assert(ipc);
+    memset(&data, 0, sizeof(data));
+    data.buffer = buf;
+    data.reg = gbinder_ipc_object_registry(ipc);
+    data.objects = g_new(void*, 2);
+    data.objects[0] = buf->data;
+    data.objects[1] = NULL;
+    gbinder_reader_init(&reader, &data, 0, buf->size);
+
+    g_assert(!gbinder_reader_read_nullable_object(&reader, &obj));
+    g_assert(!obj);
+
+    g_free(data.objects);
+    gbinder_buffer_free(buf);
+    gbinder_ipc_unref(ipc);
+    test_binder_exit_wait(&test_opt, NULL);
+}
+
 /*==========================================================================*
  * vec
  *==========================================================================*/
@@ -2966,6 +2998,7 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("parcelable/2"), test_parcelable2);
     g_test_add_func(TEST_("object/valid"), test_object);
     g_test_add_func(TEST_("object/invalid"), test_object_invalid);
+    g_test_add_func(TEST_("object/truncated_aidl"), test_object_truncated_aidl);
     g_test_add_func(TEST_("object/no_reg"), test_object_no_reg);
     g_test_add_func(TEST_("vec"), test_vec);
     g_test_add_func(TEST_("hidl_string_vec/1"), test_hidl_string_vec1);

--- a/unit/unit_remote_request/unit_remote_request.c
+++ b/unit/unit_remote_request/unit_remote_request.c
@@ -325,8 +325,13 @@ test_to_local(
     g_assert(!memcmp(request_data, bytes->data, bytes->len));
     gbinder_local_request_unref(req2);
 
+    memset(&convert, 0, sizeof(convert));
+    convert.f = &convert_f;
+    convert.io = gbinder_driver_io(driver);
+    convert.protocol = gbinder_driver_protocol(driver);
+
     /* The same with gbinder_remote_request_translate_to_local() */
-    req2 = gbinder_remote_request_convert_to_local(req, NULL);
+    req2 = gbinder_remote_request_convert_to_local(req, &convert);
     data = gbinder_local_request_data(req2);
     offsets = gbinder_output_data_offsets(data);
     bytes = data->bytes;
@@ -338,11 +343,12 @@ test_to_local(
     g_assert(!memcmp(request_data, bytes->data, bytes->len));
     gbinder_local_request_unref(req2);
 
-    /* Different driver actually requires translation */
     memset(&convert, 0, sizeof(convert));
     convert.f = &convert_f;
     convert.io = gbinder_driver_io(driver2);
     convert.protocol = gbinder_driver_protocol(driver2);
+
+    /* Different driver actually requires translation */
     req2 = gbinder_remote_request_convert_to_local(req, &convert);
     data = gbinder_local_request_data(req2);
     offsets = gbinder_output_data_offsets(data);
@@ -353,6 +359,17 @@ test_to_local(
     g_assert(!gbinder_output_data_buffers_size(data));
     g_assert(bytes->len == sizeof(request_data_hidl));
     g_assert(!memcmp(request_data_hidl, bytes->data, bytes->len));
+    gbinder_local_request_unref(req2);
+
+    gbinder_remote_request_unref(req);
+    req = gbinder_remote_request_new(NULL, gbinder_rpc_protocol_for_device(dev),
+        0, 0);
+    req2 = gbinder_remote_request_convert_to_local(req, &convert);
+    data = gbinder_local_request_data(req2);
+    bytes = data->bytes;
+    g_assert(!gbinder_output_data_offsets(data));
+    g_assert(!gbinder_output_data_buffers_size(data));
+    g_assert(!bytes->len);
     gbinder_local_request_unref(req2);
 
     gbinder_remote_request_unref(req);


### PR DESCRIPTION
Stable-AIDL HAL proxying exposes a few behaviours that libgbinder did not handle correctly:

1. Passing a binder object can trigger a synchronous interface query back through the proxy while the original transaction is still being handled.
2. Some AIDL transactions, such as those interface queries, can have an empty or null payload.
3. AIDL binder objects carry stability metadata that must be preserved when objects are forwarded through a proxy.

This PR fixes those cases by handling bufferless requests, forwarding direct synchronous proxy transactions correctly, and preserving AIDL stability metadata.

With these fixes, I can proxy an AIDL camera HAL service without crashing.