### PR TITLE
Prohibit further reads from finished parcelables

### DIFF
--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -629,6 +629,9 @@ gbinder_reader_finish_parcelable(
                 }
             }
         }
+
+        /* No more reads from this reader */
+        p->ptr = p->end;
     } else {
         GWARN("Invalid reader passed to gbinder_reader_finish_parcelable");
     }

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -2109,6 +2109,8 @@ test_parcelable2(
     /* Skip binder object #2 */
     gbinder_reader_finish_parcelable(&p3); /* done with parcelable #3 */
     gbinder_reader_finish_parcelable(&p2); /* done with parcelable #2 */
+    g_assert_true(gbinder_reader_at_end(&p3));
+    g_assert_true(gbinder_reader_at_end(&p2));
 
     /* Read binder object #3 from parcelable #1 */
     g_assert_true(gbinder_reader_read_nullable_object(&p1, &obj));


### PR DESCRIPTION
Since `gbinder_reader_finish_parcelable()` skips the unread objects, it makes sense to skip the unread data too.

Even though reading after finish would be a programming error, this adds some extra protection against reading something you didn't intend to read.