### PR TITLE
Prevent reuse of servicemanager instance table

### DIFF
--- a/src/gbinder_servicemanager.c
+++ b/src/gbinder_servicemanager.c
@@ -1124,6 +1124,24 @@ gbinder_servicemanager_finalize(
     G_OBJECT_CLASS(PARENT_CLASS)->finalize(object);
 }
 
+void
+gbinder_servicemanager_class_common_init(
+    GBinderServiceManagerClass* klass)
+{
+    /*
+     * Every subclass must call this function in its class init routine,
+     * else they may end up sharing the table. Even though the base class
+     * is abstract and can't be directly instantiated (and therefore its
+     * table remains null), AIDL classes form a hierarchy and may actually
+     * end up sharing it.
+     *
+     * It's also a good idea to individually init the mutex for every
+     * subclass, instead of assuming that memcpy would do the right thing.
+     */
+    g_mutex_init(&klass->mutex);
+    klass->table = NULL;
+}
+
 static
 void
 gbinder_servicemanager_class_init(
@@ -1132,7 +1150,7 @@ gbinder_servicemanager_class_init(
     GObjectClass* object_class = G_OBJECT_CLASS(klass);
     GType type = G_OBJECT_CLASS_TYPE(klass);
 
-    g_mutex_init(&klass->mutex);
+    gbinder_servicemanager_class_common_init(klass);
     g_type_class_add_private(klass, sizeof(GBinderServiceManagerPriv));
     object_class->dispose = gbinder_servicemanager_dispose;
     object_class->finalize = gbinder_servicemanager_finalize;

--- a/src/gbinder_servicemanager_aidl.c
+++ b/src/gbinder_servicemanager_aidl.c
@@ -574,6 +574,7 @@ gbinder_servicemanager_aidl_class_init(
     GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
     GObjectClass* object = G_OBJECT_CLASS(klass);
 
+    gbinder_servicemanager_class_common_init(manager);
     g_type_class_add_private(klass, sizeof(GBinderServiceManagerAidlPriv));
 
     klass->check_service_transaction = CHECK_SERVICE_TRANSACTION;

--- a/src/gbinder_servicemanager_aidl2.c
+++ b/src/gbinder_servicemanager_aidl2.c
@@ -84,6 +84,9 @@ void
 gbinder_servicemanager_aidl2_class_init(
     GBinderServiceManagerAidl2Class* klass)
 {
+    GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
+
+    gbinder_servicemanager_class_common_init(manager);
     klass->list_services_req = gbinder_servicemanager_aidl2_list_services_req;
     klass->add_service_req = gbinder_servicemanager_aidl2_add_service_req;
 }

--- a/src/gbinder_servicemanager_aidl3.c
+++ b/src/gbinder_servicemanager_aidl3.c
@@ -134,6 +134,7 @@ gbinder_servicemanager_aidl3_class_init(
 {
     GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
 
+    gbinder_servicemanager_class_common_init(manager);
     manager->list = gbinder_servicemanager_aidl3_list;
     manager->get_service = gbinder_servicemanager_aidl3_get_service;
 }

--- a/src/gbinder_servicemanager_aidl5.c
+++ b/src/gbinder_servicemanager_aidl5.c
@@ -140,6 +140,7 @@ gbinder_servicemanager_aidl5_class_init(
 {
     GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
 
+    gbinder_servicemanager_class_common_init(manager);
     manager->get_service = gbinder_servicemanager_aidl5_get_service;
 
     klass->check_service_transaction = AIDL5_CHECK_SERVICE_TRANSACTION;

--- a/src/gbinder_servicemanager_aidl6.c
+++ b/src/gbinder_servicemanager_aidl6.c
@@ -63,6 +63,9 @@ void
 gbinder_servicemanager_aidl6_class_init(
     GBinderServiceManagerAidl6Class* klass)
 {
+    GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
+
+    gbinder_servicemanager_class_common_init(manager);
     klass->check_service_transaction = AIDL6_CHECK_SERVICE_TRANSACTION;
     klass->add_service_transaction = AIDL6_ADD_SERVICE_TRANSACTION;
     klass->list_services_transaction = AIDL6_LIST_SERVICES_TRANSACTION;

--- a/src/gbinder_servicemanager_hidl.c
+++ b/src/gbinder_servicemanager_hidl.c
@@ -446,6 +446,8 @@ void
 gbinder_servicemanager_hidl_class_init(
     GBinderServiceManagerHidlClass* klass)
 {
+    gbinder_servicemanager_class_common_init(klass);
+
     klass->iface = SERVICEMANAGER_HIDL_IFACE;
     klass->default_device = GBINDER_DEFAULT_HWBINDER;
 

--- a/src/gbinder_servicemanager_p.h
+++ b/src/gbinder_servicemanager_p.h
@@ -98,6 +98,11 @@ gbinder_servicemanager_service_registered(
     const char* name)
     GBINDER_INTERNAL;
 
+void
+gbinder_servicemanager_class_common_init(
+    GBinderServiceManagerClass* klass)
+    GBINDER_INTERNAL;
+
 /* Declared for unit tests */
 void
 gbinder_servicemanager_exit(


### PR DESCRIPTION
Even though `GBinderServiceManagerClass` is abstract and can't be directly instantiated, AIDL classes form a hierarchy and may actually end up sharing the instance table.

It's also a good idea to individually init the mutex for every subclass, instead of assuming that memcpy would do the right thing.