### PR TITLE
More API to read parcelables

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -1,8 +1,7 @@
 /*
- * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
- *
- * You may use this file under the terms of BSD license as follows:
+ * Copyright (C) 2018-2022 Jolla Ltd.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -146,6 +145,12 @@ const void*
 gbinder_reader_read_parcelable(
     GBinderReader* reader,
     gsize* size); /* Since 1.1.19 */
+
+const void*
+gbinder_reader_read_parcelable2(
+    GBinderReader* reader,
+    gsize* size,
+    gboolean* ok); /* Since 1.1.48 */
 
 const void*
 gbinder_reader_read_hidl_struct1(

--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -152,6 +152,16 @@ gbinder_reader_read_parcelable2(
     gsize* size,
     gboolean* ok); /* Since 1.1.48 */
 
+gboolean
+gbinder_reader_start_parcelable(
+    GBinderReader* reader,
+    GBinderReader* parcelable,
+    gboolean* non_null); /* Since 1.1.48 */
+
+void
+gbinder_reader_finish_parcelable(
+    GBinderReader* parcelable); /* Since 1.1.48 */
+
 const void*
 gbinder_reader_read_hidl_struct1(
     GBinderReader* reader,

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -40,12 +40,45 @@
 #include <errno.h>
 #include <fcntl.h>
 
+/*
+ * GBINDER_READER_FLAG_HAS_PARENT flag means that the objects field
+ * actually points to the top-most GBinderReader's objects pointer,
+ * not to GBinderReaderData's objects area. That way, all nested
+ * readers would share the same objects pointer and that pointer
+ * can be correctly updated even if objects are read by the child
+ * (parcelable) reader.
+ *
+ * +-------+-------+-----+-------+
+ * | obj_1 | obj_2 | ... | obj_n | tx objects
+ * +-------+-------+-----+-------+
+ *            ^
+ *            |
+ *      +-----+
+ *      |
+ * +---------+
+ * | objects | Top level GBinderReader
+ * +---------+
+ *      ^
+ *      |    +---------+
+ *      +----| objects | GBinderReader with a parent
+ *      |    +---------+
+ *      |
+ *      |    +---------+
+ *      +----| objects | GBinderReader with a parent
+ *           +---------+
+ */
+typedef enum gbinder_reader_flags {
+    GBINDER_READER_FLAG_NONE = 0,
+    GBINDER_READER_FLAG_HAS_PARENT = 0x1,
+} GBINDER_READER_FLAGS;
+
 typedef struct gbinder_reader_priv {
     const guint8* start;
     const guint8* end;
     const guint8* ptr;
     const GBinderReaderData* data;
     void** objects;
+    GBINDER_READER_FLAGS flags;
 } GBinderReaderPriv;
 
 G_STATIC_ASSERT(sizeof(GBinderReader) >= sizeof(GBinderReaderPriv));
@@ -55,16 +88,19 @@ static inline GBinderReaderPriv* gbinder_reader_cast(GBinderReader* reader)
 static inline const GBinderReaderPriv* gbinder_reader_cast_c
     (const GBinderReader* reader)  { return (GBinderReaderPriv*)reader; }
 
+static
 void
-gbinder_reader_init(
+gbinder_reader_init2(
     GBinderReader* reader,
-    GBinderReaderData* data,
+    const GBinderReaderData* data,
     gsize offset,
-    gsize len)
+    gsize len,
+    void*** parent_objects)
 {
     GBinderReaderPriv* p = gbinder_reader_cast(reader);
 
     p->data = data;
+    p->flags = GBINDER_READER_FLAG_NONE;
     if (G_LIKELY(data)) {
         GBinderBuffer* buffer = data->buffer;
 
@@ -76,11 +112,27 @@ gbinder_reader_init(
         } else {
             p->ptr = p->start = p->end = NULL;
         }
-        p->objects = data->objects;
+
+        if (parent_objects) {
+            p->objects = (void**)parent_objects;
+            p->flags |= GBINDER_READER_FLAG_HAS_PARENT;
+        } else {
+            p->objects = data->objects;
+        }
     } else {
         p->ptr = p->start = p->end = NULL;
         p->objects = NULL;
     }
+}
+
+void
+gbinder_reader_init(
+    GBinderReader* reader,
+    GBinderReaderData* data,
+    gsize offset,
+    gsize len)
+{
+    gbinder_reader_init2(reader, data, offset, len, NULL);
 }
 
 gboolean
@@ -302,9 +354,36 @@ gbinder_reader_can_read_object(
 {
     const GBinderReaderData* data = p->data;
 
-    return data && data->reg &&
-        p->objects && p->objects[0] &&
-        p->ptr == p->objects[0];
+    if (data && data->reg) {
+        void** objs = (p->flags & GBINDER_READER_FLAG_HAS_PARENT) ?
+            (*((void***)p->objects)) : p->objects;
+
+        if (objs && objs[0] == p->ptr) {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+static
+inline
+gboolean
+gbinder_reader_consume_object(
+    GBinderReaderPriv* p,
+    gsize size)
+{
+    if (size) {
+        p->ptr += size;
+        if (p->flags & GBINDER_READER_FLAG_HAS_PARENT) {
+            /* Increment the top reader's obj pointer */
+            (*((void***)p->objects))++;
+        } else {
+            /* We are the top reader */
+            p->objects++;
+        }
+        return TRUE;
+    }
+    return FALSE;
 }
 
 int
@@ -314,14 +393,12 @@ gbinder_reader_read_fd(
     GBinderReaderPriv* p = gbinder_reader_cast(reader);
 
     if (gbinder_reader_can_read_object(p)) {
-        int fd;
-        const guint eaten = p->data->reg->io->decode_fd_object(p->ptr,
-            gbinder_reader_bytes_remaining(reader), &fd);
+        const gsize size = gbinder_reader_bytes_remaining(reader);
+        int fd = -1;
 
-        if (eaten) {
+        if (gbinder_reader_consume_object(p, p->data->reg->io->
+            decode_fd_object(p->ptr, size, &fd))) {
             GASSERT(fd >= 0);
-            p->ptr += eaten;
-            p->objects++;
             return fd;
         }
     }
@@ -355,13 +432,11 @@ gbinder_reader_read_nullable_object(
 
     if (gbinder_reader_can_read_object(p)) {
         const GBinderReaderData* data = p->data;
-        const guint eaten = data->reg->io->decode_binder_object(p->ptr,
-            gbinder_reader_bytes_remaining(reader), data->reg, out,
-            gbinder_buffer_protocol(data->buffer));
+        const GBinderRpcProtocol* rpc = gbinder_buffer_protocol(data->buffer);
+        const gsize size = gbinder_reader_bytes_remaining(reader);
 
-        if (eaten) {
-            p->ptr += eaten;
-            p->objects++;
+        if (gbinder_reader_consume_object(p, data->reg->io->
+            decode_binder_object(p->ptr,size, data->reg, out, rpc))) {
             return TRUE;
         }
     }
@@ -390,13 +465,10 @@ gbinder_reader_read_buffer_object(
     if (gbinder_reader_can_read_object(p)) {
         const GBinderReaderData* data = p->data;
         GBinderBuffer* buf = data->buffer;
-        const GBinderIo* io = data->reg->io;
         const gsize offset = p->ptr - (guint8*)buf->data;
-        const guint eaten = io->decode_buffer_object(buf, offset, out);
 
-        if (eaten) {
-            p->ptr += eaten;
-            p->objects++;
+        if (gbinder_reader_consume_object(p, data->reg->io->
+            decode_buffer_object(buf, offset, out))) {
             return TRUE;
         }
     }
@@ -489,6 +561,77 @@ gbinder_reader_read_parcelable2(
         *ok = FALSE;
     }
     return NULL;
+}
+
+gboolean
+gbinder_reader_start_parcelable(
+    GBinderReader* reader,
+    GBinderReader* parcelable,
+    gboolean* non_null) /* Since 1.1.48 */
+{
+    gsize size;
+    gboolean ok;
+    const guint8* ptr = gbinder_reader_read_parcelable2(reader, &size, &ok);
+
+    /*
+     * gbinder_reader_finish_parcelable() should be invoked on every
+     * parcelable reader initialized by this function. It's especially
+     * important (if not to say mandatory) if the parcelable contains
+     * binder objects.
+     */
+    if (ok) {
+        if (ptr) {
+            GBinderReaderPriv* p = gbinder_reader_cast(reader);
+            const GBinderReaderData* data = p->data;
+
+            gbinder_reader_init2(parcelable, data,
+                (ptr - (guint8*)data->buffer->data), size,
+                (p->flags & GBINDER_READER_FLAG_HAS_PARENT) ?
+                (void***)p->objects : &p->objects);
+        } else {
+            /* NULL parcelable (with a parent) */
+            gbinder_reader_init(parcelable, NULL, 0, 0);
+            gbinder_reader_cast(parcelable)->flags |=
+                GBINDER_READER_FLAG_HAS_PARENT;
+        }
+    } else {
+        memset(parcelable, 0, sizeof(*parcelable));
+    }
+
+    if (non_null) {
+        *non_null = ptr != NULL;
+    }
+    return ok;
+}
+
+void
+gbinder_reader_finish_parcelable(
+    GBinderReader* parcelable) /* Since 1.1.48 */
+{
+    GBinderReaderPriv* p = gbinder_reader_cast(parcelable);
+
+    /*
+     * The reader must be created by gbinder_reader_start_parcelable()
+     * and have a parent but let's check it anyway.
+     */
+    if (p->flags & GBINDER_READER_FLAG_HAS_PARENT) {
+        /*
+         * If the remaining (unread) part of the parcelable contains binder
+         * objects we must "consume" those objects or else the parent reader
+         * won't be able to read any more objects.
+         */
+        if (p->objects) {
+            guint8*** objs = (guint8***)p->objects;
+
+            if (*objs) {
+                while ((*objs)[0] > p->start && (*objs)[0] < p->end) {
+                    (*objs)++;
+                }
+            }
+        }
+    } else {
+        GWARN("Invalid reader passed to gbinder_reader_finish_parcelable");
+    }
 }
 
 /* Helper for gbinder_reader_read_hidl_struct() macro */

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -1,8 +1,7 @@
 /*
- * Copyright (C) 2018-2024 Jolla Ltd.
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
- *
- * You may use this file under the terms of BSD license as follows:
+ * Copyright (C) 2018-2024 Jolla Ltd.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -426,36 +425,68 @@ gbinder_reader_skip_buffer(
     return gbinder_reader_read_buffer_object(reader, NULL);
 }
 
-/*
- * This is supposed to be used to read aidl parcelables, and is not
- * guaranteed to work on any other kind of parcelable.
- */
+/* AIDL Parcelable */
 const void*
 gbinder_reader_read_parcelable(
     GBinderReader* reader,
     gsize* size) /* Since 1.1.19 */
 {
-    guint32 non_null, payload_size = 0;
+    /*
+     * Use gbinder_reader_read_parcelable2 if you need to distinguish a failure
+     * to read a parcelable from a successfully read NULL parcelable.
+     */
+    return gbinder_reader_read_parcelable2(reader, size, NULL);
+}
 
-    if (gbinder_reader_read_uint32(reader, &non_null) && non_null &&
-        gbinder_reader_read_uint32(reader, &payload_size) &&
-        payload_size >= sizeof(payload_size)) {
-        GBinderReaderPriv* p = gbinder_reader_cast(reader);
+const void*
+gbinder_reader_read_parcelable2(
+    GBinderReader* reader,
+    gsize* size,
+    gboolean* ok) /* Since 1.1.48 */
+{
+    GBinderReaderPriv* p = gbinder_reader_cast(reader);
+    const guint8* saved_ptr = p->ptr;
+    guint32 flag;
 
-        payload_size -= sizeof(payload_size);
-        if (p->ptr + payload_size <= p->end) {
-            const void* out = p->ptr;
-
-            /* Success */
-            p->ptr += payload_size;
+    if (gbinder_reader_read_uint32(reader, &flag)) {
+        if (flag == kNullParcelableFlag) {
             if (size) {
-                *size = payload_size;
+                *size = 0;
             }
-            return out;
+            if (ok) {
+                *ok = TRUE;
+            }
+            return NULL;
+        } else {
+            guint32 payload_size;
+
+            if (gbinder_reader_read_uint32(reader, &payload_size) &&
+                payload_size >= sizeof(payload_size)) {
+                payload_size -= sizeof(payload_size);
+                if (p->ptr + payload_size <= p->end) {
+                    const void* out = p->ptr;
+
+                    /* Non-NULL parcelable */
+                    p->ptr += payload_size;
+                    if (size) {
+                        *size = payload_size;
+                    }
+                    if (ok) {
+                        *ok = TRUE;
+                    }
+                    return out;
+                }
+            }
         }
     }
+
+    /* Restore the state on failure */
+    p->ptr = saved_ptr;
     if (size) {
         *size = 0;
+    }
+    if (ok) {
+        *ok = FALSE;
     }
     return NULL;
 }

--- a/src/gbinder_types_p.h
+++ b/src/gbinder_types_p.h
@@ -1,8 +1,7 @@
 /*
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2022 Jolla Ltd.
  * Copyright (C) 2018-2022 Slava Monich <slava.monich@jolla.com>
- *
- * You may use this file under the terms of BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,6 +75,10 @@ typedef struct gbinder_ipc_sync_api GBinderIpcSyncApi;
 
 /* As a special case, ServiceManager's handle is zero */
 #define GBINDER_SERVICEMANAGER_HANDLE (0)
+
+/* Parcelable flags */
+#define kNullParcelableFlag (0)
+#define kNonNullParcelableFlag (1)
 
 #endif /* GBINDER_TYPES_PRIVATE_H */
 

--- a/src/gbinder_writer.c
+++ b/src/gbinder_writer.c
@@ -1,9 +1,7 @@
 /*
+ * Copyright (C) 2025-2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2026 Slava Monich <slava@monich.com>
- * Copyright (C) 2025 Jolla Mobile Ltd.
  * Copyright (C) 2018-2024 Jolla Ltd.
- *
- * You may use this file under the terms of the BSD license as follows:
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,9 +52,6 @@ typedef struct gbinder_writer_priv {
     GBinderWriterData* data;
     guint offset;
 } GBinderWriterPriv;
-
-#define kNullParcelableFlag (0)
-#define kNonNullParcelableFlag (1)
 
 const GBinderWriterType gbinder_writer_type_byte = { "byte", 1, NULL };
 const GBinderWriterType gbinder_writer_type_int32 = { "int32", 4, NULL };

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -1,8 +1,7 @@
 /*
- * Copyright (C) 2018-2022 Jolla Ltd.
+ * Copyright (C) 2026 Jolla Mobile Ltd
  * Copyright (C) 2018-2024 Slava Monich <slava@monich.com>
- *
- * You may use this file under the terms of BSD license as follows:
+ * Copyright (C) 2018-2022 Jolla Ltd.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -1874,14 +1873,14 @@ test_parcelable(
     void)
 {
     const guint8 input_null_header[] = {
-        TEST_INT32_BYTES(0)
+        TEST_INT32_BYTES(kNullParcelableFlag)
     };
     const guint8 input_broken_header[] = {
-        TEST_INT32_BYTES(1),
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
         TEST_INT32_BYTES(1)
     };
     const guint8 input_non_null_header[] = {
-        TEST_INT32_BYTES(1),
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
         /* Size must be size of itself + payload */
         TEST_INT32_BYTES(sizeof(gint32) * 3)
     };
@@ -1890,8 +1889,9 @@ test_parcelable(
         TEST_INT32_BYTES(20)
     };
     gpointer in;
+    gboolean ok;
     gsize in_size, out_size;
-    const void* out = 0;
+    const void* out;
     GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
     GBinderReader reader;
     GBinderReaderData data;
@@ -1902,33 +1902,52 @@ test_parcelable(
     /* Missing payload */
     test_init_reader(driver, &data, &reader,
         TEST_ARRAY_AND_SIZE(input_non_null_header));
-    out = gbinder_reader_read_parcelable(&reader, &out_size);
-    g_assert(!out);
+    out_size = 1;
+    ok = TRUE;
+    g_assert_null(gbinder_reader_read_parcelable(&reader, &out_size));
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, &out_size, &ok));
+    g_assert_cmpuint(gbinder_reader_bytes_read(&reader), == ,0);
     g_assert_cmpuint(out_size, == ,0);
+    g_assert_false(ok);
     gbinder_buffer_free(data.buffer);
 
     /* Broken headers */
     test_init_reader(driver, &data, &reader, input_broken_header, 4);
-    out = gbinder_reader_read_parcelable(&reader, &out_size);
-    g_assert(!out);
+    out_size = 1;
+    ok = TRUE;
+    g_assert_null(gbinder_reader_read_parcelable(&reader, &out_size));
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, &out_size, &ok));
+    g_assert_cmpuint(gbinder_reader_bytes_read(&reader), == ,0);
     g_assert_cmpuint(out_size, == ,0);
+    g_assert_false(ok);
     gbinder_buffer_free(data.buffer);
 
     test_init_reader(driver, &data, &reader,
         TEST_ARRAY_AND_SIZE(input_broken_header));
-    out = gbinder_reader_read_parcelable(&reader, &out_size);
-    g_assert(!out);
+    out_size = 1;
+    ok = TRUE;
+    g_assert_null(gbinder_reader_read_parcelable(&reader, &out_size));
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, &out_size, &ok));
+    g_assert_cmpuint(gbinder_reader_bytes_read(&reader), == ,0);
     g_assert_cmpuint(out_size, == ,0);
+    g_assert_false(ok);
     gbinder_buffer_free(data.buffer);
 
     /* Null */
     test_init_reader(driver, &data, &reader,
         TEST_ARRAY_AND_SIZE(input_null_header));
     gbinder_reader_init(&reader, &data, 0, sizeof(input_null_header));
-    out = gbinder_reader_read_parcelable(&reader, &out_size);
-    g_assert(!out);
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, NULL, NULL));
+    g_assert_cmpuint(gbinder_reader_bytes_read(&reader), > ,0);
+    g_assert_true(gbinder_reader_at_end(&reader));
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(input_null_header));
+    out_size = 1;
+    ok = FALSE;
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, &out_size, &ok));
+    g_assert_true(gbinder_reader_at_end(&reader));
     g_assert_cmpuint(out_size, == ,0);
-    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_true(ok);
     gbinder_buffer_free(data.buffer);
 
     /* Non-null */
@@ -1940,11 +1959,13 @@ test_parcelable(
     data.buffer = gbinder_buffer_new(driver, in, in_size, NULL);
 
     gbinder_reader_init(&reader, &data, 0, in_size);
-    out = gbinder_reader_read_parcelable(&reader, &out_size);
-    g_assert(memcmp(&input_non_null_payload, out,
-        sizeof(input_non_null_payload)) == 0);
-    g_assert_cmpuint(out_size, == ,sizeof(input_non_null_payload));
-    g_assert(gbinder_reader_at_end(&reader));
+    out_size = 0;
+    ok = FALSE;
+    out = gbinder_reader_read_parcelable2(&reader, &out_size, &ok);
+    g_assert_true(ok);
+    g_assert_cmpmem(&input_non_null_payload, sizeof(input_non_null_payload),
+        out, out_size);
+    g_assert_true(gbinder_reader_at_end(&reader));
 
     /* And verify NULL tolerance for the size parameter */
     gbinder_reader_init(&reader, &data, 0, in_size);

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -64,6 +64,11 @@ typedef struct binder_buffer_object_64 {
 #define BINDER_FLAG_ACCEPTS_FDS 0x100
 G_STATIC_ASSERT(sizeof(BinderObject64) == BUFFER_OBJECT_SIZE_64);
 
+#define TEST_BINDER_OBJECT_64(handle) \
+    TEST_INT32_BYTES(BINDER_TYPE_HANDLE), TEST_INT32_BYTES(0 /* flags */), \
+    TEST_INT32_BYTES(handle), TEST_INT32_BYTES(0 /* padding */), \
+    TEST_INT64_BYTES(0 /* cookie */ )
+
 static
 void
 test_init_reader(
@@ -108,7 +113,7 @@ void
 test_empty(
     void)
 {
-    GBinderReader reader;
+    GBinderReader reader, parcelable;
     gsize count = 1, elemsize = 1;
     gsize size = 1;
 
@@ -148,6 +153,14 @@ test_empty(
     g_assert(!gbinder_reader_read_string16(&reader));
     g_assert(!gbinder_reader_skip_string16(&reader));
     g_assert(!gbinder_reader_read_byte_array(&reader, &size));
+    /*
+     * gbinder_reader_start_parcelable() fails but still initializes
+     * the parcelable reading, which isn't suitable for passing to
+     * gbinder_reader_finish_parcelable, but it's handled more or less
+     * gracefully (with a warning being printed to the console)
+     */
+    g_assert(!gbinder_reader_start_parcelable(&reader, &parcelable, NULL));
+    gbinder_reader_finish_parcelable(&parcelable);
 }
 
 /*==========================================================================*
@@ -1824,9 +1837,7 @@ test_buffer(
         TEST_INT64_BYTES((uintptr_t)&data2), TEST_INT64_BYTES(sizeof(data2)),
         TEST_INT64_BYTES(0), TEST_INT64_BYTES(0),
         /* Not a buffer object */
-        TEST_INT32_BYTES(BINDER_TYPE_HANDLE), TEST_INT32_BYTES(0),
-        TEST_INT64_BYTES(0), TEST_INT64_BYTES(0),
-        TEST_INT64_BYTES(0), TEST_INT64_BYTES(0)
+        TEST_BINDER_OBJECT_64(0)
     };
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
@@ -1869,7 +1880,7 @@ test_buffer(
 
 static
 void
-test_parcelable(
+test_parcelable1(
     void)
 {
     const guint8 input_null_header[] = {
@@ -1889,12 +1900,13 @@ test_parcelable(
         TEST_INT32_BYTES(20)
     };
     gpointer in;
-    gboolean ok;
+    gboolean ok, non_null;
     gsize in_size, out_size;
     const void* out;
     GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
-    GBinderReader reader;
+    GBinderReader reader, p;
     GBinderReaderData data;
+    gint32 value[2];
 
     g_assert(driver);
     memset(&data, 0, sizeof(data));
@@ -1948,6 +1960,14 @@ test_parcelable(
     g_assert_true(gbinder_reader_at_end(&reader));
     g_assert_cmpuint(out_size, == ,0);
     g_assert_true(ok);
+
+    gbinder_reader_init(&reader, &data, 0, sizeof(input_null_header));
+    non_null = TRUE;
+    g_assert_true(gbinder_reader_start_parcelable(&reader, &p, &non_null));
+    g_assert_false(non_null);
+    g_assert(gbinder_reader_at_end(&reader));
+    g_assert(gbinder_reader_at_end(&p));
+    gbinder_reader_finish_parcelable(&p);
     gbinder_buffer_free(data.buffer);
 
     /* Non-null */
@@ -1973,8 +1993,150 @@ test_parcelable(
     g_assert(memcmp(&input_non_null_payload, out,
         sizeof(input_non_null_payload)) == 0);
 
+    /* Test the nested reader */
+    gbinder_reader_init(&reader, &data, 0, in_size);
+    non_null = FALSE;
+    g_assert_true(gbinder_reader_start_parcelable(&reader, &p, &non_null));
+    g_assert_true(non_null);
+    g_assert(gbinder_reader_at_end(&reader));
+
+    memset(value, 0, sizeof(value));
+    g_assert(gbinder_reader_read_int32(&p, value));
+    g_assert(gbinder_reader_read_int32(&p, value + 1));
+    g_assert(gbinder_reader_at_end(&p));
+    g_assert_cmpuint(value[0], == ,10);
+    g_assert_cmpuint(value[1], == ,20);
+    gbinder_reader_finish_parcelable(&p);
+
     gbinder_buffer_free(data.buffer);
     gbinder_driver_unref(driver);
+}
+
+static
+void
+test_parcelable2(
+    void)
+{
+    /* Using 64-bit I/O */
+    const guint8 input[] = {
+        /* Parcelable #1 */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         8 /* parcelable #2 header */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #1 */ +
+                         8 /* parcelable #3 header */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #2 */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #3 */),
+
+        /* Parcelable #2 */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #1 */ +
+                         8 /* parcelable #3 header */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #2 */),
+        TEST_BINDER_OBJECT_64(1), /* Binder object #1 */
+
+        /* Parcelable #3 */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         BINDER_OBJECT_SIZE_64 /* binder object #2 */),
+        TEST_BINDER_OBJECT_64(2), /* Binder object #2 */
+        /* End of parcelable #3 */
+        /* End of parcelable #2 */
+
+        TEST_BINDER_OBJECT_64(3), /* Binder object #3 */
+        /* End of parcelable #1 */
+
+        TEST_INT32_BYTES(42),
+        TEST_BINDER_OBJECT_64(4), /* Binder object #4 */
+
+        /* Parcelable #4 */
+        TEST_INT32_BYTES(kNullParcelableFlag)
+    };
+    const gsize object1_offset =
+        8 /* parcelable #1 header */ +
+        8 /* parcelable #2 header */;
+    const gsize object2_offset = object1_offset +
+        BINDER_OBJECT_SIZE_64 /* binder object #1 */ +
+        8 /* parcelable #3 header */;
+    const gsize object3_offset = object2_offset +
+        BINDER_OBJECT_SIZE_64 /* binder object #2 */;
+    const gsize object4_offset = object3_offset +
+        4 /* int32 */ +
+        BINDER_OBJECT_SIZE_64 /* binder object #2 */;
+    GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
+    GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
+        g_memdup(input, sizeof(input)), sizeof(input), NULL);
+    GBinderRemoteObject* obj = NULL;
+    GBinderReaderData data;
+    GBinderReader reader, p1, p2, p3;
+    gboolean ok, non_null;
+    guint32 val;
+
+    g_assert(ipc);
+    memset(&data, 0, sizeof(data));
+    data.buffer = buf;
+    data.reg = gbinder_ipc_object_registry(ipc);
+    data.objects = g_new(void*, 5);
+    data.objects[0] = buf->data + object1_offset;
+    data.objects[1] = buf->data + object2_offset;
+    data.objects[2] = buf->data + object3_offset;
+    data.objects[3] = buf->data + object4_offset;
+    data.objects[4] = NULL;
+    gbinder_reader_init(&reader, &data, 0, buf->size);
+
+    /* Nested reader for parcelable #1 */
+    non_null = FALSE;
+    g_assert_true(gbinder_reader_start_parcelable(&reader, &p1, &non_null));
+    g_assert_true(non_null);
+
+    /* Nested reader for parcelable #2 */
+    non_null = FALSE;
+    g_assert_true(gbinder_reader_start_parcelable(&p1, &p2, &non_null));
+    g_assert_true(non_null);
+
+    /* Read binder object #1 from parcelable #2 */
+    g_assert_true(gbinder_reader_read_nullable_object(&p2, &obj));
+    g_assert_nonnull(obj);
+    g_assert_cmpuint(obj->handle, == ,1);
+    gbinder_remote_object_unref(obj);
+
+    /* Nested reader for parcelable #3 */
+    non_null = FALSE;
+    g_assert_true(gbinder_reader_start_parcelable(&p2, &p3, &non_null));
+    g_assert_true(non_null);
+    g_assert_false(gbinder_reader_at_end(&p3));
+    /* Skip binder object #2 */
+    gbinder_reader_finish_parcelable(&p3); /* done with parcelable #3 */
+    gbinder_reader_finish_parcelable(&p2); /* done with parcelable #2 */
+
+    /* Read binder object #3 from parcelable #1 */
+    g_assert_true(gbinder_reader_read_nullable_object(&p1, &obj));
+    g_assert_nonnull(obj);
+    g_assert_cmpuint(obj->handle, == ,3);
+    gbinder_remote_object_unref(obj);
+    gbinder_reader_finish_parcelable(&p1); /* done with parcelable #1 */
+
+    /* Read the remaining data from the top level reader */
+    val = 0;
+    g_assert_true(gbinder_reader_read_uint32(&reader, &val));
+    g_assert_cmpuint(val, == ,42);
+
+    g_assert_true(gbinder_reader_read_nullable_object(&reader, &obj));
+    g_assert_nonnull(obj);
+    g_assert_cmpuint(obj->handle, == ,4);
+    gbinder_remote_object_unref(obj);
+
+    g_assert_null(gbinder_reader_read_parcelable2(&reader, NULL, &ok));
+    g_assert_true(ok);
+
+    /* Now we must have reached the end */
+    g_assert_true(gbinder_reader_at_end(&reader));
+
+    gbinder_buffer_free(buf);
+    gbinder_ipc_unref(ipc);
+    g_free(data.objects);
+    test_binder_exit_wait(&test_opt, NULL);
 }
 
 /*==========================================================================*
@@ -1987,11 +2149,7 @@ test_object(
     void)
 {
     /* Using 64-bit I/O */
-    static const guint8 input[] = {
-        TEST_INT32_BYTES(BINDER_TYPE_HANDLE), TEST_INT32_BYTES(0),
-        TEST_INT32_BYTES(1 /* handle*/), TEST_INT32_BYTES(0),
-        TEST_INT64_BYTES(0)
-    };
+    static const guint8 input[] = { TEST_BINDER_OBJECT_64(1) };
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
@@ -2671,7 +2829,8 @@ int main(int argc, char* argv[])
     g_test_add_func(TEST_("hidl_string/6"), test_hidl_string6);
     g_test_add_func(TEST_("hidl_string/7"), test_hidl_string7);
     g_test_add_func(TEST_("buffer"), test_buffer);
-    g_test_add_func(TEST_("parcelable"), test_parcelable);
+    g_test_add_func(TEST_("parcelable/1"), test_parcelable1);
+    g_test_add_func(TEST_("parcelable/2"), test_parcelable2);
     g_test_add_func(TEST_("object/valid"), test_object);
     g_test_add_func(TEST_("object/invalid"), test_object_invalid);
     g_test_add_func(TEST_("object/no_reg"), test_object_no_reg);


### PR DESCRIPTION
**gbinder_reader_read_parcelable2()** allows to distinguish a failure to read a parcelable  from a successfully read NULL parcelable.
**gbinder_reader_start_parcelable()** allows to use GBinderReader API to  parse the contents of the parcelable.
**gbinder_reader_finish_parcelable()** completes reading of the parcelable