### PR TITLE
Add gbinder_reader_skip_parcelable()

### DIFF
--- a/include/gbinder_reader.h
+++ b/include/gbinder_reader.h
@@ -162,6 +162,10 @@ void
 gbinder_reader_finish_parcelable(
     GBinderReader* parcelable); /* Since 1.1.48 */
 
+gboolean
+gbinder_reader_skip_parcelable(
+    GBinderReader* reader); /* Since 1.1.49 */
+
 const void*
 gbinder_reader_read_hidl_struct1(
     GBinderReader* reader,

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -498,6 +498,44 @@ gbinder_reader_skip_buffer(
 }
 
 /* AIDL Parcelable */
+
+static
+gboolean
+gbinder_reader_read_parcelable_header(
+    GBinderReader* reader,
+    guint32* size,
+    gboolean* nullp)
+{
+    GBinderReaderPriv* p = gbinder_reader_cast(reader);
+    const guint8* saved_ptr = p->ptr;
+    guint32 flag;
+
+    if (gbinder_reader_read_uint32(reader, &flag)) {
+        if (flag == kNullParcelableFlag) {
+            *size = 0;
+            *nullp = TRUE;
+            return TRUE;
+        } else {
+            guint32 payload_size;
+
+            if (gbinder_reader_read_uint32(reader, &payload_size) &&
+                payload_size >= sizeof(payload_size)) {
+                payload_size -= sizeof(payload_size);
+                if (p->ptr + payload_size <= p->end) {
+                    /* Non-NULL parcelable */
+                    *size = payload_size;
+                    *nullp = FALSE;
+                    return TRUE;
+                }
+            }
+        }
+    }
+
+    /* Restore the state on failure */
+    p->ptr = saved_ptr;
+    return FALSE;
+}
+
 const void*
 gbinder_reader_read_parcelable(
     GBinderReader* reader,
@@ -516,51 +554,46 @@ gbinder_reader_read_parcelable2(
     gsize* size,
     gboolean* ok) /* Since 1.1.48 */
 {
-    GBinderReaderPriv* p = gbinder_reader_cast(reader);
-    const guint8* saved_ptr = p->ptr;
-    guint32 flag;
+    const void* out = NULL;
+    guint32 psize = 0;
+    gboolean nullp;
 
-    if (gbinder_reader_read_uint32(reader, &flag)) {
-        if (flag == kNullParcelableFlag) {
-            if (size) {
-                *size = 0;
-            }
-            if (ok) {
-                *ok = TRUE;
-            }
-            return NULL;
-        } else {
-            guint32 payload_size;
+    if (gbinder_reader_read_parcelable_header(reader, &psize, &nullp)) {
+        GBinderReaderPriv* p = gbinder_reader_cast(reader);
 
-            if (gbinder_reader_read_uint32(reader, &payload_size) &&
-                payload_size >= sizeof(payload_size)) {
-                payload_size -= sizeof(payload_size);
-                if (p->ptr + payload_size <= p->end) {
-                    const void* out = p->ptr;
+        if (!nullp) {
+            out = p->ptr;
+            p->ptr += psize;
 
-                    /* Non-NULL parcelable */
-                    p->ptr += payload_size;
-                    if (size) {
-                        *size = payload_size;
+            /*
+             * If this parcelable contains binder objects we must skip those
+             * objects or else we won't be able to read next objects from this
+             * tx buffer.
+             */
+            if (p->objects) {
+                guint8*** objs = (guint8***)
+                    ((p->flags & GBINDER_READER_FLAG_HAS_PARENT) ?
+                     (void***) p->objects : &p->objects);
+
+                if (*objs) {
+                    while ((*objs)[0] && (*objs)[0] < p->ptr) {
+                        (*objs)++;
                     }
-                    if (ok) {
-                        *ok = TRUE;
-                    }
-                    return out;
                 }
             }
         }
-    }
 
-    /* Restore the state on failure */
-    p->ptr = saved_ptr;
-    if (size) {
-        *size = 0;
-    }
-    if (ok) {
+        if (ok) {
+            *ok = TRUE;
+        }
+    } else if (ok) {
         *ok = FALSE;
     }
-    return NULL;
+
+    if (size) {
+        *size = psize;
+    }
+    return out;
 }
 
 gboolean
@@ -569,9 +602,8 @@ gbinder_reader_start_parcelable(
     GBinderReader* parcelable,
     gboolean* non_null) /* Since 1.1.48 */
 {
-    gsize size;
-    gboolean ok;
-    const guint8* ptr = gbinder_reader_read_parcelable2(reader, &size, &ok);
+    guint32 size;
+    gboolean nullp;
 
     /*
      * gbinder_reader_finish_parcelable() should be invoked on every
@@ -579,29 +611,35 @@ gbinder_reader_start_parcelable(
      * important (if not to say mandatory) if the parcelable contains
      * binder objects.
      */
-    if (ok) {
-        if (ptr) {
-            GBinderReaderPriv* p = gbinder_reader_cast(reader);
-            const GBinderReaderData* data = p->data;
-
-            gbinder_reader_init2(parcelable, data,
-                (ptr - (guint8*)data->buffer->data), size,
-                (p->flags & GBINDER_READER_FLAG_HAS_PARENT) ?
-                (void***)p->objects : &p->objects);
-        } else {
+    if (gbinder_reader_read_parcelable_header(reader, &size, &nullp)) {
+        if (nullp) {
             /* NULL parcelable (with a parent) */
             gbinder_reader_init(parcelable, NULL, 0, 0);
             gbinder_reader_cast(parcelable)->flags |=
                 GBINDER_READER_FLAG_HAS_PARENT;
+        } else {
+            GBinderReaderPriv* p = gbinder_reader_cast(reader);
+            const GBinderReaderData* data = p->data;
+
+            gbinder_reader_init2(parcelable, data,
+                (p->ptr - (guint8*)data->buffer->data), size,
+                (p->flags & GBINDER_READER_FLAG_HAS_PARENT) ?
+                (void***)p->objects : &p->objects);
+
+            /* Move the pointer */
+            p->ptr += size;
         }
+        if (non_null) {
+            *non_null = !nullp;
+        }
+        return TRUE;
     } else {
         memset(parcelable, 0, sizeof(*parcelable));
+        if (non_null) {
+            *non_null = FALSE;
+        }
+        return FALSE;
     }
-
-    if (non_null) {
-        *non_null = ptr != NULL;
-    }
-    return ok;
 }
 
 void
@@ -624,7 +662,7 @@ gbinder_reader_finish_parcelable(
             guint8*** objs = (guint8***)p->objects;
 
             if (*objs) {
-                while ((*objs)[0] > p->start && (*objs)[0] < p->end) {
+                while ((*objs)[0] && (*objs)[0] < p->end) {
                     (*objs)++;
                 }
             }

--- a/src/gbinder_reader.c
+++ b/src/gbinder_reader.c
@@ -675,6 +675,16 @@ gbinder_reader_finish_parcelable(
     }
 }
 
+gboolean
+gbinder_reader_skip_parcelable(
+    GBinderReader* reader) /* Since 1.1.49 */
+{
+    gboolean ok;
+
+    gbinder_reader_read_parcelable2(reader, NULL, &ok);
+    return ok;
+}
+
 /* Helper for gbinder_reader_read_hidl_struct() macro */
 const void*
 gbinder_reader_read_hidl_struct1(

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -164,6 +164,7 @@ test_empty(
     g_assert(!gbinder_reader_start_parcelable(&reader, &parcelable, &non_null));
     g_assert_false(non_null);
     gbinder_reader_finish_parcelable(&parcelable);
+    g_assert_false(gbinder_reader_skip_parcelable(&reader));
 }
 
 /*==========================================================================*
@@ -2020,6 +2021,11 @@ test_parcelable1(
     g_assert_cmpuint(size, == ,sizeof(input_non_null_payload));
     g_assert_true(gbinder_reader_at_end(&reader));
 
+    /* And gbinder_reader_skip_parcelable */
+    gbinder_reader_init(&reader, &data, 0, in_size);
+    g_assert_true(gbinder_reader_skip_parcelable(&reader));
+    g_assert_true(gbinder_reader_at_end(&reader));
+
     gbinder_buffer_free(data.buffer);
     gbinder_driver_unref(driver);
 }
@@ -2238,10 +2244,7 @@ test_parcelable2(
     gbinder_remote_object_unref(obj);
 
     /* Parcelable #6 */
-    ok = FALSE;
-    g_assert_nonnull(gbinder_reader_read_parcelable2(&reader, &size, &ok));
-    g_assert_cmpuint(size, == ,4 + BINDER_OBJECT_SIZE_64);
-    g_assert_true(ok);
+    g_assert_true(gbinder_reader_skip_parcelable(&reader));
     /* Object #6 gets skipped */
 
     /* obj7 */

--- a/unit/unit_reader/unit_reader.c
+++ b/unit/unit_reader/unit_reader.c
@@ -116,6 +116,7 @@ test_empty(
     GBinderReader reader, parcelable;
     gsize count = 1, elemsize = 1;
     gsize size = 1;
+    gboolean non_null;
 
     gbinder_reader_init(&reader, NULL, 0, 0);
     g_assert(gbinder_reader_at_end(&reader));
@@ -160,6 +161,8 @@ test_empty(
      * gracefully (with a warning being printed to the console)
      */
     g_assert(!gbinder_reader_start_parcelable(&reader, &parcelable, NULL));
+    g_assert(!gbinder_reader_start_parcelable(&reader, &parcelable, &non_null));
+    g_assert_false(non_null);
     gbinder_reader_finish_parcelable(&parcelable);
 }
 
@@ -1901,12 +1904,13 @@ test_parcelable1(
     };
     gpointer in;
     gboolean ok, non_null;
-    gsize in_size, out_size;
+    gsize size, in_size, out_size;
     const void* out;
     GBinderDriver* driver = gbinder_driver_new(GBINDER_DEFAULT_BINDER, NULL);
     GBinderReader reader, p;
     GBinderReaderData data;
     gint32 value[2];
+    void* objects[1];
 
     g_assert(driver);
     memset(&data, 0, sizeof(data));
@@ -1994,11 +1998,13 @@ test_parcelable1(
         sizeof(input_non_null_payload)) == 0);
 
     /* Test the nested reader */
+    objects[0] = NULL; /* empty but non-null object list */
+    data.objects = objects;
     gbinder_reader_init(&reader, &data, 0, in_size);
     non_null = FALSE;
     g_assert_true(gbinder_reader_start_parcelable(&reader, &p, &non_null));
     g_assert_true(non_null);
-    g_assert(gbinder_reader_at_end(&reader));
+    g_assert_true(gbinder_reader_at_end(&reader));
 
     memset(value, 0, sizeof(value));
     g_assert(gbinder_reader_read_int32(&p, value));
@@ -2007,6 +2013,12 @@ test_parcelable1(
     g_assert_cmpuint(value[0], == ,10);
     g_assert_cmpuint(value[1], == ,20);
     gbinder_reader_finish_parcelable(&p);
+
+    /* Poke the same thing with gbinder_reader_read_parcelable */
+    gbinder_reader_init(&reader, &data, 0, in_size);
+    g_assert_nonnull(gbinder_reader_read_parcelable(&reader, &size));
+    g_assert_cmpuint(size, == ,sizeof(input_non_null_payload));
+    g_assert_true(gbinder_reader_at_end(&reader));
 
     gbinder_buffer_free(data.buffer);
     gbinder_driver_unref(driver);
@@ -2019,39 +2031,103 @@ test_parcelable2(
 {
     /* Using 64-bit I/O */
     const guint8 input[] = {
+        /*
+         * parcelable p1 {
+         *   parcelable p2 {
+         *     object obj1;
+         *     parcelable p3 {
+         *       object obj2;
+         *     };
+         *   };
+         *   object obj3;
+         * };
+         *
+         * parcelable p4 {
+         *   int i1 = 40;
+         *   parcelable p5 {
+         *     int i2 = 41;
+         *     object obj4;
+         *   };
+         * };
+         *
+         * int i3 = 42;
+         * object obj5;
+         *
+         * parcelable p6 {
+         *   int i4 = 43;
+         *   object obj6;
+         * };
+         *
+         * object obj7;
+         * parcelable p7 = null;
+         * parcelable p8 {};
+         */
         /* Parcelable #1 */
         TEST_INT32_BYTES(kNonNullParcelableFlag),
         TEST_INT32_BYTES(4 /* this field */ +
                          8 /* parcelable #2 header */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #1 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj1 */ +
                          8 /* parcelable #3 header */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #2 */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #3 */),
+                         BINDER_OBJECT_SIZE_64 /* obj2 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj3 */),
 
-        /* Parcelable #2 */
+          /* Parcelable #2 */
         TEST_INT32_BYTES(kNonNullParcelableFlag),
         TEST_INT32_BYTES(4 /* this field */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #1 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj1 */ +
                          8 /* parcelable #3 header */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #2 */),
-        TEST_BINDER_OBJECT_64(1), /* Binder object #1 */
+                         BINDER_OBJECT_SIZE_64 /* obj2 */),
+        TEST_BINDER_OBJECT_64(1), /* obj1 */
 
         /* Parcelable #3 */
         TEST_INT32_BYTES(kNonNullParcelableFlag),
         TEST_INT32_BYTES(4 /* this field */ +
-                         BINDER_OBJECT_SIZE_64 /* binder object #2 */),
-        TEST_BINDER_OBJECT_64(2), /* Binder object #2 */
+                         BINDER_OBJECT_SIZE_64 /* obj2 */),
+        TEST_BINDER_OBJECT_64(2), /* obj2 */
         /* End of parcelable #3 */
         /* End of parcelable #2 */
 
-        TEST_BINDER_OBJECT_64(3), /* Binder object #3 */
+        TEST_BINDER_OBJECT_64(3), /* obj3 */
         /* End of parcelable #1 */
 
-        TEST_INT32_BYTES(42),
-        TEST_BINDER_OBJECT_64(4), /* Binder object #4 */
-
         /* Parcelable #4 */
-        TEST_INT32_BYTES(kNullParcelableFlag)
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         4 /* i1 */ +
+                         8 /* parcelable #5 header */ +
+                         4 /* i2 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj4 */),
+        TEST_INT32_BYTES(40), /* i1 */
+        /* Parcelable #5 */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         4 /* i2 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj4 */),
+        TEST_INT32_BYTES(41), /* i2 */
+        TEST_BINDER_OBJECT_64(4), /* obj4 */
+        /* End of parcelable #5 */
+        /* End of parcelable #4 */
+
+        TEST_INT32_BYTES(42), /* i3 */
+        TEST_BINDER_OBJECT_64(5), /* obj5 */
+
+        /* Parcelable #6 */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */ +
+                         4 /* i4 */ +
+                         BINDER_OBJECT_SIZE_64 /* obj6 */),
+        TEST_INT32_BYTES(43),
+        TEST_BINDER_OBJECT_64(6), /* obj6 */
+        /* End of parcelable #6 */
+
+        TEST_BINDER_OBJECT_64(7), /* obj7 */
+
+        /* Parcelable #7 (null) */
+        TEST_INT32_BYTES(kNullParcelableFlag),
+
+        /* Parcelable #8 (empty) */
+        TEST_INT32_BYTES(kNonNullParcelableFlag),
+        TEST_INT32_BYTES(4 /* this field */)
     };
     const gsize object1_offset =
         8 /* parcelable #1 header */ +
@@ -2062,27 +2138,41 @@ test_parcelable2(
     const gsize object3_offset = object2_offset +
         BINDER_OBJECT_SIZE_64 /* binder object #2 */;
     const gsize object4_offset = object3_offset +
-        4 /* int32 */ +
-        BINDER_OBJECT_SIZE_64 /* binder object #2 */;
+        BINDER_OBJECT_SIZE_64 /* binder object #3 */ +
+        8 /* parcelable #4 header */ + 4 /* i1 */ +
+        8 /* parcelable #5 header */ + 4 /* i2 */;
+    const gsize object5_offset = object4_offset +
+        BINDER_OBJECT_SIZE_64 /* binder object #4 */ +
+        4 /* i3 */;
+    const gsize object6_offset = object5_offset +
+        BINDER_OBJECT_SIZE_64 /* binder object #5 */ +
+        8 /* parcelable #6 header */ + 4 /* i4 */;
+    const gsize object7_offset = object6_offset +
+        BINDER_OBJECT_SIZE_64 /* binder object #6 */;
     GBinderIpc* ipc = gbinder_ipc_new(GBINDER_DEFAULT_HWBINDER, NULL);
     GBinderBuffer* buf = gbinder_buffer_new(ipc->driver,
         g_memdup(input, sizeof(input)), sizeof(input), NULL);
     GBinderRemoteObject* obj = NULL;
     GBinderReaderData data;
-    GBinderReader reader, p1, p2, p3;
+    GBinderReader reader, p1, p2, p3, p4;
     gboolean ok, non_null;
     guint32 val;
+    gsize size;
+    void* objects[8];
 
     g_assert(ipc);
     memset(&data, 0, sizeof(data));
     data.buffer = buf;
     data.reg = gbinder_ipc_object_registry(ipc);
-    data.objects = g_new(void*, 5);
-    data.objects[0] = buf->data + object1_offset;
-    data.objects[1] = buf->data + object2_offset;
-    data.objects[2] = buf->data + object3_offset;
-    data.objects[3] = buf->data + object4_offset;
-    data.objects[4] = NULL;
+    data.objects = objects;
+    objects[0] = buf->data + object1_offset;
+    objects[1] = buf->data + object2_offset;
+    objects[2] = buf->data + object3_offset;
+    objects[3] = buf->data + object4_offset;
+    objects[4] = buf->data + object5_offset;
+    objects[5] = buf->data + object6_offset;
+    objects[6] = buf->data + object7_offset;
+    objects[7] = NULL;
     gbinder_reader_init(&reader, &data, 0, buf->size);
 
     /* Nested reader for parcelable #1 */
@@ -2119,17 +2209,56 @@ test_parcelable2(
     gbinder_remote_object_unref(obj);
     gbinder_reader_finish_parcelable(&p1); /* done with parcelable #1 */
 
-    /* Read the remaining data from the top level reader */
+    /* Parcelable #4 */
+    g_assert_true(gbinder_reader_start_parcelable(&reader, &p4, NULL));
+    g_assert_false(gbinder_reader_at_end(&p4));
+
+    /* i1 */
+    val = 0;
+    g_assert_true(gbinder_reader_read_uint32(&p4, &val));
+    g_assert_cmpuint(val, == ,40);
+
+    /* Parcelable #5 */
+    ok = FALSE;
+    size = 0;
+    g_assert_nonnull(gbinder_reader_read_parcelable2(&p4, &size, &ok));
+    g_assert_cmpuint(size, == ,4 /* i2 */ + BINDER_OBJECT_SIZE_64 /* obj4 */);
+    g_assert_true(ok);
+    /* Object #4 gets skipped */
+
+    /* i3 */
     val = 0;
     g_assert_true(gbinder_reader_read_uint32(&reader, &val));
     g_assert_cmpuint(val, == ,42);
 
+    /* obj5 */
     g_assert_true(gbinder_reader_read_nullable_object(&reader, &obj));
     g_assert_nonnull(obj);
-    g_assert_cmpuint(obj->handle, == ,4);
+    g_assert_cmpuint(obj->handle, == ,5);
     gbinder_remote_object_unref(obj);
 
+    /* Parcelable #6 */
+    ok = FALSE;
+    g_assert_nonnull(gbinder_reader_read_parcelable2(&reader, &size, &ok));
+    g_assert_cmpuint(size, == ,4 + BINDER_OBJECT_SIZE_64);
+    g_assert_true(ok);
+    /* Object #6 gets skipped */
+
+    /* obj7 */
+    g_assert_true(gbinder_reader_read_nullable_object(&reader, &obj));
+    g_assert_nonnull(obj);
+    g_assert_cmpuint(obj->handle, == ,7);
+    gbinder_remote_object_unref(obj);
+
+    /* Parcelable #7 (null) */
+    ok = FALSE;
     g_assert_null(gbinder_reader_read_parcelable2(&reader, NULL, &ok));
+    g_assert_true(ok);
+
+    /* Parcelable #8 (empty) */
+    ok = FALSE;
+    g_assert_nonnull(gbinder_reader_read_parcelable2(&reader, &size, &ok));
+    g_assert_cmpuint(size, == ,0);
     g_assert_true(ok);
 
     /* Now we must have reached the end */
@@ -2137,7 +2266,6 @@ test_parcelable2(
 
     gbinder_buffer_free(buf);
     gbinder_ipc_unref(ipc);
-    g_free(data.objects);
     test_binder_exit_wait(&test_opt, NULL);
 }
 


### PR DESCRIPTION
Properly skips a parcelable together with everything it contains.

Also slightly changed the behavior of `gbinder_reader_read_parcelable()`, it now skips the objects which happen to be references by the parcelable. That shouldn't break anything since `gbinder_reader_read_parcelable()` was typically used for reading or skipping flat structures not containing any objects (and even that is better done with a nested reader)