### PR TITLE
Support both checkService variants for Android 15

### DIFF
--- a/src/gbinder_servicemanager_aidl5.c
+++ b/src/gbinder_servicemanager_aidl5.c
@@ -30,6 +30,11 @@
  */
 
 #include "gbinder_servicemanager_aidl.h"
+#include "gbinder_client_p.h"
+
+#include <gbinder_local_request.h>
+#include <gbinder_reader.h>
+#include <gbinder_remote_reply.h>
 
 /* Variant of AIDL servicemanager appeared in Android 15 (API level 35) */
 
@@ -51,6 +56,76 @@ enum gbinder_servicemanager_aidl5_calls {
     AIDL5_UNREGISTER_FOR_NOTIFICATIONS_TRANSACTION
 };
 
+/*
+ * Note that this weird get_service implementation is inherited by aidl6
+ * implementation and it's fine - who knows if Google guys at some point
+ * decide to replace IBinder with Service again. Even if they never do,
+ * this implementation is optimized for IBinder which is the current
+ * Android 16 behavior, at least at the time of this writing.
+ */
+static
+GBinderRemoteObject*
+gbinder_servicemanager_aidl5_get_service(
+    GBinderServiceManager* manager,
+    const char* name,
+    int* status,
+    const GBinderIpcSyncApi* api)
+{
+    GBinderClient* client = manager->client;
+    GBinderLocalRequest* req = gbinder_client_new_request(client);
+    GBinderRemoteObject* obj = NULL;
+    GBinderRemoteReply* reply;
+    GBinderReader reader;
+    GBinderServiceManagerAidlClass* klass =
+        GBINDER_SERVICEMANAGER_AIDL_GET_CLASS(manager);
+
+    gbinder_local_request_append_string16(req, name);
+    reply = gbinder_client_transact_sync_reply2(client,
+        klass->check_service_transaction, req, status, api);
+
+    gbinder_remote_reply_init_reader(reply, &reader);
+    gbinder_reader_read_int32(&reader, NULL /* status? */);
+
+    /*
+     * Could be either of these:
+     *
+     * @nullable IBinder checkService(@utf8InCpp String name);
+     * Service checkService(@utf8InCpp String name);
+     *
+     * The return value has mutated during Android 15 lifetime.
+     */
+    if (!gbinder_reader_read_nullable_object(&reader, &obj)) {
+        gint32 tag;
+
+        /*
+         * If it's not IBinder then it must be a Service:
+         *
+         * union Service {
+         *     ServiceWithMetadata serviceWithMetadata;  // tag = 0
+         *     @nullable IBinder accessor;
+         * }
+         *
+         * parcelable ServiceWithMetadata {
+         *     @nullable IBinder service;
+         *     boolean isLazyService;
+         * }
+         */
+        if (gbinder_reader_read_int32(&reader, NULL /* what is it? */) &&
+            gbinder_reader_read_int32(&reader, &tag) && tag == 0) {
+            GBinderReader parcel;
+
+            if (gbinder_reader_start_parcelable(&reader, &parcel, NULL)) {
+                obj = gbinder_reader_read_object(&parcel);
+                gbinder_reader_finish_parcelable(&parcel);
+            }
+        }
+    }
+
+    gbinder_remote_reply_unref(reply);
+    gbinder_local_request_unref(req);
+    return obj;
+}
+
 static
 void
 gbinder_servicemanager_aidl5_init(
@@ -63,6 +138,10 @@ void
 gbinder_servicemanager_aidl5_class_init(
     GBinderServiceManagerAidl5Class* klass)
 {
+    GBinderServiceManagerClass* manager = GBINDER_SERVICEMANAGER_CLASS(klass);
+
+    manager->get_service = gbinder_servicemanager_aidl5_get_service;
+
     klass->check_service_transaction = AIDL5_CHECK_SERVICE_TRANSACTION;
     klass->add_service_transaction = AIDL5_ADD_SERVICE_TRANSACTION;
     klass->list_services_transaction = AIDL5_LIST_SERVICES_TRANSACTION;

--- a/unit/unit_servicemanager_aidl5/unit_servicemanager_aidl5.c
+++ b/unit/unit_servicemanager_aidl5/unit_servicemanager_aidl5.c
@@ -86,6 +86,7 @@ typedef struct service_manager_aidl5 {
     GBinderLocalObject parent;
     GHashTable* objects;
     GMutex mutex;
+    gboolean return_service;
 } ServiceManagerAidl5;
 
 #define SERVICE_MANAGER_AIDL5_TYPE (service_manager_aidl5_get_type())
@@ -127,7 +128,29 @@ servicemanager_aidl5_handler(
 
             gbinder_local_reply_init_writer(reply, &writer);
             gbinder_writer_append_int32(&writer, GBINDER_STATUS_OK);
-            gbinder_writer_append_remote_object(&writer, remote_obj);
+            if (self->return_service) {
+                GBinderWriter parcel;
+
+                /* union Service {
+                 *     ServiceWithMetadata serviceWithMetadata;
+                 *     @nullable IBinder accessor;
+                 *  }
+                 *
+                 * parcelable ServiceWithMetadata {
+                 *     @nullable IBinder service;
+                 *     boolean isLazyService;
+                 * }
+                 */
+                gbinder_writer_append_int32(&writer, 0);
+                gbinder_writer_append_int32(&writer, 0); /* Tag */
+                gbinder_writer_start_parcelable(&writer, &parcel);
+                gbinder_writer_append_remote_object(&parcel, remote_obj);
+                gbinder_writer_append_bool(&parcel, FALSE);
+                gbinder_writer_finish_parcelable(&parcel);
+            } else {
+                /* Just IBinder */
+                gbinder_writer_append_remote_object(&writer, remote_obj);
+            }
             if (remote_obj) {
                 GDEBUG("Found name '%s' => %p", str, remote_obj);
             } else {
@@ -251,13 +274,15 @@ service_manager_aidl5_class_init(
 static
 ServiceManagerAidl5*
 servicemanager_aidl5_new(
-    const char* dev)
+    const char* dev,
+    gboolean return_service)
 {
     ServiceManagerAidl5* self = g_object_new(SERVICE_MANAGER_AIDL5_TYPE, NULL);
     GBinderLocalObject* obj = GBINDER_LOCAL_OBJECT(self);
     GBinderIpc* ipc = gbinder_ipc_new(dev, NULL);
     const int fd = gbinder_driver_fd(ipc->driver);
 
+    self->return_service = return_service;
     gbinder_local_object_init_base(obj, ipc, servicemanager_aidl_ifaces,
         NULL, NULL);
     test_binder_register_object(fd, obj, SVCMGR_HANDLE);
@@ -283,7 +308,8 @@ typedef struct test_context {
 static
 void
 test_context_init(
-    TestContext* test)
+    TestContext* test,
+    gboolean return_service)
 {
     const char* dev = GBINDER_DEFAULT_BINDER;
     const char* config =
@@ -307,7 +333,7 @@ test_context_init(
     test->fd = gbinder_driver_fd(ipc->driver);
     test->object = gbinder_local_object_new(ipc, NULL, NULL, NULL);
     test_binder_register_object(test->fd, test->object, AUTO_HANDLE);
-    test->service = servicemanager_aidl5_new(dev);
+    test->service = servicemanager_aidl5_new(dev, return_service);
     test->client = gbinder_servicemanager_new(dev);
     test->loop = g_main_loop_new(NULL, FALSE);
     gbinder_ipc_unref(ipc);
@@ -360,13 +386,14 @@ test_context_wait_ref(
 
 static
 void
-test_get_run()
+test_get_run(
+    gconstpointer param)
 {
     TestContext test;
     const char* name = "name";
     int status = -1;
 
-    test_context_init(&test);
+    test_context_init(&test, GPOINTER_TO_INT(param));
 
     /* Query the object (it's not there yet) */
     GDEBUG("Querying '%s'", name);
@@ -396,9 +423,10 @@ test_get_run()
 
 static
 void
-test_get()
+test_get(
+    gconstpointer param)
 {
-    test_run_in_context(&test_opt, test_get_run);
+    test_run_in_context_param(&test_opt, test_get_run, param);
 }
 
 /*==========================================================================*
@@ -413,7 +441,7 @@ test_list_run()
     const char* name = "name";
     char** list;
 
-    test_context_init(&test);
+    test_context_init(&test, FALSE);
 
     /* Request the list */
     list = gbinder_servicemanager_list_sync(test.client);
@@ -461,7 +489,8 @@ int main(int argc, char* argv[])
     g_type_init();
     G_GNUC_END_IGNORE_DEPRECATIONS;
     g_test_init(&argc, &argv, NULL);
-    g_test_add_func(TEST_("get"), test_get);
+    g_test_add_data_func(TEST_("get/1"), GINT_TO_POINTER(0), test_get);
+    g_test_add_data_func(TEST_("get/2"), GINT_TO_POINTER(1), test_get);
     g_test_add_func(TEST_("list"), test_list);
     test_init(&test_opt, argc, argv);
     return g_test_run();


### PR DESCRIPTION
There are 2 variants in Android 15:

```aidl
   @nullable IBinder checkService(@utf8InCpp String name);
   Service checkService(@utf8InCpp String name);
```

Both variants should be supported. There's no easy way to figure out at run time which one is being used, other than trying to parse the output of checkService.